### PR TITLE
infra: macos-13 is deprecated

### DIFF
--- a/.github/workflows/stash-action-test.yml
+++ b/.github/workflows/stash-action-test.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
     needs: test-save
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

<!-- Please describe the proposed action; what it does and why this is needed. 
     It will help if you can tell us which project is interested in this action 
     and why.
-->


## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [ ] The action is listed in the GitHub Actions Marketplace
- [ ] The action is not already on the list of approved actions
- [ ] The action has a sufficient number of contributors or has contributors within the ASF community
- [ ] The action has a clearly defined license
- [ ] The action is actively developed or maintained
- [ ] The action has CI/unit tests configured
