### PR TITLE
gateway: add `astral-sh/setup-uv`

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -18,6 +18,10 @@ apache/*:
   '*':
     expires_at: 2025-08-01
     keep: true
+astral-sh/setup-uv:
+  b75a909f75acd358c2196fb9a5f1299a9a8868a4:
+    tag: v6.7.0
+    expires_at: 2050-01-01
 bytedeco/javacpp-presets/.github/actions/*:
   '*':
     expires_at: 2025-08-01
@@ -833,7 +837,3 @@ vmactions/freebsd-vm:
   05856381fab64eeee9b038a0818f6cec649ca17a:
     expires_at: 2050-01-01
     tag: v1.2.3
-astral-sh/setup-uv:
-  '*':
-    expires_at: 2050-01-01
-    keep: true

--- a/actions.yml
+++ b/actions.yml
@@ -833,3 +833,7 @@ vmactions/freebsd-vm:
   05856381fab64eeee9b038a0818f6cec649ca17a:
     expires_at: 2050-01-01
     tag: v1.2.3
+astral-sh/setup-uv:
+  '*':
+    expires_at: 2050-01-01
+    keep: true


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

<!-- Please describe the proposed action; what it does and why this is needed. 
     It will help if you can tell us which project is interested in this action 
     and why.
-->

Add `astral-sh/setup-uv`, the official action to install and cache the **uv** Python package/project manager, to the org-wide allow list. uv provides fast, reproducible Python environment management, lockfiles, and a pip-compatible interface and can also install Python itself; the action installs uv on the runner and (optionally) persists uv’s cache to speed up subsequent runs. This is broadly useful for ASF projects with Python components (builds, tests, docs). 

**Name of action:** `astral-sh/setup-uv`

**URL of action:** https://github.com/astral-sh/setup-uv

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** [`b75a909f75acd358c2196fb9a5f1299a9a8868a4`](https://github.com/astral-sh/setup-uv/commit/b75a909f75acd358c2196fb9a5f1299a9a8868a4)

## Permissions

The action downloads uv release artifacts from the `astral-sh/uv` GitHub Releases API and adds the binary to `PATH`. No repository write operations are performed by the action itself.

## Related Actions

- **`actions/setup-python`** (already allowed via `actions/*`) installs Python versions and integrates with runner caches. `astral-sh/setup-uv` is complementary: it installs **uv** (and uv can then install Python and manage environments), adds optional uv cache persistence, and supports lockfile-driven workflows for determinism and speed. 

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license *(MIT license in repo)*
- [x] The action is actively developed or maintained *(recent releases incl. v6.7.0 on 2025-09-14)*
- [x] The action has CI/unit tests configured *(repo shows CI workflows incl. `test`)*
