### PR TITLE
Add new action posit-dev/setup-air v1.0.0

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -883,3 +883,7 @@ mlugg/setup-zig:
   8d6198c65fb0feaa111df26e6b467fea8345e46f:
     expires_at: 2050-01-01
     tag: v2.0.5
+posit-dev/setup-air:
+  63e80dedb6d275c94a3841e15e5ff8691e1ab237:
+    expires_at: 2050-01-01
+    tag: v1.0.0


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

Automatic formatting of R Code.  

**Name of action:** 

posit-dev/setup-air

**URL of action:**

https://github.com/posit-dev/setup-air
https://posit-dev.github.io/air/integration-github-actions.html

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**

63e80dedb6d275c94a3841e15e5ff8691e1ab237

## Permissions

Mostly read access though write access for PRs would be handy for automatically fixing issues if we want to use that.

## Related Actions

There are other actions for R styling within the currently allowed `r-lib/actions/*`, but this is a newer one which is significantly faster, gaining traction in R, released by Posit, and will cut down CI run times.

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [ ] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
