### PR TITLE
Add tag scala-steward v2.78.0 to actions.yml

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -655,6 +655,8 @@ scala-steward-org/scala-steward-action:
     tag: v2.76.0
   53d486a68877f4a6d1e110e8058fe21e593db356:
     tag: v2.77.0
+  f60ccd18bc9d8083e6809d9dc3db4a69a71d856c:
+    tag: v2.78.0
 scalacenter/sbt-dependency-submission:
   64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3:
     tag: v3.1.0


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

<!-- Please describe the proposed action; what it does and why this is needed. 
     It will help if you can tell us which project is interested in this action 
     and why.
-->

**Name of action:** 

scala-steward-org/scala-steward-action v2.78.0 (latest release) is missing and is breaking Pekko builds because Dependabot suggested we upgrade

**URL of action:**

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**

https://github.com/scala-steward-org/scala-steward-action/releases/tag/v2.78.0

## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [ ] The action is listed in the GitHub Actions Marketplace
- [ ] The action is not already on the list of approved actions
- [ ] The action has a sufficient number of contributors or has contributors within the ASF community
- [ ] The action has a clearly defined license
- [ ] The action is actively developed or maintained
- [ ] The action has CI/unit tests configured
