### PR TITLE
Add "include-hidden-files" to stash action

### DIFF
--- a/stash/save/action.yml
+++ b/stash/save/action.yml
@@ -75,6 +75,11 @@ inputs:
       Default is true to enable updating the stash.
       Only applies within a workflow. Existing stashes are unaffected.
     default: 'true'
+  include-hidden-files:
+    description: >
+      If true, hidden files will be included in the artifact.
+      If false, hidden files will be excluded from the artifact.
+    default: 'false'
 
 outputs:
   stash-id:
@@ -123,3 +128,4 @@ runs:
         if-no-files-found: ${{ inputs.if-no-files-found }}
         compression-level: ${{ inputs.compression-level }}
         overwrite: ${{ inputs.overwrite }}
+        include-hidden-files: ${{ inputs.include-hidden-files }}


### PR DESCRIPTION
When you try to upload the whole `~/.cache` directory as stash you need to specify `include-hidden-files` as `true`.
