### PR TITLE
add SHA for scalacenter/sbt-dependency-submission

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -699,6 +699,8 @@ scala-steward-org/scala-steward-action:
     expires_at: 2025-08-01
     keep: true
 scalacenter/sbt-dependency-submission:
+  64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3:
+    expires_at: 2050-01-01
   '*':
     expires_at: 2025-08-01
     keep: true


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

<!-- Please describe the proposed action; what it does and why this is needed. 
     It will help if you can tell us which project is interested in this action 
     and why.
-->

**Name of action:** 

scalacenter/sbt-dependency-submission v3.1.0 -- pins a SHA version, already approved

**URL of action:**

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**


## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [ ] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [ ] The action has CI/unit tests configured
