### PR TITLE
chore: Remove redundant bump scope in dependabot commit message

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     commit-message:
-      prefix: "gateway(bump)"
+      prefix: "gateway"
     directories:
       - "/"
       - "/pelican/"


### PR DESCRIPTION
The commit messages all begin with "Bump ..." so adding that as a scope is just noise.