### PR TITLE
Add comment explaining actions.yml

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -1,3 +1,8 @@
+# Main configuration file. We manually add trusted actions here.
+# Version updates can be triggered by merging dependabot PRs
+# into .github/workflows/dummy-workflow.yml . This will also
+# update expiry dates for previous versions.
+# Versions that are known to be problematic should be removed explicitly manually.
 1Password/load-secrets-action:
   581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0:
     expires_at: 2025-08-01


### PR DESCRIPTION
This was added earlier in https://github.com/apache/infrastructure-actions/pull/162 but didn't survive the `actions.yml` update in https://github.com/apache/infrastructure-actions/commit/3222bfcd237a4a533e19a8ded068b2723514d35d

Now that we updated to ruyaml in
https://github.com/apache/infrastructure-actions/pull/169 I think comments should be preserved
