### PR TITLE
ci: trigger workflow on changes to gateway files

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,15 +32,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python environment
-        uses: actions/setup-python@v5
-
-      - name: Install dependencies
-        run: |
-          pip install pytest ruyaml
-
       - name: Run tests
         run: |
-          pytest
+          pipx install uv
+          uvx --with ruyaml pytest
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update_actions.yml
+++ b/.github/workflows/update_actions.yml
@@ -29,8 +29,10 @@ jobs:
         with:
           persist-credentials: true
 
+      - run: pip install ruyaml 
+
       - name: Update actions.yml
-        shell: python
+        shell: python 
         run: |
           import sys
           sys.path.append("./gateway/")

--- a/.github/workflows/update_actions.yml
+++ b/.github/workflows/update_actions.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - ".github/workflows/update_actions.yml"
       - ".github/workflows/dummy.yml"
+      - gateway/*
 
 permissions:
   contents: read

--- a/.github/workflows/update_dummy.yml
+++ b/.github/workflows/update_dummy.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - ".github/workflows/update_dummy.yml"
       - "actions.yml"
+      - gateway/*
 
 permissions: {}
 

--- a/.github/workflows/update_dummy.yml
+++ b/.github/workflows/update_dummy.yml
@@ -29,8 +29,10 @@ jobs:
           # We have to use a PAT to commit the workflow file
           token: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN || github.token }}
 
+      - run: pip install ruyaml 
+
       - name: Update Workflow 
-        shell: python
+        shell: python 
         run: |
           import sys
           sys.path.append("./gateway/")

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -7,6 +7,7 @@
 
 import os
 from datetime import date, timedelta
+from io import StringIO
 from pathlib import Path
 from typing import Dict, NotRequired, TypedDict
 
@@ -74,6 +75,11 @@ def write_yaml(path: Path, yaml_dict: dict | list):
         yaml = ruyaml.YAML()
         yaml.dump(yaml_dict, file)
 
+def to_yaml_string(yaml_dict: dict | list):
+    yaml = ruyaml.YAML()
+    stream = StringIO()
+    yaml.dump(yaml_dict, stream)
+    return stream.getvalue()
 
 def write_str(path: Path, content: str):
     with open(path, "w") as file:
@@ -190,10 +196,8 @@ def update_actions(dummy_path: Path, actions_path: Path):
     actions: ActionsYAML = load_yaml(actions_path)
 
     update_refs(steps, actions)
-    yaml = ruyaml.YAML()
-    gha_print(yaml.dump(actions), "Generated List")
+    gha_print(to_yaml_string(actions), "Generated List")
     write_yaml(actions_path, actions)
-
 
 def create_pattern(actions: ActionsYAML) -> list[str]:
     """
@@ -227,9 +231,8 @@ def update_patterns(pattern_path: Path, list_path: Path):
     """
     actions: ActionsYAML = load_yaml(list_path)
     patterns = create_pattern(actions)
-    comment = f"# This file was generated from {pattern_path} by gateway/gateway.py. DO NOT UPDATE MANUALLY.\n"
-    yaml = ruyaml.YAML()
-    patterns_str = comment + yaml.safe_dump(patterns)
+    comment = f"# This file was generated from {list_path} by gateway/gateway.py. DO NOT UPDATE MANUALLY.\n"
+    patterns_str = comment + to_yaml_string(patterns)
     gha_print(patterns_str, "Generated Patterns")
     write_str(pattern_path, patterns_str)
 
@@ -283,6 +286,5 @@ def clean_actions(actions_path: Path):
     """
     actions: ActionsYAML = load_yaml(actions_path)
     remove_expired_refs(actions)
-    yaml = ruyaml.YAML()
-    gha_print(yaml.safe_dump(actions), "Cleaned Actions")
+    gha_print(to_yaml_string(actions), "Cleaned Actions")
     write_yaml(actions_path, actions)

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -190,7 +190,8 @@ def update_actions(dummy_path: Path, actions_path: Path):
     actions: ActionsYAML = load_yaml(actions_path)
 
     update_refs(steps, actions)
-    gha_print(yaml.safe_dump(actions), "Generated List")
+    yaml = ruyaml.YAML()
+    gha_print(yaml.dump(actions), "Generated List")
     write_yaml(actions_path, actions)
 
 
@@ -227,6 +228,7 @@ def update_patterns(pattern_path: Path, list_path: Path):
     actions: ActionsYAML = load_yaml(list_path)
     patterns = create_pattern(actions)
     comment = f"# This file was generated from {pattern_path} by gateway/gateway.py. DO NOT UPDATE MANUALLY.\n"
+    yaml = ruyaml.YAML()
     patterns_str = comment + yaml.safe_dump(patterns)
     gha_print(patterns_str, "Generated Patterns")
     write_str(pattern_path, patterns_str)
@@ -281,5 +283,6 @@ def clean_actions(actions_path: Path):
     """
     actions: ActionsYAML = load_yaml(actions_path)
     remove_expired_refs(actions)
+    yaml = ruyaml.YAML()
     gha_print(yaml.safe_dump(actions), "Cleaned Actions")
     write_yaml(actions_path, actions)

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -1,9 +1,17 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "ruyaml",
+# ]
+# ///
+
 import os
 from datetime import date, timedelta
 from pathlib import Path
 from typing import Dict, NotRequired, TypedDict
 
 import ruyaml
+
 
 class RefDetails(TypedDict):
     """


### PR DESCRIPTION
The workflows are meant to run on PRs but we haven't triggered them on changes to the actual scripts so far.

That's why we missed some changes in #169 