### PR TITLE
Approve VirtusLab/scala-cli-setup 1.6.2

### DIFF
--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -163,4 +163,5 @@
 - easimon/maximize-build-space@*
 - VirtusLab/scala-cli-setup@ef3764b372549ee60cce795f98da0df46e2567ff
 - VirtusLab/scala-cli-setup@2203916b75d15293db29f4bcbd7ff082a27fe6ef
+- VirtusLab/scala-cli-setup@cafdb148305f582fe7017dbe02bbec29ce217b74
 - snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

New version of action already used in Pekko

**Name of action:** 

scala-cli-setup

**URL of action:**

https://github.com/VirtusLab/scala-cli-setup

**Version to pin to (branch, tag, hash):**

1.6.2 cafdb148305f582fe7017dbe02bbec29ce217b74

## Permissions

No change compared to already-approved 1.5.4 https://github.com/VirtusLab/scala-cli-setup/compare/v1.5.4...v1.6.2

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
