### PR TITLE
chore(stash): only run test workflow on relevant changes

### DIFF
--- a/.github/workflows/stash-action-test.yml
+++ b/.github/workflows/stash-action-test.yml
@@ -15,9 +15,15 @@ name: Test Stash Action
 
 on:
   pull_request:
+    paths:
+      - ".github/workflows/stash-action-test.yml"
+      - "stash/**"
   push:
     branches:
       - main
+    paths:
+      - ".github/workflows/stash-action-test.yml"
+      - "stash/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
I forgot to add a path filter when moving the workflow in the new repo. It doesn't make sense to run these on unrelated PRs like #77 . 

The workflow will now only run on changes to the workflow or stash action.