### PR TITLE
Add `tag` value for `https://github.com/jwgmeligmeyling/pmd-github-action/releases`

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -480,6 +480,7 @@ jwgmeligmeyling/checkstyle-github-action:
     keep: true
 jwgmeligmeyling/pmd-github-action:
   322e346bd76a0757c4d54ff9209e245965aa066d:
+    tag: v1.2
     expires_at: 2050-01-01
 jwgmeligmeyling/spotbugs-github-action:
   '*':


### PR DESCRIPTION
See https://github.com/jwgmeligmeyling/pmd-github-action/releases (the actual tag name is a little bit longer than `v1.2`)
