### PR TITLE
Add `gradle/develocity-actions`

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -103,6 +103,10 @@ jobs:
         if: false
       - uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6  # v3.5.0
         if: false
+      - uses: gradle/develocity-actions/maven-publish-build-scan@974e8dbcbda40db6828fc35f349c80a7c0e71529  # v2.1
+        if: false
+      - uses: gradle/develocity-actions/setup-maven@974e8dbcbda40db6828fc35f349c80a7c0e71529  # v2.1
+        if: false
       - uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         if: false
       - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85  # v4.0.0

--- a/actions.yml
+++ b/actions.yml
@@ -362,6 +362,18 @@ gradle/actions/setup-gradle:
 gradle/actions/wrapper-validation:
   0723195856401067f7a2779048b490ace7a47d7c:
     tag: v5.0.2
+gradle/develocity-actions/maven-publish-build-scan:
+  4a2aed82eea165ba2d5c494fc2a8730d7fdff229:
+    tag: v1.4
+    expires_at: 2026-04-24
+  974e8dbcbda40db6828fc35f349c80a7c0e71529:
+    tag: v2.1
+gradle/develocity-actions/setup-maven:
+  4a2aed82eea165ba2d5c494fc2a8730d7fdff229:
+    tag: v1.4
+    expires_at: 2026-04-24
+  974e8dbcbda40db6828fc35f349c80a7c0e71529:
+    tag: v2.1
 gradle/wrapper-validation-action:
   '*':
     keep: true


### PR DESCRIPTION
The Log4j build uses `gradle/develocity-actions`.

We didn't have time to update to the latest release, so we need both the current version `2.1` and the one we are using `1.4` to be added to the whitelist.
