### PR TITLE
Temporarily add `gradle/actions` version `4.4.2`

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -351,15 +351,30 @@ graalvm/setup-graalvm:
   f744c72a42b1995d7b0cbc314bde4bace7ac1fe1:
     tag: v1.5.0
 gradle/actions/dependency-submission:
+  017a9effdb900e5b5b2fddfb590a105619dca3c3:
+    tag: v4.4.2
+    expires_at: 2026-04-24
+  4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2:
+    tag: v5.0.0
+    expires_at: 2026-05-24
   0723195856401067f7a2779048b490ace7a47d7c:
     tag: v5.0.2
 gradle/actions/setup-gradle:
+  017a9effdb900e5b5b2fddfb590a105619dca3c3:
+    tag: v4.4.2
+    expires_at: 2026-04-24
   4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2:
     tag: v5.0.0
     expires_at: 2026-05-24
   0723195856401067f7a2779048b490ace7a47d7c:
     tag: v5.0.2
 gradle/actions/wrapper-validation:
+  017a9effdb900e5b5b2fddfb590a105619dca3c3:
+    tag: v4.4.2
+    expires_at: 2026-04-24
+  4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2:
+    tag: v5.0.0
+    expires_at: 2026-05-24
   0723195856401067f7a2779048b490ace7a47d7c:
     tag: v5.0.2
 gradle/wrapper-validation-action:


### PR DESCRIPTION
Can we temporarily enable version `4.4.2`?

I am currently release Log4j and updating to the latest version would introduce a 72 hours delay to release `logging-parent`. The old version is only required for this release (conservatively 2 weeks, if there are big voting delays).

**Note**: this is one of the actions from a “verified” vendor. We always pin by hash, so if it was compromised, we would probably know by now.