### PR TITLE
gateway: add mlugg/setup-zig

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -882,3 +882,7 @@ golangci/golangci-lint-action:
   55c2c1448f86e01eaae002a5a3a9624417608d84:
     expires_at: 2050-08-01
     keep: true
+mlugg/setup-zig:
+  7dccf5e6d09267c55f815f2db29495f30ba2ebca:
+    expires_at: 2050-01-01
+    tag: v2.0.1


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview
This is the replacement for https://github.com/korandoru/setup-zig?tab=readme-ov-file#archived
which was archived. `mlugg` is a zig core developer so this is an almost 'official' action.

**Name of action:**
mlugg/setup-zig 

**URL of action:**
https://github.com/mlugg/setup-zig

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**
v2.0.1 7dccf5e6d09267c55f815f2db29495f30ba2ebca

## Permissions
None

## Related Actions
See above, korandoru/setup-zig

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
