### PR TITLE
Allow pypa/gh-action-pip-audit

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -37,9 +37,9 @@ golangci/*:
     expires_at: 2025-08-01
     keep: true
 pypa/gh-action-pip-audit:
-  release/v1*:
-    expires_at: 2025-08-01
-    keep: true
+  1220774d901786e6f652ae159f7b6bc8fea6d266:
+    tag: v1.1.0
+    expires_at: 2026-03-31
 pypa/gh-action-pypi-publish:
   release/v1*:
     expires_at: 2025-08-01

--- a/actions.yml
+++ b/actions.yml
@@ -36,6 +36,10 @@ golangci/*:
   '*':
     expires_at: 2025-08-01
     keep: true
+pypa/gh-action-pip-audit:
+  release/v1*:
+    expires_at: 2025-08-01
+    keep: true
 pypa/gh-action-pypi-publish:
   release/v1*:
     expires_at: 2025-08-01


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

<!-- Please describe the proposed action; what it does and why this is needed. 
     It will help if you can tell us which project is interested in this action 
     and why.
-->

This is currently used in https://github.com/apache/libcloud/tree/trunk/.github/actions and I think it's a pypa official action that we can trust.

**Name of action:** pypa/gh-action-pip-audit

**URL of action:** https://github.com/pypa/gh-action-pip-audit

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**

Following the other pypa actions listed below, I choose:

```yaml
  release/v1*:
    expires_at: 2025-08-01
    keep: true
```

## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

I think the read permission is enough.

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

This should be like `pypa/gh-action-pypi-publish` but only for verifying, not publishing.

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
