### PR TITLE
Add lhotari/sandboxed-trivy-action v1.0.1

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -484,8 +484,8 @@ leafo/gh-actions-luarocks:
   4c082a5fad45388feaeb0798dbd82dbd7dc65bca:
     tag: v5
 lhotari/sandboxed-trivy-action:
-  f5a39c678492e26ad3b2dc52edf1b638771401b5:
-    tag: v1.0.0
+  555963036b2012b44c1071508a236e569db28ebb:
+    tag: v1.0.1
 lycheeverse/lychee-action:
   8646ba30535128ac92d33dfc9133794bfdd9b411:
     tag: v2.8.0


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

This action is forked from [aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action) with security hardened by running Trivy inside a sandboxed Docker container. More details about the security hardening in the [README file](https://github.com/lhotari/sandboxed-trivy-action?tab=readme-ov-file#security) of the repository.
Credits to [Aqua Security](https://www.aquasec.com/) for the original action. 

**Name of action:**
lhotari/sandboxed-trivy-action

**URL of action:** 
https://github.com/lhotari/sandboxed-trivy-action
https://github.com/marketplace/actions/sandboxed-trivy

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**
555963036b2012b44c1071508a236e569db28ebb

## Permissions

<!-- Describe the permissions required and whether these permissions can have 
     security or provenance implications such as write access to code or read 
     access to credentials. -->
No special permissions required.

## Related Actions

<!-- If this action is similar to an existing, allowed action (please do check!), 
     let us know how this one differs and is a better option for your use case.
     -->
This is a fork of https://github.com/aquasecurity/trivy-action

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
