### PR TITLE
fix(gateway): Use `:` as a reference separator for docker actions

### DIFF
--- a/gateway/test_dummy.yml
+++ b/gateway/test_dummy.yml
@@ -52,8 +52,8 @@ jobs:
     - uses: damccorm/tag-ur-it@6fa72bbf1a2ea157b533d7e7abeafdb5855dbea5
     - uses: dawidd6/action-send-mail@4226df7daafa6fc901a43789c49bf7ab309066e7
     - uses: dawidd6/action-send-mail@v3
-    - uses: docker://jekyll/jekyll@sha256:400b8d1569f118bca8a3a09a25f32803b00a55d1ea241feaf5f904d66ca9c625
-    - uses: docker://jekyll/jekyll@*
+    - uses: docker://jekyll/jekyll:sha256:400b8d1569f118bca8a3a09a25f32803b00a55d1ea241feaf5f904d66ca9c625
+    - uses: docker://jekyll/jekyll:*
     - uses: dominikh/staticcheck-action@4ec9a0dff54be2642bc76581598ba433fd8d4967
     - uses: dominikh/staticcheck-action@v1.1.0
     - uses: dorny/paths-filter@v3.0.2

--- a/gateway/test_gateway.py
+++ b/gateway/test_gateway.py
@@ -25,6 +25,7 @@ def test_update_refs():
     steps = [
         {"uses": "actions/setup-go@v5"},
         {"uses": "dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36"},
+        {"uses": "docker://alpine:3.18.4"},
     ]
 
     refs: ActionsYAML = {
@@ -41,6 +42,9 @@ def test_update_refs():
             "0bc4621a3135347011ad047f9ecf449bf72ce2bd": {
                 "expires_at": indefinitely
             }
+        },
+        "docker://alpine": {
+            "3.17.2": {"expires_at": indefinitely}
         },
     }
 
@@ -62,6 +66,10 @@ def test_update_refs():
                 "expires_at": indefinitely,
             },
         },
+        "docker://alpine": {
+            "3.17.2": {"expires_at": calculate_expiry(12)},
+            "3.18.4": {"expires_at": indefinitely},
+        },
     }
 
     update_refs(steps, refs)
@@ -70,6 +78,7 @@ def test_update_refs():
 def test_update_refs_expiry():
     steps = [
         {"uses": "dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36"},
+        {"uses": "docker://postgres:15.4"},
     ]
 
     refs: ActionsYAML = {
@@ -91,6 +100,15 @@ def test_update_refs_expiry():
                 "expires_at": indefinitely
             },
         },
+        "docker://postgres": {
+            "15.3": {
+                "expires_at": calculate_expiry(16)
+            },
+            "14.8": {
+                "expires_at": indefinitely,
+                "keep": True,
+            },
+        },
     }
 
     expected_refs: ActionsYAML = {
@@ -115,6 +133,18 @@ def test_update_refs_expiry():
                 "expires_at": indefinitely,
             },
         },
+        "docker://postgres": {
+            "15.3": {
+                "expires_at": calculate_expiry(12)
+            },
+            "14.8": {
+                "expires_at": indefinitely,
+                "keep": True,
+            },
+            "15.4": {
+                "expires_at": indefinitely,
+            },
+        },
     }
 
     update_refs(steps, refs)
@@ -124,6 +154,7 @@ def test_update_tagged_ref():
     steps = load_yaml_string('''
     - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
     - uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8   # v16
+    - uses: docker://redis:7.2.4   # stable
     ''')
 
     refs: ActionsYAML = {
@@ -137,6 +168,9 @@ def test_update_tagged_ref():
             "0bc4621a3135347011ad047f9ecf449bf72ce2bd": {
                 "expires_at": indefinitely
             }
+        },
+        "docker://redis": {
+            "7.0.14": {"expires_at": indefinitely}
         },
     }
 
@@ -161,6 +195,10 @@ def test_update_tagged_ref():
                 "tag": "v16",
             }
         },
+        "docker://redis": {
+            "7.0.14": {"expires_at": calculate_expiry(12)},
+            "7.2.4": {"expires_at": indefinitely, "tag": "stable"},
+        },
     }
 
     update_refs(steps, refs)
@@ -174,14 +212,17 @@ def test_create_pattern():
             "v4": {"expires_at": indefinitely, "keep": True},
         },
         "hashicorp/setup-terraform": {"v2": {"expires_at": datetime.date(1100, 1, 1)}},
+        "docker://alpine": {
+            "3.18.4": {"expires_at": indefinitely},
+            "3.17.0": {"expires_at": datetime.date(1100, 1, 1)},
+        },
     }
-    expected = ["actions/setup-go@v5", "actions/setup-go@v4"]
+    expected = ["actions/setup-go@v5", "actions/setup-go@v4", "docker://alpine:3.18.4"]
     pattern = create_pattern(actions)
-    assert pattern == expected
+    assert sorted(pattern) == sorted(expected)
 
 
 def test_clean_actions():
-
     refs: ActionsYAML = {
         "actions/setup-go": {
             "v5": {"expires_at": calculate_expiry() + timedelta(days=2)},
@@ -196,6 +237,10 @@ def test_clean_actions():
                 "expires_at": indefinitely,
             },
         },
+        "docker://postgres": {
+            "14.7": {"expires_at": datetime.date(1900, 1, 1)},
+            "15.4": {"expires_at": indefinitely},
+        },
     }
 
     expected_refs: ActionsYAML = {
@@ -207,6 +252,9 @@ def test_clean_actions():
             "de90cc6fb38fc0963ad72b210f1f284cd68cea36": {
                 "expires_at": indefinitely,
             }
+        },
+        "docker://postgres": {
+            "15.4": {"expires_at": indefinitely},
         },
     }
 


### PR DESCRIPTION
Resolves: #253 