### PR TITLE
Add Docker official actions (login, buildx, metadata, build-push)

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -295,6 +295,18 @@ docker://jekyll/jekyll:
 docker://pandoc/core:
   sha256:48e15e83db0df6fb39b24adb0210ecbde85003a3a8139d526e29c98f95ac0a93:
     tag: 3.7.0.2
+docker/build-push-action:
+  10e90e3645eae34f1e60eeb005ba3a3d33f178e8:
+    tag: v6.19.2
+docker/login-action:
+  c94ce9fb468520275223c153574b00df6fe4bcc9:
+    tag: v3.7.0
+docker/metadata-action:
+  c299e40c65443455700f0fdfc63efafe5b349051:
+    tag: v5.10.0
+docker/setup-buildx-action:
+  8d2750c68a42422c14e847fe6c8ac0403b4cbd6f:
+    tag: v3.12.0
 docker/setup-qemu-action:
   29109295f81e9208d7d86ff1c6c12d2833863392:
     tag: v3.6.0


### PR DESCRIPTION
# Request for adding new GitHub Actions to the allow list

## Overview

Docker's official CI/CD actions used by [apache/iggy](https://github.com/apache/iggy) for multi-arch Docker image builds and publishing. These are companion actions to `docker/setup-qemu-action` which is already on the allow list.

These actions were previously allowed implicitly but started failing on March 20, 2026 after an apparent org-level policy change.

**Name of actions:**
docker/login-action
docker/setup-buildx-action
docker/metadata-action
docker/build-push-action

**URL of actions:**
https://github.com/docker/login-action
https://github.com/docker/setup-buildx-action
https://github.com/docker/metadata-action
https://github.com/docker/build-push-action

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**

| Action | Hash | Tag |
|--------|------|-----|
| docker/login-action | [c94ce9fb468520275223c153574b00df6fe4bcc9](https://github.com/docker/login-action/commit/c94ce9fb468520275223c153574b00df6fe4bcc9) | [v3.7.0](https://github.com/docker/login-action/releases/tag/v3.7.0) |
| docker/setup-buildx-action | [8d2750c68a42422c14e847fe6c8ac0403b4cbd6f](https://github.com/docker/setup-buildx-action/commit/8d2750c68a42422c14e847fe6c8ac0403b4cbd6f) | [v3.12.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.12.0) |
| docker/metadata-action | [c299e40c65443455700f0fdfc63efafe5b349051](https://github.com/docker/metadata-action/commit/c299e40c65443455700f0fdfc63efafe5b349051) | [v5.10.0](https://github.com/docker/metadata-action/releases/tag/v5.10.0) |
| docker/build-push-action | [10e90e3645eae34f1e60eeb005ba3a3d33f178e8](https://github.com/docker/build-push-action/commit/10e90e3645eae34f1e60eeb005ba3a3d33f178e8) | [v6.19.2](https://github.com/docker/build-push-action/releases/tag/v6.19.2) |

## Permissions

- **docker/login-action**: Reads Docker Hub credentials from environment variables to authenticate with the registry. Requires `DOCKERHUB_USER` and `DOCKERHUB_TOKEN` to be set.
- **docker/setup-buildx-action**: Sets up Docker Buildx builder instance. No special permissions required.
- **docker/metadata-action**: Extracts metadata (tags, labels) from Git reference and GitHub events. No special permissions required.
- **docker/build-push-action**: Builds and pushes Docker images using Buildx. Requires registry credentials to be configured via docker/login-action for push operations.

## Related Actions

`docker/setup-qemu-action` is already approved (SHA `29109295f81e9208d7d86ff1c6c12d2833863392`, tag v3.6.0). These four actions form the standard Docker CI/CD toolkit and are typically used together for multi-arch image builds.

## Checklist

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license (Apache-2.0)
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured