### PR TITLE
Add biomejs/setup-biome to allow list

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -160,6 +160,9 @@ azure/setup-helm:
 betahuhn/repo-file-sync-action:
   8b92be3375cf1d1b0cd579af488a9255572e4619:
     tag: v1.21.1
+biomejs/setup-biome:
+  454fa0d884737805f48d7dc236c1761a0ac3cc13:
+    tag: v2.6.0
 browser-actions/setup-firefox:
   5914774dda97099441f02628f8d46411fcfbd208:
     tag: v1.7.0


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

This is [BiomeJS](https://github.com/biomejs/biome), a JS formatter and linter written in Rust. ASF Tooling use it for [ATR](https://github.com/apache/tooling-trusted-releases) linting.

**Name of action:** `setup-biome`

**URL of action:** `https://github.com/biomejs/setup-biome`

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** `454fa0d884737805f48d7dc236c1761a0ac3cc13`


## Permissions

`contents: read`

No known security implications on public repositories. For private repositories, beware of the potential exfiltration vector.

## Related Actions

There are several existing lint actions. No JS lint actions that I could find.

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace ([yes](https://github.com/marketplace/actions/setup-biome))
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community (12 contributors)
- [x] The action has a clearly defined license (MIT)
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
