### PR TITLE
Group all dependabot updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
@assignUser @dfoulks1 

Considering that now a lot of dependabot updates will happen on a regular basis, it would make sense to group them together to avoid getting too many notifications and having to merge them manually. WDYT?