### PR TITLE
Add rust-lang/crates-io-auth-action v1

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -60,6 +60,9 @@ readthedocs/actions/preview:
   '*':
     expires_at: 2025-08-01
     keep: true
+rust-lang/crates-io-auth-action:
+  b7e9a28eded4986ec6b1fa40eeee8f8f165559ec:
+    tag: v1.0.3
 rustsec/*:
   '*':
     expires_at: 2025-08-01

--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -15,6 +15,7 @@
 - quarto-dev/quarto-actions/*@*
 - r-lib/actions/*@*
 - readthedocs/actions/preview@*
+- rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec
 - rustsec/*@*
 - vhelm/chart-releaser-action@*
 - AdoptOpenJDK/install-jdk@*


### PR DESCRIPTION
Add rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec (tag v1.0.3) to the ASF GitHub Actions allowlist.

Why: Apache Fory uses the crates.io trusted publishing flow for Rust releases and needs this action for OIDC token exchange.

Alternatives considered: Using a long-lived CARGO_REGISTRY_TOKEN secret, but the project has enabled Trusted Publishing.

Security considerations: Action is maintained by rust-lang and is pinned to an exact commit SHA per policy.