### PR TITLE
INFRA-25891 Allow pelican action to run in build only mode (publish=false)

### DIFF
--- a/pelican/README.md
+++ b/pelican/README.md
@@ -1,7 +1,8 @@
 # ASF Infrastructure Pelican Action
 
 ## Inputs
-* destination 	Pelican Output branch (required) 	 	default: asf-site
+* destination 	Pelican Output branch (optional) 	 	default: asf-site
+* publish 	Publish to destination branch (optional) 	default: true
 * gfm 	 	Uses GitHub Flavored Markdown (optional) 	default: true
 * output 	 	Pelican generated output directory (optional) 	default: output
 * tempdir 	Temporary Directory name (optional) 	 	default: ../output
@@ -22,7 +23,6 @@ jobs:
         with:
           destination: master
           gfm: 'true'
-          publish: 'true'
 ```
 
 Example workflow for only building the site, not publishing. Useful for PR tests:
@@ -37,7 +37,6 @@ jobs:
         with:
       - uses: apache/infrastructure-actions/pelican@main
         with:
-          gfm: 'true'
           publish: 'false'
 ```
 

--- a/pelican/README.md
+++ b/pelican/README.md
@@ -22,7 +22,25 @@ jobs:
         with:
           destination: master
           gfm: 'true'
+          publish: 'true'
 ```
+
+Example workflow for only building the site, not publishing. Useful for PR tests:
+
+```
+...
+jobs:
+  build-pelican:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+      - uses: apache/infrastructure-actions/pelican@main
+        with:
+          gfm: 'true'
+          publish: 'false'
+```
+
 
 # Pelican Migration Scripts
 

--- a/pelican/action.yml
+++ b/pelican/action.yml
@@ -3,8 +3,12 @@ description: "Generate a Pelican website from Markdown"
 inputs:
   destination:
     description: "Pelican Output branch"
-    required: true
+    required: false
     default: "asf-site"
+  publish:
+    description: "Publish the site to the destination branch. If false, the site is built but not published."
+    required: false
+    default: "true"
   gfm:
     description: "Uses GitHub Flavored Markdown"
     required: false
@@ -100,6 +104,7 @@ runs:
         python3 -B -m pelican content -e "$PP" -o ${{ inputs.tempdir }} $OPTS
 
     - name: Check out previous branch
+      if: ${{ inputs.publish == 'true' }}
       shell: bash
       run: | 
         git config --global user.email "private@infra.apache.org"
@@ -119,6 +124,7 @@ runs:
         fi
 
     - name: Commit Directly to the branch
+      if: ${{ inputs.publish == 'true' }}
       shell: bash
       run: |
         # Remove all existing output so deletions will be captured


### PR DESCRIPTION
# Use pelican action for PR tests

It would be useful to run pelican build on PRs before merge, to validate that the site builds at all. Currenlty the action will always publish / push the built site to a git branch. But with this new `publish: 'false'` option, the action can be configured for PR workflow like this#63 

```yaml
...
on:
  pull_request:
    branches:
      - 'main'
...
      - name: Build Pelican Site
        uses: apache/infrastructure-actions/pelican@main
        with:
          publish: 'false'
```