### PR TITLE
Add aws-actions/configure-aws-credentials v4.0.2 to approved actions

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -148,6 +148,8 @@ aws-actions/configure-aws-credentials:
     expires_at: 2026-05-22
   8df5847569e6427dd6c4fb1cf565c83acfa8afa7:
     tag: v6.0.0
+  e3dd6a429d7300a6a4c196c26e071d42e0343502:
+    tag: v4.0.2
 azure/setup-helm:
   1a275c3b69536ee54be43f2070a358922e12c8d4:
     tag: v4.3.1


### PR DESCRIPTION
## Summary
- Adds `aws-actions/configure-aws-credentials` v4.0.2 (commit `e3dd6a429d7300a6a4c196c26e071d42e0343502`) to the approved actions list

## Test plan
- [ ] Verify the action SHA matches the official v4.0.2 release tag
- [ ] Confirm CI checks pass

Generated by [Claude Code](https://claude.ai/claude-code)