### PR TITLE
Add `tj-actions/changed-files`

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -856,6 +856,10 @@ testlens-app/setup-testlens:
 timonvs/pr-labeler-action:
   '*':
     keep: true
+tj-actions/changed-files:
+  24d32ffd492484c1d75e0c0b894501ddb9d30d62:
+    expires_at: 2050-01-01
+    tag: v47.0.0
 TobKed/label-when-approved-action:
   '*':
     keep: true
@@ -874,6 +878,13 @@ vimtor/action-zip:
 vishalsinha21/dynamic-checklist:
   '*':
     keep: true
+vmactions/freebsd-vm:
+  05856381fab64eeee9b038a0818f6cec649ca17a:
+    expires_at: 2025-12-22
+    tag: v1.2.3
+  487ce35b96fae3e60d45b521735f5aa436ecfade:
+    expires_at: 2050-01-01
+    tag: v1.2.4
 wei/curl:
   '*':
     keep: true


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

I want to add this action, because for Datafusion we [need a way](https://github.com/apache/datafusion/issues/6880) to check if the PR has touched some files, and Merge Queue [doesn't work](https://github.com/orgs/community/discussions/45899) with `paths-ignore`

**Name of action:**  tj-actions/changed-files

**URL of action:** https://github.com/tj-actions/changed-files

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** [`24d32ff`](https://github.com/tj-actions/changed-files/commit/24d32ffd492484c1d75e0c0b894501ddb9d30d62)


## Permissions

Action can work with read only access 

## Related Actions

There's a similar one https://github.com/Ana06/get-changed-files already in the list, but I believe it's not maintained 

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace: https://github.com/marketplace/actions/changed-files
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [X] The action has a clearly defined license: MIT
- [x] The action is actively developed or maintained: commits every months since 2021
- [x] The action has CI/unit tests configured: https://github.com/tj-actions/changed-files/tree/main/test
