### PR TITLE
remove marcospereira/action-surefire-report

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -507,10 +507,6 @@ manusa/actions-setup-minikube:
   '*':
     expires_at: 2025-08-01
     keep: true
-marcospereira/action-surefire-report:
-  '*':
-    expires_at: 2025-08-01
-    keep: true
 maxim-lobanov/setup-xcode:
   '*':
     expires_at: 2025-08-01


### PR DESCRIPTION
Only Apache Pekko was using it. marcospereira/action-surefire-report is a clone of scacap/action-surefire-report and Pekko now uses that.