### PR TITLE
INFRA-27769: Add anchore/sbom-action and anchore/scan-action to allow list

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -39,6 +39,12 @@ amannn/action-semantic-pull-request:
 ana06/get-changed-files:
   25f79e676e7ea1868813e21465014798211fad8c:
     tag: v2.3.0
+anchore/sbom-action:
+  e22c389904149dbc22b58101806040fa8d37a610:
+    tag: v0.24.0
+anchore/scan-action:
+  e1165082ffb1fe366ebaf02d8526e7c4989ea9d2:
+    tag: v7.4.0
 arduino/setup-protoc:
   '*':
     keep: true


### PR DESCRIPTION
## Why these actions are needed

Apache NiFi uses `anchore/sbom-action` and `anchore/scan-action` in its CI pipeline to generate and scan SBOMs (Software Bill of Materials) as part of its code-compliance workflow.

These actions are currently blocked, causing the workflow to fail:
- https://github.com/apache/nifi/actions/runs/23547840792

### Actions added

| Action | Commit SHA | Tag |
|--------|-----------|-----|
| `anchore/sbom-action` | `e22c389904149dbc22b58101806040fa8d37a610` | `v0.24.0` |
| `anchore/scan-action` | `e1165082ffb1fe366ebaf02d8526e7c4989ea9d2` | `v7.4.0` |

### How NiFi uses these actions

In the [code-compliance workflow](https://github.com/apache/nifi/blob/main/.github/workflows/code-compliance.yml):
1. **`anchore/sbom-action`** generates an SPDX SBOM from the NiFi assembly build artifact
2. **`anchore/scan-action`** scans the generated SBOM for known vulnerabilities using Grype

### Alternatives considered

These are the standard Anchore open-source tools for SBOM generation (Syft) and vulnerability scanning (Grype). There are no direct alternatives that provide the same level of integration with GitHub Actions.

### Security concerns

Both actions are maintained by [Anchore](https://anchore.com), a well-known software supply chain security company. The actions are widely used across open-source projects:
- [`anchore/sbom-action`](https://github.com/anchore/sbom-action) - generates SBOMs using Syft
- [`anchore/scan-action`](https://github.com/anchore/scan-action) - scans for vulnerabilities using Grype

Both are pinned to exact commit SHAs as required.