### PR TITLE
add mirromutth/mysql-action

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -801,3 +801,9 @@ golangci/golangci-lint-action:
   55c2c1448f86e01eaae002a5a3a9624417608d84:
     expires_at: 2050-08-01
     keep: true
+mirromutth/mysql-action:
+  de1fba8b3f90ce8db80f663a7043be3cf3231248:
+    expires_at: 2050-08-01
+    keep: true
+  v1.1:
+    expires_at: 2025-08-01


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

<!-- Please describe the proposed action; what it does and why this is needed. 
     It will help if you can tell us which project is interested in this action 
     and why.
-->

add mirromutth/mysql-action with set up a MySQL container for UT.

**Name of action:** 

mirromutth/mysql-action

**URL of action:**

https://github.com/mirromutth/mysql-action
https://github.com/marketplace/actions/setup-mysql

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**

de1fba8b3f90ce8db80f663a7043be3cf3231248

## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [ ] The action is listed in the GitHub Actions Marketplace
- [ ] The action is not already on the list of approved actions
- [ ] The action has a sufficient number of contributors or has contributors within the ASF community
- [ ] The action has a clearly defined license
- [ ] The action is actively developed or maintained
- [ ] The action has CI/unit tests configured
