### PR TITLE
Enable delete branch on merge github setting

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,4 +1,5 @@
 github:
+  del_branch_on_merge: true
   features:
     issues: true
 


### PR DESCRIPTION
This enables the setting "del_branch_on_merge" to delete branches after they have been merged.