### PR TITLE
Add sbt-dependency-submission action version v3.2.1

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -569,6 +569,9 @@ scacap/action-surefire-report:
     keep: true
   5609ce4db72c09db044803b344a8968fd1f315da:
     tag: v1.9.1
+scalacenter/sbt-dependency-submission:
+  f43202114d7522a4b233e052f82c2eea8d658134:
+    tag: v3.2.1
 scala-steward-org/scala-steward-action:
   f60ccd18bc9d8083e6809d9dc3db4a69a71d856c:
     tag: v2.78.0


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

<!-- Please describe the proposed action; what it does and why this is needed. 
     It will help if you can tell us which project is interested in this action 
     and why.
-->

**Name of action:** 

scalacenter/sbt-dependency-submission@f43202114d7522a4b233e052f82c2eea8d658134

**URL of action:**

https://github.com/scalacenter/sbt-dependency-submission/releases/tag/v3.2.1

https://github.com/marketplace/actions/sbt-dependency-submission

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**

scalacenter/sbt-dependency-submission@f43202114d7522a4b233e052f82c2eea8d658134

v3.2.1

## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
