### PR TITLE
Fix tag name for `scalacenter/sbt-dependency-submission`

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -694,7 +694,7 @@ scala-steward-org/scala-steward-action:
 scalacenter/sbt-dependency-submission:
   64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3:
     expires_at: 2050-01-01
-    tag: v3.0.2
+    tag: v3.1.0
   '*':
     expires_at: 2025-08-01
     keep: true


### PR DESCRIPTION
This PR updates the definition of an action that already exists in `actions.yml`.

## Overview

The tag `v3.0.2` mentioned in `actions.yml` for `scalacenter/sbt-dependency-submission` doesn't exist. Instead, the tag `v3.1.0` references the same SHA.

**Name of action:** 

scalacenter/sbt-dependency-submission

https://github.com/scalacenter/sbt-dependency-submission

64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3
