### PR TITLE
Add expanduser to the path passed to stash restore action

### DIFF
--- a/stash/restore/action.yml
+++ b/stash/restore/action.yml
@@ -78,7 +78,7 @@ runs:
         m.output_munged_name(output = 'stash_head')
         m.output_munged_name(ref = 'base_ref', output = 'stash_base')
         with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-          f.write(f'stash_path={os.path.abspath(os.environ["stash_path"])}' + '\n')
+          f.write(f'stash_path={os.path.abspath(os.path.expanduser(os.environ["stash_path"]))}' + '\n')
 
     - name: Check for stash artifact
       id: check-stash


### PR DESCRIPTION
Often when you want to upload cache, you are doing it from the ~/.cache or similar directory. And you want to pass "~" rather than path to the home directory. The original upload-artifact and download-artifact are expanding the `~` to home dir, and since "stash/save" uses direction "upload-artifact" it also accepts the `~` prefix. However the "stash/restore" action uses gh download and passes the path via environment variable, so bash will not expand it. We need to manually expand user in the mung step
