### PR TITLE
Fix failing pelican test for PRs created by dependabot

### DIFF
--- a/.github/workflows/pelican-action-test.yml
+++ b/.github/workflows/pelican-action-test.yml
@@ -6,6 +6,10 @@ on:
       - '.github/workflows/pelican-action-test.yml'
     # N.B. Cannot easily test pull_request: because the source may not have rights to create/update the test-site
   workflow_dispatch:
+
+permissions:
+  contents: write
+
 jobs:
   pelican-test:
     # do not run the pelican test if the PR was triggered / created by dependabot as the workflow

--- a/.github/workflows/pelican-action-test.yml
+++ b/.github/workflows/pelican-action-test.yml
@@ -12,9 +12,6 @@ permissions:
 
 jobs:
   pelican-test:
-    # do not run the pelican test if the PR was triggered / created by dependabot as the workflow
-    # will not be granted write permissions to contents to successfully run the job
-    if: github.actor != 'dependabot[bot]'
     env: # source and target branches
       SOURCE: testsite
       TARGET: testsite-${{ github.ref_name }} # each branch has own test output

--- a/.github/workflows/pelican-action-test.yml
+++ b/.github/workflows/pelican-action-test.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 jobs:
   pelican-test:
+    # do not run the pelican test if the PR was triggered / created by dependabot as the workflow
+    # will not be granted write permissions to contents to successfully run the job
+    if: github.actor != 'dependabot[bot]'
     env: # source and target branches
       SOURCE: testsite
       TARGET: testsite-${{ github.ref_name }} # each branch has own test output


### PR DESCRIPTION
This fixes the workflow failures for PRs created from dependabot as such workflow runs will not be granted write permissions by default but the test actually writes to the branch.

Documentation about restrictions: https://docs.github.com/en/code-security/dependabot/troubleshooting-dependabot/troubleshooting-dependabot-on-github-actions#restrictions-when-dependabot-triggers-events

Blog post that dependabot triggered workflows will honor the requested permissions:

https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/