### PR TITLE
Added explicit markupsafe version

### DIFF
--- a/pelican/action.yml
+++ b/pelican/action.yml
@@ -45,7 +45,7 @@ runs:
       run: |
         (
           test "${{ inputs.debug }}" == 'true' || exec >/dev/null
-          PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install pelican==${{ inputs.version }} markdown bs4 ezt requests
+          PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install pelican==${{ inputs.version }} markdown bs4 ezt requests markupsafe==2.0.1
         )
         python3 -V
         echo "Pelican version:"


### PR DESCRIPTION
The recent update to ubuntu-24 on the GHA runners seems to have caused an issue installing a newer version of markupsafe that doesn't have soft_unicode. `markupsafe==2.0.1` is now explicitly installed.
