### PR TITLE
INFRA-25890 Pelican Action: Add support for installing requirements.txt

### DIFF
--- a/pelican/README.md
+++ b/pelican/README.md
@@ -7,6 +7,7 @@
 * tempdir 	Temporary Directory name (optional) 	 	default: ../output
 * debug 	 	Pelican Debug mode (optional) 	 		default: false
 * version 	Pelican Version (default 4.5.4) (optional) 	default: 4.5.4
+* requirements	Python Requirements file (optional) 	default: requirements.txt
 
 ## Example Workflow Usage:
 

--- a/pelican/action.yml
+++ b/pelican/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Pelican Version (default 4.5.4)"
     required: false
     default: '4.5.4'
+  requirements:
+    description: "Python requirements file name to install. Default=requirements.txt"
+    required: false
+    default: 'requirements.txt'
   fatal:
     description: "Value for --fatal option [errors|warnings] - sets exit code to error (default: errors)"
     required: false
@@ -97,6 +101,11 @@ runs:
         echo "Getting plugins from action location: ${{ github.action_path }}"
         PP=$(python3 ${{ github.action_path }}/plugin_paths.py '${{ github.action_path }}/plugins')
         set -x # Show the expanded variables
+        if [ -f "${{ inputs.requirements }}" ]
+        then
+          echo "Installing python requirements from ${{ inputs.requirements }}"
+          pip3 install -r ${{ inputs.requirements }}
+        fi
         python3 -B -m pelican content -e "$PP" -o ${{ inputs.tempdir }} $OPTS
 
     - name: Check out previous branch

--- a/pelican/action.yml
+++ b/pelican/action.yml
@@ -105,6 +105,8 @@ runs:
         then
           echo "Installing python requirements from ${{ inputs.requirements }}"
           pip3 install -r ${{ inputs.requirements }}
+        else
+          echo "Requirements file ${{ inputs.requirements }} does not exist"
         fi
         python3 -B -m pelican content -e "$PP" -o ${{ inputs.tempdir }} $OPTS
 


### PR DESCRIPTION
Some web sites have custom Pelican plugins that require python modules. This PR will accept a new input `requirements` where user can specify name of a file to load python requirements from. Default is `requirements.txt`. If the specified file does not exist, we'll log a line and continue the build.

https://issues.apache.org/jira/browse/INFRA-25890