### PR TITLE
Revert dependabot PRs #520 and #556

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -129,7 +129,7 @@ jobs:
         if: false
       - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411  # v2.8.0
         if: false
-      - uses: manusa/actions-setup-minikube@96202dee4ae1c2f46a62fe197273aaf22b83f42d  # v2.16.1
+      - uses: manusa/actions-setup-minikube@8234275e0386fe1cdaf519d28c90f4f03fad89e4  # v2.15.0
         if: false
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
         if: false


### PR DESCRIPTION
## Summary
- Revert #556 (leafo/gh-actions-luarocks 5.0.0 → 6.0.0)
- Revert #520 (manusa/actions-setup-minikube 2.15.0 → 2.16.1)

## Reason
These PRs were merged prematurely and need to be reverted.

Generated-by: Claude Opus 4.6 (1M context)