### PR TITLE
Partially revert/fix #425

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -656,8 +656,11 @@ scalacenter/sbt-dependency-submission:
   64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3:
     tag: v3.1.0
     expires_at: 2026-03-10
+  #f43202114d7522a4b233e052f82c2eea8d658134:
+  #  tag: v3.2.1
   bfbba169ec2dad010624339a27f402b311ed4083:
-    tag: v3.2.1
+    # This SHA was referenced as v3.1.1, but that tag no longer exists.
+    expires_at: 2025-08-01
 scottbrenner/puppet-lint-action:
   '*':
     expires_at: 2025-08-01


### PR DESCRIPTION
[`f43202114d7522a4b233e052f82c2eea8d658134`](https://github.com/scalacenter/sbt-dependency-submission/commit/f43202114d7522a4b233e052f82c2eea8d658134) (v3.2.1) is a much newer commit, than [`bfbba169ec2dad010624339a27f402b311ed4083`](https://github.com/scalacenter/sbt-dependency-submission/commit/bfbba169ec2dad010624339a27f402b311ed4083) (no longer existing v3.1.1 tag).

Removing v3.2.1 as #425 could effectively be a version bump, to let it go though the usual action-version-bump review process. Adding `bfbba169ec2dad010624339a27f402b311ed4083` without a tag.
