### PR TITLE
Extend where matching: eq, ne, in and notin

### DIFF
--- a/pelican/plugins/asfdata.py
+++ b/pelican/plugins/asfdata.py
@@ -99,14 +99,52 @@ def remove_part(reference, part):
             remove_part(reference[refs], part)
 
 
-# trim out parts of a data source that don't match part = True
-def where_parts(reference, part):
+# does the part match the where clause?
+# This can be:
+#   where: key
+# In this case, the key lookup value must be True
+# or:
+#   where: key eq|ne|in|notin value(s)
+# The key lookup value must equal or not equal the value, or
+# must be (not) one of the space-separated values (respectively)
+def partMatches(actual, cond, expected):
+    if cond is None and expected is None:
+        return actual # Is it True?
+    if cond == 'eq':
+        return actual == expected
+    if cond == 'ne':
+        return actual != expected
+    if cond == 'in':
+        return actual in expected
+    if cond == 'notin':
+        return actual not in expected
+    raise Exception(f"Unexpected condition {cond}") # pylint: disable=broad-exception-raised
+
+# trim out parts of a data source that don't match the part condition (default == True)
+def where_parts(reference, where_clause):
+    items = where_clause.split()
+    key = items.pop(0)
+    if len(items) == 0:
+        cond = None
+        expected = None
+    elif len(items) >= 2:
+        cond = items.pop(0)
+        if cond in ['ne', 'eq'] and len(items) == 1: # should only be one item left
+            expected = items.pop(0)
+        elif cond in ['in', 'notin']:
+            expected = items
+        else:
+            # TODO: choose better exception
+            raise Exception(f"Unexpected condition '{cond}' or extra param: {len(items)}")  # pylint: disable=broad-exception-raised
+    else:
+        # TODO: choose better exception
+        raise Exception("'where' expects 1 parameter optionally followed by at least 2 parameters") # pylint: disable=broad-exception-raised
     # currently only works on True parts
     # if we trim as we go we invalidate the iterator. Instead create a deletion list.
     filtered = [ ]
     # first find the list that needs to be trimmed.
     for refs in reference:
-        if not reference[refs][part]:
+        if not partMatches(reference[refs][key], cond, expected):
             filtered.append(refs)
     # remove the parts to be trimmed.
     for refs in filtered:


### PR DESCRIPTION
Current 'where' matching is very limited; it only looks for a field value of `True`

This PR extends the conditions to allow for more filtering.
- by value matching string
- by value not matching string
- by value in list
- by value not in list

For example, this would allow one to extract graduated podlings from https://whimsy.apache.org/public/public_podlings.json by using:

```
pods2:
  url: https://whimsy.apache.org/public/public_podlings.json
  graduated:
    path: podling
    where: status eq graduated
```