### PR TITLE
Add freebsd-vm action into allowlist

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -870,3 +870,7 @@ posit-dev/setup-air:
   63e80dedb6d275c94a3841e15e5ff8691e1ab237:
     expires_at: 2050-01-01
     tag: v1.0.0
+vmactions/freebsd-vm:
+  05856381fab64eeee9b038a0818f6cec649ca17a:
+    expires_at: 2050-01-01
+    tag: v1.2.3


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

<!-- Please describe the proposed action; what it does and why this is needed. 
     It will help if you can tell us which project is interested in this action 
     and why.
-->

**Name of action:** vmactions/freebsd-vm

**URL of action:** https://github.com/vmactions/freebsd-vm

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**

`05856381fab64eeee9b038a0818f6cec649ca17a`

https://github.com/vmactions/freebsd-vm/commit/05856381fab64eeee9b038a0818f6cec649ca17a

## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

None.

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

None.

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
