### PR TITLE
Add testlens action

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -619,6 +619,9 @@ tcort/github-action-markdown-link-check:
 terraform-linters/setup-tflint:
   4cb9feea73331a35b422df102992a03a44a3bb33:
     tag: v6.2.1
+testlens-app/setup-testlens:
+  '*':
+    keep: true
 test-summary/action:
   '*':
     keep: true


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

https://issues.apache.org/jira/browse/INFRA-27662 added the testlens GitHub app for grails, there is an associated action to setup testlens for our workflows.  This configures PRs to have test summaries & handle flaky tests.

**Name of action:** setup-testlens

**URL of action:** https://github.com/testlens-app/setup-testlens

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**
I would prefer to pin all versions at this time.

## Permissions

The permissions were already granted via infrastructure ticket.

## Related Actions
None at this time.

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [ ] The action is listed in the GitHub Actions Marketplace
- [X] The action is not already on the list of approved actions
- [X] The action has a sufficient number of contributors or has contributors within the ASF community
- [ ] The action has a clearly defined license
- [X] The action is actively developed or maintained
- [] The action has CI/unit tests configured
