### PR TITLE
Allow use of `ppkarwasz/fetch-metadata` alongside `dependabot/fetch-metadata`

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -623,6 +623,10 @@ potiuk/cancel-workflow-runs:
   '*':
     expires_at: 2025-08-01
     keep: true
+ppkarwasz/fetch-metadata:
+  14da1d746fb4c6f05dbc353e4fd619a1065c8ff6:
+    expires_at: 2025-10-01
+    tag: v0.1.0
 pre-commit/action:
   2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd:
     expires_at: 2050-01-01


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

This PR allows the usage of the `ppkarwasz/fetch-metadata` GitHub Action as an alternative to `dependabot/fetch-metadata` in ASF repositories.

The `ppkarwasz/fetch-metadata` action is a personal improvement of the original `dependabot/fetch-metadata`, adding support for grouped Dependabot pull requests, a feature that is currently missing from the upstream action. The implementation has already been reviewed and approved by the Dependabot team (see dependabot/fetch-metadata#632), but the upstream project has been inactive for several months, likely due to reduced maintenance capacity at GitHub. This has prevented the improvement from being merged and released.

**Name of action:** `ppkarwasz/fetch-metadata`

**URL of action:** https://github.com/ppkarwasz/fetch-metadata

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** `14da1d746fb4c6f05dbc353e4fd619a1065c8ff6`

## Permissions

The action only requires `read` permissions, so no explicit permission besides what is publicly available.

## Related Actions

`dependabot/fetch-metadata`

## Why this change is needed

In Apache Logging Services, every pull request must include a changelog entry. Previously, under CTR, we used a workflow that automatically added the changelog entry and merged the PR.

Since switching to RTC, this automation can no longer complete the merge step, resulting in repositories accumulating unmerged Dependabot PRs that must be:

* manually reviewed,
* updated with an empty commit to re-trigger required status checks,
* and merged by hand.

We already have an improved workflow in place (see apache/logging-parent#419) that provides:

* **Security enhancements** through separation of privileged and unprivileged workflows (`ppkarwasz/fetch-metadata` is used only in the unprivileged workflow),
* **Automatic merge using `auto-merge` instead of manual merging**, and
* **Support for grouped Dependabot PRs** (reducing noise to ~1 PR per repository per month).

The final item, grouped PR support, requires the `ppkarwasz/fetch-metadata` action.

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [ ] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [ ] The action is actively developed or maintained
- [ ] The action has CI/unit tests configured
