### PR TITLE
Add new dorny/paths-filter to allow using `predicate-quantifier`

### DIFF
--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -200,4 +200,4 @@
 - swatinem/rust-cache@v2*
 - geekyeggo/delete-artifact@v5*
 - geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b
-
+- dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

SkyWalking use  https://github.com/apache/skywalking/pull/13121

**Name of action:** dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36

**URL of action:** https://github.com/dorny/paths-filter

**Version to pin to (branch, tag, hash):** de90cc6fb38fc0963ad72b210f1f284cd68cea36


## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [ ] The action is listed in the GitHub Actions Marketplace
- [ ] The action is not already on the list of approved actions
- [ ] The action has a sufficient number of contributors or has contributors within the ASF community
- [ ] The action has a clearly defined license
- [ ] The action is actively developed or maintained
- [ ] The action has CI/unit tests configured
