### PR TITLE
Add `gradle/actions/setup-gradle` action

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -355,7 +355,7 @@ google-github-actions/setup-gcloud:
 gradle/actions/setup-gradle:
   4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2:
     expires_at: 2050-01-01
-    tag: v5
+    tag: v5.0.0
 gr2m/twitter-together:
   '*':
     expires_at: 2025-08-01


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

The action sets up Gradle in workflows. It's (at least IMHO) an easy way to get Gradle running.

[`gradle/actions/setup-gradle`](https://github.com/gradle/actions/tree/main/setup-gradle)

[`4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2`](https://github.com/gradle/actions/releases/tag/v5)

Tag: [`v5`](https://github.com/gradle/actions/tree/v5/setup-gradle)

## Permissions

No permissions required.

## Related Actions

n/a

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [X] The action is listed in the GitHub Actions Marketplace (https://github.com/marketplace/actions/build-with-gradle)
- [X] The action is not already on the list of approved actions
- [X] The action has a sufficient number of contributors or has contributors within the ASF community
- [X] The action has a clearly defined license (MIT)
- [X] The action is actively developed or maintained
- [X] The action has CI/unit tests configured
