### PR TITLE
gateway: open dependabot floodgates further

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,4 @@ updates:
       - "/stash/save"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 50


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-

hopefully fixes #213
