### PR TITLE
Switch to v4 branch for upload-artifact action

### DIFF
--- a/stash/save/action.yml
+++ b/stash/save/action.yml
@@ -115,7 +115,7 @@ runs:
 
     - name: Upload Stash
       id: upload
-      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.mung.outputs.stash_name }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
We do not need to pin the action to specific commit, because it is an official github-maintained actions. Switching to branch will allow us to use latest bug-fix/feature version.