### PR TITLE
gateway: ignore cpp-linter 2.16 dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,4 +26,10 @@ updates:
       - "/stash/save"
     schedule:
       interval: "daily"
+    ignore:
+      # post-2.16 versions depend on hustcer/setup-nu which
+      # we're not comfortable trusting fully yet. See also
+      # https://github.com/apache/infrastructure-actions/issues/324
+      - dependency-name: "cpp-linter/cpp-linter-action"
+        versions: ">=2.16"
     open-pull-requests-limit: 50


### PR DESCRIPTION
Guessing the syntax since
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated doesn't appear to document the GitHub Actions case...
