### PR TITLE
Add gradle/actions/dependency-submission

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -342,6 +342,9 @@ google-github-actions/auth:
 google-github-actions/setup-gcloud:
   aa5489c8933f4cc7a4f7d45035b3b1440c9c10db:
     tag: v3.0.1
+gradle/actions/dependency-submission:
+  0723195856401067f7a2779048b490ace7a47d7c:
+    tag: v5.0.2
 gradle/actions/setup-gradle:
   4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2:
     tag: v5.0.0


### PR DESCRIPTION
This fixes #549

# Request for adding a new GitHub Action to the allow list

## Overview

Apache Lucene uses gradle/actions/dependency-submission@0723195856401067f7a2779048b490ace7a47d7c

Without the explicit dependency-submission, transitive Java dependencies (maven ecosystem) aren't tracked in the github dependency graph, and we won't receive vulnerability notifications for them: we'll only see direct dependencies.

Docs: https://github.com/gradle/actions/tree/main/dependency-submission

It is from same repository as the other gradle actions (same hash, same version), so same safety/restrictions apply, so should be safe.

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [ ] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
