### PR TITLE
add sha versions for some actions used by Pekko

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -494,6 +494,8 @@ ludeeus/action-shellcheck:
   94e0aab03ca135d11a35e5bfc14e6746dc56e7e9:
     expires_at: 2050-01-01
 manusa/actions-setup-minikube:
+  b589f2d61bf96695c546929c72b38563e856059d:
+    expires_at: 2050-01-01
   '*':
     expires_at: 2025-08-01
     keep: true
@@ -667,6 +669,8 @@ ruby/setup-ruby:
     expires_at: 2025-08-01
     keep: true
 sbt/setup-sbt:
+  26ab4b0fa1c47fa62fc1f6e51823a658fb6c760c:
+    expires_at: 2050-01-01
   '*':
     expires_at: 2025-08-01
     keep: true
@@ -675,6 +679,8 @@ scacap/action-surefire-report:
     expires_at: 2025-08-01
     keep: true
 scala-steward-org/scala-steward-action:
+  5021652c555c5724af574758b78ea5be49640007:
+    expires_at: 2050-01-01
   '*':
     expires_at: 2025-08-01
     keep: true

--- a/actions.yml
+++ b/actions.yml
@@ -96,6 +96,8 @@ TobKed/label-when-approved-action:
 VirtusLab/scala-cli-setup:
   ef3764b372549ee60cce795f98da0df46e2567ff:
     expires_at: 2050-01-01
+  6fc878be89f1990f6599f4f6a2e52a252e54d9f9:
+    expires_at: 2050-01-01
 actions-cool/check-user-permission:
   '*':
     expires_at: 2025-08-01


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

Adding SHA versions for a few of the actions used by Pekko team. None of the changes add new actions, just allow specific SHAs - where currently wildcard versions are supported but with an August 2025 expiry.

**Name of action:** 

**URL of action:**

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**


## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [ ] The action is not already on the list of approved actions
- [ ] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
