### PR TITLE
Add coverity scan

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -819,6 +819,10 @@ uraimo/run-on-arch-action:
   d94c13912ea685de38fccc1109385b83fd79427d:
     expires_at: 2050-01-01
     tag: v3.0.1
+vapier/coverity-scan-action:
+  2068473c7bdf8c2fb984a6a40ae76ee7facd7a85:
+    expires_at: 2050-01-01
+    tag: v1.8.0
 vimtor/action-zip:
   5f1c4aa587ea41db1110df6a99981dbe19cee310:
     expires_at: 2050-01-01


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

The action automates the process of creating and uploading a build to the Coverity Scan service. Using this action removes the need for projects to re-invent the wheel to manually code a CI job to do the same actions.

**Name of action:** 
Coverity Scan Action

**URL of action:**
https://github.com/vapier/coverity-scan-action

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**
2068473c7bdf8c2fb984a6a40ae76ee7facd7a85

## Permissions

Read access to the code (not an issue).
Read access to upload token for Coverity scan.

## Related Actions

None

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [X] The action is listed in the GitHub Actions Marketplace
- [X] The action is not already on the list of approved actions
- [ ] The action has a sufficient number of contributors or has contributors within the ASF community
- [X] The action has a clearly defined license
- [X] The action is actively developed or maintained
- [X] The action has CI/unit tests configured

The action is simple enough that it could be forked if the current contributors stopped supporting it.