### PR TITLE
chore: Update dependabot commit message

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    commit-message:
+      prefix: "gateway(bump)"
     directories:
       - "/"
       - "/pelican/"


### PR DESCRIPTION
This will prefix all dependabot PRs with `gateway(bump)` as this will be the most likely scenario for a dependabot update, an update to the dummy workflow.

For all other dependencies updates for action (like stash action) we will need to re-name the PR but that should be much less work than the other way around. And if it's to annoying we can find another way around this.