### PR TITLE
Revert "Group all dependabot updates together"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,3 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    groups:
-      github-actions:
-        patterns:
-          - "*"


### PR DESCRIPTION
Reverts apache/infrastructure-actions#121

Too many changes, it times out.