### PR TITLE
Allow mlugg/setup-zig for all the versions

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -890,6 +890,6 @@ golangci/golangci-lint-action:
     expires_at: 2050-08-01
     keep: true
 mlugg/setup-zig:
-  7dccf5e6d09267c55f815f2db29495f30ba2ebca:
-    expires_at: 2050-01-01
-    tag: v2.0.1
+  '*':
+    expires_at: 2025-08-01
+    keep: true


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

mlugg/setup-zig is the de-facto official action to set up Zig. The owner is Zig Software Foundation's member.

**Name of action:** mlugg/setup-zig

**URL of action:** https://github.com/mlugg/setup-zig

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** I use `*` follow `setup-php` / `setup-dlang` and so on.

## Permissions

Default

## Related Actions

No

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [ ] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
