### PR TITLE
gateway: fix tag for ilammy/setup-nasm

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: helm/chart-releaser-action@fc23f249f75decd5edf254c6b4401532cef093c3  # v1.4.0
       - uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b  # v2.7.0
       - uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3  # v1.12.0
-      - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b  # v1
+      - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b  # v1.5.2
       - uses: jasonetco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5  # v2
       - uses: jrouly/scalafmt-native-action@14620cde093e5ff6bfbbecd4f638370024287b9d  # v4
       - uses: jwgmeligmeyling/pmd-github-action@322e346bd76a0757c4d54ff9209e245965aa066d


### PR DESCRIPTION
Carries the branch tag v1, replace with actual release tag.