### PR TITLE
Add docker/setup-qemu-action

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -242,6 +242,10 @@ dlang-community/setup-dlang:
 docker://jekyll/jekyll:
   sha256:400b8d1569f118bca8a3a09a25f32803b00a55d1ea241feaf5f904d66ca9c625:
     expires_at: 2050-01-01
+docker/setup-qemu-action:
+  '*':
+    expires_at: 2025-08-01
+    keep: true
 dominikh/staticcheck-action:
   4ec9a0dff54be2642bc76581598ba433fd8d4967:
     expires_at: 2050-01-01


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

GitHub Action to install [QEMU](https://github.com/qemu/qemu) static binaries. This is necessary for building multi-platform images in GitHub Action runners with `docker buildx`.

**Name of action:** 
docker/setup-qemu-action

**URL of action:**
https://github.com/marketplace/actions/docker-setup-qemu
https://github.com/docker/setup-qemu-action

**Version to pin to (branch, tag, hash):**
v3 (or no pinning `*` since this is an official Docker action) 

## Permissions

none

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
