### PR TITLE
actions: remove wildcard for scala-steward

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -739,9 +739,6 @@ scala-steward-org/scala-steward-action:
   5021652c555c5724af574758b78ea5be49640007:
     expires_at: 2025-10-25
     tag: v2.75.0
-  '*':
-    expires_at: 2025-08-01
-    keep: true
   961c41c9fd3dc8a0f1f8dd59d60d071e17348ae8:
     expires_at: 2025-12-08
     tag: v2.76.0


### PR DESCRIPTION
we want to move away from wildcards and scala-steward usages are (almost) all pinned now.
