### PR TITLE
Fix tag name for `scalacenter/sbt-dependency-submission`

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -657,7 +657,7 @@ scalacenter/sbt-dependency-submission:
     tag: v3.1.0
     expires_at: 2026-03-10
   bfbba169ec2dad010624339a27f402b311ed4083:
-    tag: v3.1.1
+    tag: v3.2.1
 scottbrenner/puppet-lint-action:
   '*':
     expires_at: 2025-08-01


### PR DESCRIPTION
The Git SHA refers to `v3.2.1`, there's no `v3.1.1`.

Commit link: https://github.com/scalacenter/sbt-dependency-submission/commit/bfbba169ec2dad010624339a27f402b311ed4083
Tags: https://github.com/scalacenter/sbt-dependency-submission/tags
