### PR TITLE
gateway: remove actions/setup-go from explicit allowlist

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -130,9 +130,6 @@ actions-cool/maintain-one-comment:
   '*':
     expires_at: 2025-08-01
     keep: true
-actions/setup-go:
-  44694675825211faa026b3c33043df3e48a5fa00:
-    tag: v6.0.0
 addnab/docker-run-action:
   4f65fabd2431ebc8d299f8e5a018d79a769ae185:
     tag: v3


### PR DESCRIPTION
as actions/* is already implicitly allowed

# Request for adding a new GitHub Action to the allow list

## Overview

<!-- Please describe the proposed action; what it does and why this is needed. 
     It will help if you can tell us which project is interested in this action 
     and why.
-->

**Name of action:** 

**URL of action:**

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**


## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [ ] The action is listed in the GitHub Actions Marketplace
- [ ] The action is not already on the list of approved actions
- [ ] The action has a sufficient number of contributors or has contributors within the ASF community
- [ ] The action has a clearly defined license
- [ ] The action is actively developed or maintained
- [ ] The action has CI/unit tests configured
