### PR TITLE
Allow `slsa-framework/source-actions`

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -675,6 +675,10 @@ sigstore/cosign-installer:
   faadad0cce49287aee09b3a48701e75088a2c6ad:
     expires_at: 2026-12-31
     tag: v4.0.0
+slsa-framework/source-actions:
+  dea965cdca5e0cb422bf7b2653c9d15f678ad01c:
+    expires_at: 2026-12-31
+    tag: v0.1.0
 snok/install-poetry:
   76e04a911780d5b312d89783f7b1cd627778900a:
     tag: v1


### PR DESCRIPTION
## Overview

The `slsa-framework/source-actions` repository provides experimental GitHub Actions for generating provenance attestations for [SLSA Source L2](https://slsa.dev/spec/v1.2/source-requirements#source-l2).

I have successfully tested these actions in non-ASF repositories. To my knowledge, their use within ASF repositories currently depends on the implementation of rulesets in the `.asf.yaml` file (see apache/infrastructure-asfyaml#49). However, I don’t see any downside to adding this repository to the allow list ahead of that work.

**Name of action:** `slsa-framework/source-actions`

**URL of action:** https://github.com/slsa-framework/source-actions

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** `dea965cdca5e0cb422bf7b2653c9d15f678ad01c` (v0.1.0)


## Permissions

The action is implemented using the Go [source-tool](https://github.com/slsa-framework/source-tool) utility. The list of permissions is not explicitly documented, but looking at the source code it requires:

- Read access to the [Repository Rules REST API](https://docs.github.com/en/rest/repos/rules) (read access to “Metadata”),
- **Write** access to the [Contents REST API](https://docs.github.com/en/rest/repos/contents) to store Git notes (`refs/notes/commits`),
- Access to the OIDC token.

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [ ] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [ ] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [ ] The action has CI/unit tests configured
