### PR TITLE
gateway: remove unused pdm-project/setup-pdm

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -668,12 +668,6 @@ packetcoders/action-setup-cache-python-poetry:
   a3f2e6ed12462e038bc14270d139e373bf5ac564:
     expires_at: 2050-01-01
     tag: v1.1.0
-pdm-project/setup-pdm:
-  v4:
-    expires_at: 2025-08-01
-  483717a073bdef51804a58dac17d043a4183c384:
-    expires_at: 2050-01-01
-    tag: v4
 peaceiris/actions-gh-pages:
   '*':
     expires_at: 2025-08-01


### PR DESCRIPTION
The action is unused and seems to cause dependabot [issues](https://github.com/apache/infrastructure-actions/actions/runs/15686410932/job/44190613501#step:3:1636).