### PR TITLE
Pin MarkupSafe version

### DIFF
--- a/pelican/Dockerfile
+++ b/pelican/Dockerfile
@@ -50,7 +50,7 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt --no-deps
 
 # Could perhaps be added to requirements.txt but that would affect other uses
-RUN pip install 'MarkupSafe<2.1.0' # needed for Pelican 4.5.4
+RUN pip install 'MarkupSafe==2.0.1' # needed for Pelican 4.5.4
 
 # Now add the local code; do this last to avoid unnecessary rebuilds
 COPY plugin_paths.py .


### PR DESCRIPTION
# Request for updating an existing GitHub Action

## Overview

This is a small change to the pelican github action to pin the version of MarkupSafe during the docker build stage.

## Reasoning

MarkupSafe removed the pip dependency soft_unicode in later versions. With the current specification of MarkupSafe in the docker definition, you may not get the required dependency. There is one issue report relating to this: https://github.com/pallets/markupsafe/issues/304

This has led to recent failures in our pipelines such as: https://github.com/apache/datafusion-site/actions/runs/12319494192/job/34386667171?pr=50

## Alternative

One alternative is to leave the MarkupSafe definition as is and also add in an explicit install of soft_unicode.

## Work Around

We are currently working around this issue by adding in an additional github action step to install the pinned version of MarkupSafe.

Relates to https://github.com/apache/datafusion-site/pull/51