### PR TITLE
Add aquasecurity/trivy-action

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -118,6 +118,10 @@ al-cheb/configure-pagefile-action:
 amannn/action-semantic-pull-request:
   '*':
     keep: true
+aquasecurity/trivy-action:
+  57a97c7e7821a5776cebc9bb87c984fa69cba8f1:
+    expires_at: 2050-01-01
+    tag: "v0.35.0"
 arduino/setup-protoc:
   '*':
     keep: true


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

GitHub Action for [Trivy](https://github.com/aquasecurity/trivy) security scanner.

**Name of action:** 
aquasecurity/trivy-action

**URL of action:**
https://github.com/marketplace/actions/aqua-security-trivy
https://github.com/aquasecurity/trivy-action

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**
[57a97c7e7821a5776cebc9bb87c984fa69cba8f1](https://github.com/aquasecurity/trivy-action/commits/57a97c7e7821a5776cebc9bb87c984fa69cba8f1/)
(for [tag `v0.35.0`](https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0))

## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
