### PR TITLE
pelican: upgrade python version to use latest 3.10 and debian bullseye

### DIFF
--- a/pelican/Dockerfile
+++ b/pelican/Dockerfile
@@ -1,10 +1,10 @@
 # Settings
 # ========
-ARG PYTHON_VERSION=3.9.17
+ARG PYTHON_VERSION=3.10.18-bullseye
 ARG GFM_VERSION=0.28.3.gfm.12 # must agree with copy below
 
 # Build cmake-gfm
-FROM python:${PYTHON_VERSION}-slim-buster as pelican-asf
+FROM python:${PYTHON_VERSION} as pelican-asf
 
 RUN apt update && apt upgrade -y
 RUN apt install curl cmake build-essential -y
@@ -18,7 +18,7 @@ COPY build-cmark.sh bin/build-cmark.sh
 RUN bash bin/build-cmark.sh ${GFM_VERSION}
 
 # rebase the image to save on image size
-FROM python:${PYTHON_VERSION}-slim-buster
+FROM python:${PYTHON_VERSION}
 
 # Use the Pelican version as installed on CI pelican builders (2023-06-02)
 ARG PELICAN_VERSION=4.5.4


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

<!-- Please describe the proposed action; what it does and why this is needed. 
     It will help if you can tell us which project is interested in this action 
     and why.
-->
Closes #218, follow up to #219

`buster`/Debian 10 is EOL https://www.debian.org/News/2024/20240615
Using `bullseye`/Debian 11 https://wiki.debian.org/LTS/Using

**Name of action:** 
Pelican 

**URL of action:**

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**


## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [ ] The action is listed in the GitHub Actions Marketplace
- [ ] The action is not already on the list of approved actions
- [ ] The action has a sufficient number of contributors or has contributors within the ASF community
- [ ] The action has a clearly defined license
- [ ] The action is actively developed or maintained
- [ ] The action has CI/unit tests configured
