### PR TITLE
runs-on 2.1.0 (update)

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -671,7 +671,5 @@ posit-dev/setup-air:
   63e80dedb6d275c94a3841e15e5ff8691e1ab237:
     tag: v1.0.0
 runs-on/action:
-  cd2b598b0515d39d78c38a02d529db87d2196d1e:
-    tag: v2.0.3
-  742bf56072eb4845a0f94b3394673e4903c90ff0:
-    tag: v2.1.0
+  '*':
+    keep: true


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

Add the update: https://github.com/runs-on/action/releases/tag/v2.1.0