### PR TITLE
Add google auth action since it was split from setup-gcloud

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -402,6 +402,7 @@ golang/govulncheck-action:
 google-github-actions/auth:
   ba79af03959ebeac9769e648f473a284504d9193:
     expires_at: 2050-01-01
+    tag: v2.1.10 
 google-github-actions/setup-gcloud:
   77e7a554d41e2ee56fc945c52dfd3f33d12def9a:
     expires_at: 2050-01-01

--- a/actions.yml
+++ b/actions.yml
@@ -399,6 +399,9 @@ golang/govulncheck-action:
   '*':
     expires_at: 2025-08-01
     keep: true
+google-github-actions/auth:
+  ba79af03959ebeac9769e648f473a284504d9193:
+    expires_at: 2050-01-01
 google-github-actions/setup-gcloud:
   77e7a554d41e2ee56fc945c52dfd3f33d12def9a:
     expires_at: 2050-01-01


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

Grails uses the `google-github-actions/setup-gcloud` to deploy our containers for the backend of start.grails.org.  The authentication portion of this action has been split into `google-github-actions/auth`.  This change adds the hash of the latest tag for auth so we can continue publishing. 

**Name of action:**  google-github-actions/auth

**URL of action:** https://github.com/google-github-actions/auth

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** ba79af03959ebeac9769e648f473a284504d9193


## Permissions

none

## Related Actions

`google-github-actions/setup-gcloud` is already approved and now requires this action.  There is currently not an entry for this in the approved list.

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [X] The action is listed in the GitHub Actions Marketplace
- [X] The action is not already on the list of approved actions
- [X] The action has a sufficient number of contributors or has contributors within the ASF community
- [X] The action has a clearly defined license
- [X] The action is actively developed or maintained
- [X] The action has CI/unit tests configured
