### PR TITLE
chore: add editorconfig-checker/action-editorconfig-checker

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -73,6 +73,8 @@ jobs:
         if: false
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
         if: false
+      - use: editorconfig-checker/action-editorconfig-checker@4b6cd6190d435e7e084fb35e36a096e98506f7b9  # v2.1.0
+        if: false
       - uses: erisu/apache-rat-action@46fb01ce7d8f76bdcd7ab10e7af46e1ea95ca01c  # v2.0.0
         if: false
       - uses: erisu/license-checker-action@99cffa11264fe545fd0baa6c13bca5a00ae608f2  # v2.0.1

--- a/actions.yml
+++ b/actions.yml
@@ -333,6 +333,9 @@ easimon/maximize-build-space:
   '*':
     expires_at: 2025-08-01
     keep: true
+editorconfig-checker/action-editorconfig-checker:
+  4b6cd6190d435e7e084fb35e36a096e98506f7b9:
+    tag: v2.1.0
 eps1lon/actions-label-merge-conflict:
   '*':
     expires_at: 2025-08-01


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

<!-- Please describe the proposed action; what it does and why this is needed. 
     It will help if you can tell us which project is interested in this action 
     and why.
-->

This GitHub Action, which wraps the `editorconfig-checker` tool, to check if the files follows the `.editorconfig` rules.

**Name of action:** 

`editorconfig-checker/action-editorconfig-checker`

**URL of action:**

https://github.com/editorconfig-checker/action-editorconfig-checker

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**

[`4b6cd6190d435e7e084fb35e36a096e98506f7b9`](https://github.com/editorconfig-checker/action-editorconfig-checker/commit/4b6cd6190d435e7e084fb35e36a096e98506f7b9) -> [v2.1.0](https://github.com/editorconfig-checker/action-editorconfig-checker/releases/tag/v2.1.0)

## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

- None that I can see. 

In terms of workflow that would use this action, only the following permission block is defined:

```yaml
    permissions:
      contents: read
```

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

None that I could find

## Checklist

You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
  - https://github.com/marketplace/actions/editorconfig-checker-action
- [x] The action is not already on the list of approved actions
- [ ] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
  - MIT License
- [x] The action is actively developed or maintained
  - Last version released: 4 months ago
  - Last commit to main branch: within 1 week
- [x] The action has CI/unit tests configured
  - Has some sort of GHA workflow
    - Compare the expected and actual dist/ directories
    - Dependabot automerge
  - Does not appear to have unit testing.
