### PR TITLE
Request to add advanced-security/dismiss-alerts to actions.yml

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -9,6 +9,9 @@
     expires_at: 2026-04-24
   8d0d610af187e78a2772c2d18d627f4c52d3fbfb:
     tag: v3.1.0
+advanced-security/dismiss-alerts:
+  046d6b48d2e43cf563f96f67332c47c432eff83e:
+    tag: v2.0.2
 ana06/get-changed-files:
   25f79e676e7ea1868813e21465014798211fad8c:
     tag: v2.3.0


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

From the tooling team / Apache Trusted Releases project 

**Name of action:** 

Dismiss Alerts (Advanced Security, GitHub)

**URL of action:**

https://github.com/advanced-security/dismiss-alerts/tree/v2.0.2

Hash: 046d6b48d2e43cf563f96f67332c47c432eff83e


## Permissions

```
security-events: write
```

## Related Actions


## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
