### PR TITLE
Workflow to check any ASF project's action usage

### DIFF
--- a/.github/workflows/check-project-actions.yml
+++ b/.github/workflows/check-project-actions.yml
@@ -1,0 +1,62 @@
+# Workflow to be called from ASF project repository workflows to check
+# whether the referenced GitHub actions are approved.
+#
+# The README.md of ASF Infrastructure Actions repository https://github.com/apache/infrastructure-actions
+# contains usage instructions.
+#
+# See: ASF Infrastructure GitHub Actions Policy: https://infra.apache.org/github-actions-policy.html
+
+
+name: check-project-actions.yml
+on:
+  workflow_call:
+    inputs:
+      repository:
+        required: false
+        description: The `repository` parameter for `actions/checkout`
+        type: string
+      ref:
+        required: false
+        description: The `ref` parameter for `actions/checkout`
+        type: string
+      fetch-depth:
+        required: false
+        description: The `fetch-depth` parameter for `actions/checkout`
+        type: number
+        default: 1
+      submodules:
+        required: false
+        description: The `submodules` parameter for `actions/checkout`
+        type: boolean
+        default: false
+
+jobs:
+  check-project-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout apache/infrastructure-actions"
+        uses: actions/checkout@v2
+        with:
+          repository: 'apache/infrastructure-actions'
+          ref: 'main'
+          path: infrastructure-actions
+      - name: "Checkout repository to be checked"
+        uses: actions/checkout@v2
+        with:
+          repository: '${{ inputs.repository }}'
+          ref: ${{ inputs.ref }}
+          fetch-depth: ${{ inputs.fetch-depth }}
+          submodules: ${{ inputs.submodules }}
+          path: repository
+
+      - run: pip install ruyaml
+
+      - name: Check project actions in repository
+        working-directory: infrastructure-actions
+        shell: python
+        run: |
+          import sys
+          sys.path.append("./gateway/")
+
+          import check_repository_actions as c
+          c.check_project_actions('../repository', '../infrastructure-actions/approved_patterns.yml')

--- a/.github/workflows/check-project-actions.yml
+++ b/.github/workflows/check-project-actions.yml
@@ -65,7 +65,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: "Checkout apache/infrastructure-actions"
         uses: actions/checkout@v2
@@ -92,10 +91,3 @@ jobs:
 
           import check_repository_actions as c
           c.check_project_actions('./repository-to-be-checked', './approved_patterns.yml')
-
-      - name: Comment on PR
-        if: failure() && github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run:
-          gh pr --repo ${{ github.repository }} comment ${{ github.event.pull_request.number }} --body-file step-summary-output.txt

--- a/.github/workflows/check-project-actions.yml
+++ b/.github/workflows/check-project-actions.yml
@@ -65,6 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - name: "Checkout apache/infrastructure-actions"
         uses: actions/checkout@v2
@@ -91,3 +92,10 @@ jobs:
 
           import check_repository_actions as c
           c.check_project_actions('./repository-to-be-checked', './approved_patterns.yml')
+
+      - name: Comment on PR
+        if: failure() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run:
+          gh pr --repo ${{ github.repository }} comment ${{ github.event.pull_request.number }} --body-file step-summary-output.txt

--- a/.github/workflows/check-project-actions.yml
+++ b/.github/workflows/check-project-actions.yml
@@ -1,5 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 # Workflow to be called from ASF project repository workflows to check
-# whether the referenced GitHub actions are approved.
+# whether the GitHub actions referenced in GitHub workflows (`.github/workflows`) and
+# composite actions (`.github/actions`) are approved.
 #
 # The README.md of ASF Infrastructure Actions repository https://github.com/apache/infrastructure-actions
 # contains usage instructions.
@@ -7,39 +27,51 @@
 # See: ASF Infrastructure GitHub Actions Policy: https://infra.apache.org/github-actions-policy.html
 
 
-name: check-project-actions.yml
+name: Check Actions Usage
 on:
   workflow_call:
     inputs:
       repository:
         required: false
-        description: The `repository` parameter for `actions/checkout`
+        description: |
+          Optional, the `repository` parameter for `actions/checkout`.
+          If not specified, the default is to use the repository of the calling workflow.
+          See https://github.com/actions/checkout?tab=readme-ov-file#usage for details.
         type: string
       ref:
         required: false
-        description: The `ref` parameter for `actions/checkout`
+        description: |
+          Optional, the `ref` parameter for `actions/checkout`
+          If not specified, the default is to use the repository of the calling workflow.
+          See https://github.com/actions/checkout?tab=readme-ov-file#usage for details.
         type: string
       fetch-depth:
         required: false
-        description: The `fetch-depth` parameter for `actions/checkout`
+        description: |
+          Optional, the `fetch-depth` parameter for `actions/checkout`.
+          See https://github.com/actions/checkout?tab=readme-ov-file#usage for details.
         type: number
         default: 1
       submodules:
         required: false
-        description: The `submodules` parameter for `actions/checkout`
+        description: |
+          Optional, the `submodules` parameter for `actions/checkout`.
+          See https://github.com/actions/checkout?tab=readme-ov-file#usage for details.
         type: boolean
         default: false
 
 jobs:
   check-project-actions:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: "Checkout apache/infrastructure-actions"
         uses: actions/checkout@v2
         with:
           repository: 'apache/infrastructure-actions'
           ref: 'main'
-          path: infrastructure-actions
+
       - name: "Checkout repository to be checked"
         uses: actions/checkout@v2
         with:
@@ -47,16 +79,15 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: ${{ inputs.fetch-depth }}
           submodules: ${{ inputs.submodules }}
-          path: repository
+          path: repository-to-be-checked
 
       - run: pip install ruyaml
 
-      - name: Check project actions in repository
-        working-directory: infrastructure-actions
+      - name: Check allowed actions usage
         shell: python
         run: |
           import sys
           sys.path.append("./gateway/")
 
           import check_repository_actions as c
-          c.check_project_actions('../repository', '../infrastructure-actions/approved_patterns.yml')
+          c.check_project_actions('./repository-to-be-checked', './approved_patterns.yml')

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This repository hosts GitHub Actions developed by the ASF community and approved for any ASF top level project to use. It also manages the organization wide allow list of GitHub Actions via 'Configuration as Code'.
 
+- [Checking the Action Usage in an ASF Project](#checking-the-action-usage-in-an-asf-project)
 - [Submitting an Action](#submitting-an-action)
 - [Available GitHub Actions](#available-github-actions)
 - [Organization-wide GitHub Actions Allow List](#management-of-organization-wide-github-actions-allow-list)
@@ -10,6 +11,47 @@ This repository hosts GitHub Actions developed by the ASF community and approved
   - [Adding a New Version](#adding-a-new-version-to-the-allow-list)
   - [Manual Version Addition](#manual-addition-of-specific-versions)
   - [Removing a Version](#removing-a-version-manually)
+
+## Checking the Action Usage in an ASF Project
+
+You can let your CI workflows check if the Actions used in your project are approved for use in the ASF.
+
+Either create a new workflow in your project repository, e.g. `.github/workflows/check-project-actions.yml`,
+like the following example, or call the workflow from a job from your existing CI workflow in your repository.
+
+```yaml
+ name: Check action references
+ on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+  pull_request:
+    paths:
+      - ".github/**"
+ jobs:
+   # This is the job that verifies your project's usage of approved GitHub actions
+   check:
+     name: Check actions usage
+     uses: apache/infrastructure-actions/.github/workflows/check-project-actions.yml@main
+```
+
+When calling the `check-project-actions` from a `push` or `pull_request` event, the workflow should work
+automatically against the "right" reference.
+
+You can also pass the `repository`, `ref`, `fetch-depth` and `submodules` parameters, as documented for
+the the [GitHub `actions/checkout` action](https://github.com/actions/checkout?tab=readme-ov-file#usage)
+to the workflow call to check against a specific commit or tag. For example:
+```yaml
+  check:
+    name: Check actions usage
+    uses: apache/infrastructure-actions/.github/workflows/check-project-actions.yml@main
+    with:
+      repository: apacha/my-project
+      ref: my-branch
+```
 
 ## Submitting an Action
 

--- a/README.md
+++ b/README.md
@@ -16,42 +16,22 @@ This repository hosts GitHub Actions developed by the ASF community and approved
 
 You can let your CI workflows check if the Actions used in your project are approved for use in the ASF.
 
-Either create a new workflow in your project repository, e.g. `.github/workflows/check-project-actions.yml`,
-like the following example, or call the workflow from a job from your existing CI workflow in your repository.
-
+An example workflow that can be used as a template for your project's CI can be found
+[here `check-actions-usage/sample-ci-workflow.yml`](check-actions-usage/sample-ci-workflow.yml).
+It is usually enough to add the following job to an existing `.github/workflows/ci.yml` file:
 ```yaml
- name: Check action references
- on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - ".github/**"
-  pull_request:
-    paths:
-      - ".github/**"
- jobs:
-   # This is the job that verifies your project's usage of approved GitHub actions
-   check:
-     name: Check actions usage
-     uses: apache/infrastructure-actions/.github/workflows/check-project-actions.yml@main
+jobs:
+  check:
+    name: Check actions usage
+    uses: apache/infrastructure-actions/.github/workflows/check-project-actions.yml@main
 ```
 
-When calling the `check-project-actions` from a `push` or `pull_request` event, the workflow should work
+When calling the `check-project-actions` workflow from a `push` or `pull_request` event, it should work
 automatically against the "right" reference.
 
 You can also pass the `repository`, `ref`, `fetch-depth` and `submodules` parameters, as documented for
 the the [GitHub `actions/checkout` action](https://github.com/actions/checkout?tab=readme-ov-file#usage)
-to the workflow call to check against a specific commit or tag. For example:
-```yaml
-  check:
-    name: Check actions usage
-    uses: apache/infrastructure-actions/.github/workflows/check-project-actions.yml@main
-    with:
-      repository: apacha/my-project
-      ref: my-branch
-```
+to the workflow call to check against a specific commit or tag.
 
 ## Submitting an Action
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ jobs:
     permissions:
       # Only read access to the repository's content
       contents: read
-      # Allow the workflow to add a comment to a PR in case the actions-verification failed
-      pull-requests: write
 ```
 
 When calling the `check-project-actions` workflow from a `push` or `pull_request` event, it should work

--- a/README.md
+++ b/README.md
@@ -32,11 +32,7 @@ jobs:
 ```
 
 When calling the `check-project-actions` workflow from a `push` or `pull_request` event, it should work
-automatically against the "right" reference.
-
-You can also pass the `repository`, `ref`, `fetch-depth` and `submodules` parameters, as documented for
-the the [GitHub `actions/checkout` action](https://github.com/actions/checkout?tab=readme-ov-file#usage)
-to the workflow call to check against a specific commit or tag.
+automatically against the "right" reference. See the sample workflow linked above for more details.
 
 ## Submitting an Action
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ jobs:
   check:
     name: Check actions usage
     uses: apache/infrastructure-actions/.github/workflows/check-project-actions.yml@main
+    permissions:
+      # Only read access to the repository's content
+      contents: read
+      # Allow the workflow to add a comment to a PR in case the actions-verification failed
+      pull-requests: write
 ```
 
 When calling the `check-project-actions` workflow from a `push` or `pull_request` event, it should work

--- a/check-actions-usage/sample-ci-workflow.yml
+++ b/check-actions-usage/sample-ci-workflow.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: Example CI validating allowed GH Actions usage
+name: Example CI workflow validating allowed GH Actions usage in an ASF project
 on:
   # If you want to run this workflow manually, keep `workflow_dispatch`. Otherwise, remove this trigger.
   workflow_dispatch:
@@ -38,11 +38,13 @@ jobs:
     name: Check actions usage
     uses: apache/infrastructure-actions/check-project-actions/check-project-actions.yml@main
     permissions:
-      # Only read access to the repository's content
+      # Only read access to the repository's content.
       contents: read
-      # Allow the workflow to add a comment to a PR in case the actions-verification failed
+      # Allow the workflow to add a comment to a PR in case the actions-verification failed.
+      # This is required to run the workflow.
       pull-requests: write
-    # Optional: specify a different repository and/or ref to check. These options are passed to
+      # All other permissions are "none".
+    # Optionally, you can specify a different repository and/or ref to check. These options are passed to
     # GitHub actions/checkout, see https://github.com/actions/checkout?tab=readme-ov-file#usage for details.
     #with:
       #repository: apache/my-project

--- a/check-actions-usage/sample-ci-workflow.yml
+++ b/check-actions-usage/sample-ci-workflow.yml
@@ -32,14 +32,16 @@ on:
     paths:
       - ".github/**"
 
-permissions:
-  contents: read
-
 jobs:
   # This is the job that verifies your project's usage of approved GitHub actions
   check:
     name: Check actions usage
     uses: apache/infrastructure-actions/check-project-actions/check-project-actions.yml@main
+    permissions:
+      # Only read access to the repository's content
+      contents: read
+      # Allow the workflow to add a comment to a PR in case the actions-verification failed
+      pull-requests: write
     # Optional: specify a different repository and/or ref to check. These options are passed to
     # GitHub actions/checkout, see https://github.com/actions/checkout?tab=readme-ov-file#usage for details.
     #with:

--- a/check-actions-usage/sample-ci-workflow.yml
+++ b/check-actions-usage/sample-ci-workflow.yml
@@ -32,6 +32,11 @@ on:
     paths:
       - ".github/**"
 
+permissions:
+  # Only read access is required.
+  contents: read
+  # All other permissions are "none".
+
 jobs:
   # This is the job that verifies your project's usage of approved GitHub actions
   check:
@@ -40,9 +45,6 @@ jobs:
     permissions:
       # Only read access to the repository's content.
       contents: read
-      # Allow the workflow to add a comment to a PR in case the actions-verification failed.
-      # This is required to run the workflow.
-      pull-requests: write
       # All other permissions are "none".
     # Optionally, you can specify a different repository and/or ref to check. These options are passed to
     # GitHub actions/checkout, see https://github.com/actions/checkout?tab=readme-ov-file#usage for details.

--- a/check-actions-usage/sample-ci-workflow.yml
+++ b/check-actions-usage/sample-ci-workflow.yml
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Example CI validating allowed GH Actions usage
+on:
+  # If you want to run this workflow manually, keep `workflow_dispatch`. Otherwise, remove this trigger.
+  workflow_dispatch:
+  # Trigger the workflow on push or pull requests when the contents of your `.github` directory change.
+  # Note: the cheeck-project-actions.yml workflow inspects the `.github/workflows` and `.github/actions` directories.
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+  pull_request:
+    paths:
+      - ".github/**"
+
+permissions:
+  contents: read
+
+jobs:
+  # This is the job that verifies your project's usage of approved GitHub actions
+  check:
+    name: Check actions usage
+    uses: apache/infrastructure-actions/check-project-actions/check-project-actions.yml@main
+    # Optional: specify a different repository and/or ref to check. These options are passed to
+    # GitHub actions/checkout, see https://github.com/actions/checkout?tab=readme-ov-file#usage for details.
+    #with:
+      #repository: apache/my-project
+      #ref: my-branch
+      #fetch-depth:
+      #submodules:

--- a/gateway/check_repository_actions.py
+++ b/gateway/check_repository_actions.py
@@ -1,0 +1,154 @@
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "ruyaml",
+# ]
+# ///
+
+import fnmatch
+import os
+import re
+import sys
+
+from pathlib import Path
+
+from gateway import load_yaml, on_gha
+
+re_action = r"^([A-Za-z0-9-_.]+/[A-Za-z0-9-_.]+)(/.+)?(@(.+))?$"
+re_local_file = r"^[.]/.+"
+
+
+def _iter_uses_nodes(node: dict, yaml_path: str = ""):
+    """
+    Walk the entire YAML structure (dicts/lists/scalars) and yield every value
+    whose key is exactly 'uses', along with a best-effort YAML-path string.
+    """
+    if isinstance(node, dict):
+        for k, v in node.items():
+            next_path = f"{"" if len(yaml_path) == 0 else f"{yaml_path}."}{k}"
+            if k == "uses":
+                yield next_path, v
+            yield from _iter_uses_nodes(v, next_path)
+    elif isinstance(node, list):
+        for i, item in enumerate(node):
+            next_path = f"{yaml_path}[{i}]"
+            yield from _iter_uses_nodes(item, next_path)
+    else:
+        return
+
+
+def check_project_actions(repository: str | os.PathLike, approved_patterns_file: str | os.PathLike) -> None:
+    """
+    Check that all GitHub actions used in workflows and actions are approved.
+
+    See GitHub documentation https://docs.github.com/en/enterprise-cloud@latest/admin/enforcing-policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-github-actions-in-your-enterprise
+
+    @param repository: Path to the repository root directory to check. YAML files under '.github/workflows' and '.github/actions' will be checked.
+    @param approved_patterns_file: Path to the YAML file containing approved action patterns.
+    """
+    repo_root = Path(repository)
+    if not repo_root.exists():
+        raise FileNotFoundError(f"Repository path does not exist: {repo_root}")
+
+    # Only consider workflows under '.github/workflows' (the only directory mentioned).
+    github_dir = repo_root / ".github"
+    if not github_dir.is_dir():
+        print(f"No directory found at: {github_dir}")
+        return
+
+    yaml_files: list[Path] = sorted(
+        [
+            *github_dir.rglob("workflows/*.yml"),
+            *github_dir.rglob("workflows/*.yaml"),
+            *github_dir.rglob("actions/**/*.yml"),
+            *github_dir.rglob("actions/**/*.yaml")
+        ]
+    )
+
+    approved_patterns_yaml = load_yaml(Path(approved_patterns_file))
+    if not isinstance(approved_patterns_yaml, list):
+        raise ValueError(
+            f"Approved patterns file {approved_patterns_file} must contain a list of strings, got {type(approved_patterns_yaml)}")
+    approved_patterns: list[str] = []
+    for entry in approved_patterns_yaml:
+        if not isinstance(entry, str):
+            raise ValueError(
+                f"Approved patterns file {approved_patterns_file} must contain a list of strings, got {type(entry)}")
+        for e in entry.split(","):
+            approved_patterns.append(e.strip())
+    print(f"There are {len(approved_patterns)} entries in the approved patterns file {approved_patterns_file}:")
+    for p in sorted(approved_patterns):
+        print(f"- {p}")
+
+    print(f"Found {len(yaml_files)} workflow or action YAML file(s) under {github_dir}:")
+    failures: list[str] = []
+    for p in yaml_files:
+        relative_path = p.relative_to(repo_root)
+        print(f"Checking file {relative_path}")
+        yaml = load_yaml(p)
+        uses_entries = list(_iter_uses_nodes(yaml))
+        for yaml_path, uses_value in uses_entries:
+            matcher = re.match(re_action, uses_value)
+            if matcher is not None:
+                print(f"  {yaml_path}: {uses_value}")
+                if uses_value.startswith("./"):
+                    print(f"    ✅ Local file reference, allowing")
+                elif uses_value.startswith("docker://apache/"):
+                    print(f"    ✅ Apache project image, allowing")
+                elif uses_value.startswith("apache/"):
+                    print(f"    ✅ Apache action reference, allowing")
+                elif uses_value.startswith("actions/"):
+                    print(f"    ✅ GitHub action reference, allowing")
+                else:
+                    approved = False
+                    blocked = False
+                    for pattern in approved_patterns:
+                        blocked = pattern.startswith("!")
+                        if blocked:
+                            pattern = pattern[1:]
+                        matches = fnmatch.fnmatch(uses_value, pattern)
+                        if matches:
+                            if blocked:
+                                approved = False
+                                break
+                            approved = True
+                    if approved:
+                        print(f"    ✅ Approved pattern")
+                    elif blocked:
+                        print(f"    ❌ Action is explicitly blocked")
+                        failures.append(f"❌ {relative_path} {yaml_path}: '{uses_value}' is explicitly blocked")
+                    else:
+                        print(f"    ❌ Not approved")
+                        failures.append(f"❌ {relative_path} {yaml_path}: '{uses_value}' is not approved")
+
+    if on_gha():
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+            f.write(f"# GitHub Actions verification result\n")
+            f.write("\n")
+            f.write("For more information visit the [ASF Infrastructure GitHub Actions Policy](https://infra.apache.org/github-actions-policy.html) page\n")
+            f.write("and the [ASF Infrastructure Actions](https://github.com/apache/infrastructure-actions) repository.\n")
+            f.write("\n")
+            if len(failures) > 0:
+                f.write(f"## Failures ({len(failures)})\n")
+                for msg in failures:
+                    f.write(f"{msg}\n\n")
+            else:
+                f.write(f"✅ Success, all action usages match the currently approved patterns.\n")
+
+    if len(failures) > 0:
+        raise Exception(f"One or more action references are not approved or explicitly blocked:\n{"\n".join(failures)}")
+
+
+def run_main(args: list[str]):
+    approved_patterns_file = Path(os.getcwd()) / "approved_patterns.yml"
+    if len(args) > 0:
+        check_path = args[0]
+        if len(args) > 1:
+            approved_patterns_file = args[1]
+    else:
+        check_path = Path(os.getcwd())
+    check_project_actions(check_path, approved_patterns_file)
+
+
+if __name__ == "__main__":
+    run_main(sys.argv[1:])

--- a/gateway/check_repository_actions.py
+++ b/gateway/check_repository_actions.py
@@ -4,6 +4,25 @@
 #     "ruyaml",
 # ]
 # ///
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
 
 import fnmatch
 import os

--- a/gateway/check_repository_actions.py
+++ b/gateway/check_repository_actions.py
@@ -159,33 +159,23 @@ def check_project_actions(repository: str | os.PathLike, approved_patterns_file:
                         failures.append(f"❌ {relative_path} {yaml_path}: '{uses_value}' is not approved")
 
     if on_gha():
-        summary_lines: list[str] = [
-            "# GitHub Actions verification result",
-            "",
-            "For more information visit the [ASF Infrastructure GitHub Actions Policy](https://infra.apache.org/github-actions-policy.html) page",
-            "and the [ASF Infrastructure Actions](https://github.com/apache/infrastructure-actions) repository.",
-        ]
-
-        if len(failures) > 0:
-            summary_lines.extend(["", f"## Failures ({len(failures)})"])
-            for msg in failures:
-                summary_lines.extend([msg, ""])
-
-        if len(warnings) > 0:
-            summary_lines.extend(["", f"## Warnings ({len(warnings)})"])
-            for msg in warnings:
-                summary_lines.extend([msg, ""])
-
-        if len(failures) == 0:
-            summary_lines.append("✅ Success, all action usages match the currently approved patterns.")
-
-        summary_text = "\n".join(summary_lines).rstrip() + "\n"
-
         with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
-            f.write(summary_text)
-        # This file is used in the workflow to post a comment on a pull request.
-        with open("step-summary-output.txt", "a") as f:
-            f.write(summary_text)
+            f.write(f"# GitHub Actions verification result\n")
+            f.write("\n")
+            f.write("For more information visit the [ASF Infrastructure GitHub Actions Policy](https://infra.apache.org/github-actions-policy.html) page\n")
+            f.write("and the [ASF Infrastructure Actions](https://github.com/apache/infrastructure-actions) repository.\n")
+            if len(failures) > 0:
+                f.write("\n")
+                f.write(f"## Failures ({len(failures)})\n")
+                for msg in failures:
+                    f.write(f"{msg}\n\n")
+            if len(warnings) > 0:
+                f.write("\n")
+                f.write(f"## Warnings ({len(warnings)})\n")
+                for msg in warnings:
+                    f.write(f"{msg}\n\n")
+            if len(failures) == 0:
+                f.write(f"✅ Success, all action usages match the currently approved patterns.\n")
 
     if len(failures) > 0:
         raise Exception(f"One or more action references are not approved or explicitly blocked:\n{"\n".join(failures)}")

--- a/gateway/check_repository_actions.py
+++ b/gateway/check_repository_actions.py
@@ -159,23 +159,33 @@ def check_project_actions(repository: str | os.PathLike, approved_patterns_file:
                         failures.append(f"❌ {relative_path} {yaml_path}: '{uses_value}' is not approved")
 
     if on_gha():
+        summary_lines: list[str] = [
+            "# GitHub Actions verification result",
+            "",
+            "For more information visit the [ASF Infrastructure GitHub Actions Policy](https://infra.apache.org/github-actions-policy.html) page",
+            "and the [ASF Infrastructure Actions](https://github.com/apache/infrastructure-actions) repository.",
+        ]
+
+        if len(failures) > 0:
+            summary_lines.extend(["", f"## Failures ({len(failures)})"])
+            for msg in failures:
+                summary_lines.extend([msg, ""])
+
+        if len(warnings) > 0:
+            summary_lines.extend(["", f"## Warnings ({len(warnings)})"])
+            for msg in warnings:
+                summary_lines.extend([msg, ""])
+
+        if len(failures) == 0:
+            summary_lines.append("✅ Success, all action usages match the currently approved patterns.")
+
+        summary_text = "\n".join(summary_lines).rstrip() + "\n"
+
         with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
-            f.write(f"# GitHub Actions verification result\n")
-            f.write("\n")
-            f.write("For more information visit the [ASF Infrastructure GitHub Actions Policy](https://infra.apache.org/github-actions-policy.html) page\n")
-            f.write("and the [ASF Infrastructure Actions](https://github.com/apache/infrastructure-actions) repository.\n")
-            if len(failures) > 0:
-                f.write("\n")
-                f.write(f"## Failures ({len(failures)})\n")
-                for msg in failures:
-                    f.write(f"{msg}\n\n")
-            if len(warnings) > 0:
-                f.write("\n")
-                f.write(f"## Warnings ({len(warnings)})\n")
-                for msg in warnings:
-                    f.write(f"{msg}\n\n")
-            if len(failures) == 0:
-                f.write(f"✅ Success, all action usages match the currently approved patterns.\n")
+            f.write(summary_text)
+        # This file is used in the workflow to post a comment on a pull request.
+        with open("step-summary-output.txt", "a") as f:
+            f.write(summary_text)
 
     if len(failures) > 0:
         raise Exception(f"One or more action references are not approved or explicitly blocked:\n{"\n".join(failures)}")


### PR DESCRIPTION
This change adds a GitHub workflow to be called from ASF projects' CI to verify that the referenced actions are approved by ASF Infrastructure.

Fixes #482