### PR TITLE
Update PULL_REQUEST_TEMPLATE.md to be explicit about only adding SHAs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@
 
 **URL of action:**
 
-**Version to pin to (branch, tag, hash):**
+**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**
 
 
 ## Permissions


### PR DESCRIPTION
Added a link to the GHA policy and removed mention of branches and tags.