### PR TITLE
Remove `scala-steward-org/scala-steward-action`

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -635,9 +635,6 @@ scacap/action-surefire-report:
 scalacenter/sbt-dependency-submission:
   f43202114d7522a4b233e052f82c2eea8d658134:
     tag: v3.2.1
-scala-steward-org/scala-steward-action:
-  f60ccd18bc9d8083e6809d9dc3db4a69a71d856c:
-    tag: v2.78.0
 scottbrenner/puppet-lint-action:
   '*':
     keep: true


### PR DESCRIPTION
Pekko was the only project using this action, and we have moved to using the public instance instead to reduce attack surface.

See also https://lists.apache.org/thread/8v1cpvd8y3bo04hy0hn84j5gshcmrfcg
