### PR TITLE
Add terraform tflint action needed to check PRs of infra terraform code

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -627,7 +627,7 @@ tcort/github-action-markdown-link-check:
   e7c7a18363c842693fadde5d41a3bd3573a7a225:
     tag: v1.1.2
 terraform-linters/setup-tflint:
-  4cb9feea73331a35b422df102992a03a44a3bb33
+  4cb9feea73331a35b422df102992a03a44a3bb33:
     tag: v6.2.1
 test-summary/action:
   '*':


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview
Installs a Terraform linter [TFLint](https://github.com/terraform-linters/tflint) executable in the PATH.

terraform-linters/setup-tflint

https://github.com/terraform-linters/setup-tflint

4cb9feea73331a35b422df102992a03a44a3bb33


## Permissions

Installs tflint which then read terraform HCL code to run lint checks on it

## Related Actions
N/A

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [X] The action is listed in the GitHub Actions Marketplace
- [X] The action is not already on the list of approved actions
- [X] The action has a sufficient number of contributors or has contributors within the ASF community
- [X] The action has a clearly defined license
- [X] The action is actively developed or maintained
- [X] The action has CI/unit tests configured
