### PR TITLE
chore: Increase dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,5 +23,4 @@ updates:
       - "/stash/restore"
       - "/stash/save"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "daily"


### PR DESCRIPTION
As we'd ideally want infrastructure-actions to pick up upgrades before they're proposed in projects
