### PR TITLE
Add Jimver/cuda-toolkit

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -440,6 +440,10 @@ jidicula/clang-format-action:
   '*':
     expires_at: 2025-08-01
     keep: true
+Jimver/cuda-toolkit:
+  6008063726ffe3309d1b22e413d9e88fed91a2f2:
+    expires_at: 2050-01-01
+    tag: v0.2.29
 jlumbroso/free-disk-space:
   '*':
     expires_at: 2025-08-01


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

`Jimver/cuda-toolkit` provides a way to  seup cuda toolkit to the system. It can be useful for testing build of source code that comes optionally comes with cuda support in environments like windows

**Name of action:** 

Jimver/cuda-toolkit

**URL of action:**

https://github.com/Jimver/cuda-toolkit

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**

6008063726ffe3309d1b22e413d9e88fed91a2f2


## Permissions

None

## Related Actions


## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
