### PR TITLE
Add cooldown to dependabot and expand .gitignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,5 @@ updates:
       - dependency-name: "cpp-linter/cpp-linter-action"
         versions: ">=2.16"
     open-pull-requests-limit: 50
+    cooldown:
+      default: 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,41 @@
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Claude Code
+.claude/
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg
+dist/
+build/
+.eggs/
+*.whl
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Testing / Coverage
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# Environment variables
+.env
+.env.local
+
+# OS
+.DS_Store
+Thumbs.db
+
 # Generated file, prevent accidental commits
 approved_patterns.yml
-/gateway/__pycache__
 /gateway/test_out_dummy.yml

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository hosts GitHub Actions developed by the ASF community and approved
   - [Adding a New Action](#adding-a-new-action-to-the-allow-list)
   - [Reviewing](#reviewing)
   - [Adding a New Version](#adding-a-new-version-to-the-allow-list)
+    - [Dependabot Cooldown Period](#dependabot-cooldown-period)
   - [Manual Version Addition](#manual-addition-of-specific-versions)
   - [Removing a Version](#removing-a-version-manually)
 
@@ -99,6 +100,23 @@ In most cases, new versions are automatically added through Dependabot:
 - This grace period gives projects sufficient time to update their workflows
 
 Projects are encouraged to help review updates to actions they use. Please have a look at the diff and mention in your approval what you have checked and why you think the action is safe.
+
+#### Dependabot Cooldown Period
+
+This repository uses a [Dependabot cooldown period](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown) of 4 days. After a Dependabot PR is merged or closed, Dependabot will wait 4 days before opening the next PR for the same ecosystem. This helps keep the volume of update PRs manageable and gives reviewers time to catch up.
+
+> [!TIP]
+> We recommend that ASF projects configure a similar cooldown in their own `dependabot.yml` to avoid being overwhelmed by update PRs and to catch up with approved actions here:
+> ```yaml
+> updates:
+>   - package-ecosystem: "github-actions"
+>     directory: "/"
+>     schedule:
+>       interval: "weekly"
+>     cooldown:
+>       default: 4
+> ```
+> Adjust the `default` value (in days) to match your project's review capacity.
 
 ### Manual Addition of Specific Versions
 


### PR DESCRIPTION
## Summary
- Add cooldown configuration to dependabot
- Expand `.gitignore` with standard Python project patterns (bytecode, venvs, coverage, IDE files, etc.)
- Remove `.idea/` from tracking

## Test plan
- [ ] Verify dependabot respects the new cooldown setting
- [ ] Confirm ignored files are no longer tracked

Generated-by: Claude Opus 4.6 (1M context)