### PR TITLE
Add sonarcube scan github actions for code scanning

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -697,6 +697,12 @@ snok/install-poetry:
 softprops/action-gh-release:
   '*':
     keep: true
+SonarSource/sonarqube-scan-action:
+  a31c9398be7ace6bbfaf30c0bd5d415f843d45e9:
+    tag: v7.0.0
+SonarSource/sonarqube-scan-action/install-build-wrapper:
+  a31c9398be7ace6bbfaf30c0bd5d415f843d45e9:
+    tag: v7.0.0
 stCarolas/setup-maven:
   '*':
     keep: true


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

<!-- Please describe the proposed action; what it does and why this is needed. 
     It will help if you can tell us which project is interested in this action 
     and why.
-->
This actions is for SonarQube code scanning.

In ASF Infra, we have SonarQube support for projects. So it would be great that we could direct integrating it into GitHub Actions.

In [Apache Kvrocks](https://github.com/apache/kvrocks), we leverage SonarQube for code quality scanning.

**Name of action:** 
- SonarSource/sonarqube-scan-action
- SonarSource/sonarqube-scan-action/install-build-wrapper

**URL of action:**
- https://github.com/SonarSource/sonarqube-scan-action
- https://github.com/SonarSource/sonarqube-scan-action/tree/master/install-build-wrapper

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**
[a31c9398be7ace6bbfaf30c0bd5d415f843d45e9](https://github.com/SonarSource/sonarqube-scan-action/commit/a31c9398be7ace6bbfaf30c0bd5d415f843d45e9)


## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->

It should have access to read SonarQube credentials.

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [ ] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
