### PR TITLE
Fix leafo/gh-actions-luarocks reference

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -493,6 +493,9 @@ leafo/gh-actions-lua:
     keep: true
 leafo/gh-actions-luarocks:
   97053c556d6ce2c8e26eb7ac93743437c7af7248:
+    expires_at: 2026-08-01
+    tag: v5
+  4c082a5fad45388feaeb0798dbd82dbd7dc65bca:
     tag: v5
 manusa/actions-setup-minikube:
   b589f2d61bf96695c546929c72b38563e856059d:


### PR DESCRIPTION
Update the moving tag `v5` with the current SHA.
