### PR TITLE
Add gradle/actions/wrapper-validation

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -354,6 +354,9 @@ gradle/actions/setup-gradle:
     expires_at: 2026-05-24
   0723195856401067f7a2779048b490ace7a47d7c:
     tag: v5.0.2
+gradle/actions/wrapper-validation:
+  0723195856401067f7a2779048b490ace7a47d7c:
+    tag: v5.0.2
 gr2m/twitter-together:
   '*':
     keep: true


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

We use gradle/actions/wrapper-validation in  JMeter to check signatures of the dependencies.  The [docs](https://github.com/gradle/actions/tree/v5.0.2?tab=readme-ov-file#the-wrapper-validation-action) state it is part of the already allowed gradle/actions/setup-gradle action, which is already on the allow list, so this should be safe, too.

**Name of action:** gradle/actions/rapper-validation  

**URL of action:** https://github.com/gradle/actions/tree/v5.0.2/wrapper-validation

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** 0723195856401067f7a2779048b490ace7a47d7c


## Permissions

None, that I know of. Same as gradle/actions/setup-gradle, I suppose.

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->
Part of gradle/actions/setup-gradle (which we don't use, (yet?)).

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [ ] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
