### PR TITLE
chore: update erisu/license-checker-action (v2.0.1)

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -71,7 +71,7 @@ jobs:
         if: false
       - uses: erisu/apache-rat-action@46fb01ce7d8f76bdcd7ab10e7af46e1ea95ca01c  # v2.0.0
         if: false
-      - uses: erisu/license-checker-action@1c222d0c2f5898a4c40b8bd6fd6888650bd6f68a  # v2.0.0
+      - uses: erisu/license-checker-action@99cffa11264fe545fd0baa6c13bca5a00ae608f2  # v2.0.1
         if: false
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
         if: false

--- a/actions.yml
+++ b/actions.yml
@@ -315,7 +315,10 @@ erisu/apache-rat-action:
     tag: v2.0.0
 erisu/license-checker-action:
   1c222d0c2f5898a4c40b8bd6fd6888650bd6f68a:
+    expires_at: 2026-01-01
     tag: v2.0.0
+  99cffa11264fe545fd0baa6c13bca5a00ae608f2:
+    tag: v2.0.1
 gaurav-nelson/github-action-markdown-link-check:
   '*':
     expires_at: 2025-08-01

--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -89,6 +89,7 @@
 - erisu/apache-rat-action@3127a8c18f3bb10e91c60e835144085b31c5c463
 - erisu/apache-rat-action@46fb01ce7d8f76bdcd7ab10e7af46e1ea95ca01c
 - erisu/license-checker-action@1c222d0c2f5898a4c40b8bd6fd6888650bd6f68a
+- erisu/license-checker-action@99cffa11264fe545fd0baa6c13bca5a00ae608f2
 - gaurav-nelson/github-action-markdown-link-check@*
 - geekyeggo/delete-artifact@*
 - golang/govulncheck-action@*


### PR DESCRIPTION
# Request for updating an existing GitHub Action to the allow list

## Overview

<!-- Please describe the proposed action; what it does and why this is needed. 
     It will help if you can tell us which project is interested in this action 
     and why.
-->

This GitHub Action is being used to audit the licenses of the project's NPM dependency tree. The purpose of this action is to provide early detection during commits and PR to ensure that updated or newly added npm dependencies follows the ASF 3rd Party Category A License requirements.

**Name of action:** 

`erisu/license-checker-action`

**URL of action:**

https://github.com/erisu/license-checker-action

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**

`99cffa11264fe545fd0baa6c13bca5a00ae608f2` -> v2.0.1

## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

- None 

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

- None 

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [ ] The action is listed in the GitHub Actions Marketplace
- [ ] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
  - The CI is enabled to run CodeQL against the JS code.
  - Dependabot should also be enabled to monitor the npm dependencies.