### PR TITLE
Add JustinBeckwith/linkinator-action v2.4

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -110,6 +110,9 @@ JustinBeckwith/linkinator-action:
     expires_at: 2026-02-23
   af984b9f30f63e796ae2ea5be5e07cb587f1bbd9:
     tag: v2.3
+    expires_at: 2026-05-09
+  f62ba0c110a76effb2ee6022cc6ce4ab161085e3:
+    tag: v2.4
 Kesin11/actions-timeline:
   54d513e0b5ff1158f1cf8321108d666a5a6c1fca:
     tag: v2.2.5


### PR DESCRIPTION
## Summary

Add `JustinBeckwith/linkinator-action` v2.4 (`f62ba0c110a76effb2ee6022cc6ce4ab161085e3`) to the allow list.

## Rationale

This version is required by Apache Superset: https://github.com/apache/superset/pull/37562

### Changes in v2.4

The [v2.4.0 release](https://github.com/JustinBeckwith/linkinator-action/releases/tag/v2.4.0) includes:
- Node.js 24 support
- Migration to Vitest for testing
- Updated dependencies including `@actions/core` to v2

This is a semver minor version bump focused on modernization and compatibility with current tooling standards.

## Changes to actions.yml

- Added v2.4 (`f62ba0c110a76effb2ee6022cc6ce4ab161085e3`)
- Set 3-month expiry (2026-05-09) on v2.3 to allow projects time to update