### PR TITLE
supercharge/redis-github-action

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -716,6 +716,10 @@ subosito/flutter-action:
   '*':
     expires_at: 2025-08-01
     keep: true
+supercharge/redis-github-action:
+  ea9b21c6ecece47bd99595c532e481390ea0f044:
+    expires_at: 2050-01-01
+    keep: true
 swatinem/rust-cache:
   '*':
     expires_at: 2025-08-01


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

This GitHub Action starts a Redis server on the default port 6379.

Used by grails-redis during CI

https://github.com/search?q=org%3Aapache+supercharge%2Fredis-github-action&type=code

**Name of action:** supercharge/redis-github-action

**URL of action:**
https://github.com/supercharge/redis-github-action
https://github.com/marketplace/actions/redis-server-in-github-actions

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**
ea9b21c6ecece47bd99595c532e481390ea0f044 (1.8.0)

## Permissions

none

## Related Actions

none

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
