### PR TITLE
chore(gateway): add missing newline to dummy workflow

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -155,7 +155,7 @@ jobs:
             details = refs[ref]
             steps.append(f"      - uses: {name}@{ref}" + (f"  # {details['tag']}" if 'tag' in details else ''))
 
-    return header + "\n".join(steps)
+    return header + "\n".join(steps) + "\n"
 
 
 def update_refs(


### PR DESCRIPTION
The missing newline always adds an insertion when editing files in dependabot PRs through the webinterface.