### PR TITLE
Remove deprecated gradle/wrapper-validation-action

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -107,8 +107,6 @@ jobs:
         if: false
       - uses: graalvm/setup-graalvm@f744c72a42b1995d7b0cbc314bde4bace7ac1fe1  # v1.5.0
         if: false
-      - uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6  # v3.5.0
-        if: false
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         if: false
       - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85  # v4.0.0

--- a/actions.yml
+++ b/actions.yml
@@ -405,11 +405,6 @@ graalvm/setup-graalvm:
     expires_at: 2026-06-14
   f744c72a42b1995d7b0cbc314bde4bace7ac1fe1:
     tag: v1.5.0
-gradle/wrapper-validation-action:
-  '*':
-    keep: true
-  f9c9c575b8b21b6485636a91ffecd10e558c62f6:
-    tag: v3.5.0
 gsactions/commit-message-checker:
   '*':
     keep: true

--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -134,8 +134,6 @@
 - graalvm/setup-graalvm@790e28947b79a9c09c3391c0f18bf8d0f102ed69
 - graalvm/setup-graalvm@54b4f5a65c1a84b2fdfdc2078fe43df32819e4b1
 - graalvm/setup-graalvm@f744c72a42b1995d7b0cbc314bde4bace7ac1fe1
-- gradle/wrapper-validation-action@*
-- gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6
 - gsactions/commit-message-checker@*
 - hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
 - hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd


### PR DESCRIPTION
## Summary
- Remove `gradle/wrapper-validation-action` from `dummy.yml` and `approved_patterns.yml`
- This old repo now redirects to `gradle/actions/wrapper-validation`, causing GitHub's enterprise allowlist to reject it as `gradle/actions/wrapper-validation@v3.5.0` (not approved)
- The newer `gradle/actions/wrapper-validation@v5.0.2` is already present in the workflow and approved

## Test plan
- [ ] Verify the dummy workflow passes on this PR (no more allowlist rejection)
- [ ] Confirm no other workflows reference `gradle/wrapper-validation-action`

🤖 Generated with [Claude Code](https://claude.com/claude-code)