### PR TITLE
Fix setup-bazel reference

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -39,7 +39,7 @@ jobs:
         if: false
       - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
         if: false
-      - uses: bazel-contrib/setup-bazel@8d2cb86a3680a820c3e219597279ce3f80d17a47  # v0.15.0
+      - uses: bazel-contrib/setup-bazel@4fd964a13a440a8aeb0be47350db2fc640f19ca8  # 0.15.0
         if: false
       - uses: betahuhn/repo-file-sync-action@8b92be3375cf1d1b0cd579af488a9255572e4619  # v1.21.1
         if: false

--- a/actions.yml
+++ b/actions.yml
@@ -171,8 +171,8 @@ bazel-contrib/setup-bazel:
   '*':
     expires_at: 2026-12-21
     keep: true
-  8d2cb86a3680a820c3e219597279ce3f80d17a47:
-    tag: v0.15.0
+  4fd964a13a440a8aeb0be47350db2fc640f19ca8:
+    tag: 0.15.0
 betahuhn/repo-file-sync-action:
   8b92be3375cf1d1b0cd579af488a9255572e4619:
     tag: v1.21.1


### PR DESCRIPTION
The commit `8d2cb86a3680a820c3e219597279ce3f80d17a47` [doesn't exist](https://github.com/bazel-contrib/setup-bazel/commit/8d2cb86a3680a820c3e219597279ce3f80d17a47) (it is the tag's ID, not the commit ID) in the action's repository, the tag names [do not start with a `v`](https://github.com/bazel-contrib/setup-bazel/tags).

In `actions.yml`: Update the tag reference.
In `dummy.yml`: Update to the correct Git SHA for `0.15.0`.
