### PR TITLE
gateway!: remove archived actions-rs/*  wildcard

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -12,10 +12,6 @@ ana06/get-changed-files:
   25f79e676e7ea1868813e21465014798211fad8c:
     tag: v2.3.0
     expires_at: 2050-01-01
-actions-rs/*:
-  '*':
-    expires_at: 2025-08-01
-    keep: true
 apache/*:
   '*':
     expires_at: 2025-08-01


### PR DESCRIPTION
Over a month ago I opened PRs to remove the use of this action across apache/* most of the PRs where merged.

It's now time to remove this org that has been archived for several(!) years.