### PR TITLE
Request to add JetBrains/qodana-action

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -446,6 +446,9 @@ jarvusinnovations/background-action:
 jasonetco/create-an-issue:
   1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5:
     tag: v2
+JetBrains/qodana-action:
+  89eb4357efd2b52e639f3216e63edaf33b82622b:
+    tag: v2025.3.2
 jidicula/clang-format-action:
   '*':
     keep: true
@@ -787,6 +790,3 @@ runs-on/action:
     expires_at: 2026-06-14
   742bf56072eb4845a0f94b3394673e4903c90ff0:
     tag: v2.1.0
-JetBrains/qodana-action:
-  89eb4357efd2b52e639f3216e63edaf33b82622b:
-    tag: v2025.3.2


### PR DESCRIPTION
## Request to add JetBrains/qodana-action

**Action:** `JetBrains/qodana-action`
**SHA:** `89eb4357efd2b52e639f3216e63edaf33b82622b`
**Tag:** `v2025.3.2`

**Repository:** https://github.com/JetBrains/qodana-action

### Justification

[The Apache Struts IntelliJ Plugin](https://github.com/apache/struts-intellij-plugin) uses JetBrains Qodana for automated code inspections in its CI pipeline. We are pinning all GitHub Actions to SHA hashes for supply-chain security, and need this action approved to complete that effort (see https://github.com/apache/struts-intellij-plugin/pull/59).

### Alternatives considered

There is no direct alternative — Qodana is the official JetBrains static analysis tool and is tightly integrated with IntelliJ Platform plugin development.

### Security

JetBrains/qodana-action is an official action maintained by JetBrains, a well-known vendor in the developer tooling space. It runs Qodana static analysis in a Docker container.

## Permissions

The action requires `contents: read` to check out and analyze the repository code. It does not require write access to code or read access to credentials. When used with Qodana Cloud reporting, an optional `QODANA_TOKEN` can be provided, but this is not required for local-only analysis. The action has no security or provenance implications beyond reading the repository source code.

## Related Actions

There is no similar action on the current approved list. Qodana is JetBrains' proprietary static analysis platform — it is the only tool that provides deep IntelliJ-based inspections (the same inspections that run inside IntelliJ IDEA). Generic linters or static analysis tools (e.g., SonarQube, CodeQL) do not cover IntelliJ Platform plugin-specific inspections.

## Checklist

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license (Apache 2.0)
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
