### PR TITLE
allow astral-sh/setup-uv v7.0.0

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -52,6 +52,10 @@ arduino/setup-protoc:
   '*':
     keep: true
 astral-sh/setup-uv:
+  eb1897b8dc4b5d5bfe39a428a8f2304605e0983c:
+    # needed for helm/chart-testing-action @ v2.8.0
+    tag: v7.0.0
+    expires_at: 2026-06-30
   681c641aba71e4a1c380be3ab5e12ad51f415867:
     tag: v7.1.6
     expires_at: 2026-05-15


### PR DESCRIPTION
Add `astral-sh/setup-uv @ v7.0.0` to allowed actions.  This version is used by latest `helm/chart-testing-action @ v2.8.0`, which is in the whitelist:

https://github.com/apache/infrastructure-actions/blob/a35f4419d8cbc3f27d487c808ca61a0df973a104/actions.yml#L412-L414

`v7.0.0` was allowed previously (#358), but has expired after 8a7952e0e97e5b88954bf18605d8eb4c92ffa828.

There aren’t any published [security advisories](https://github.com/astral-sh/setup-uv/security).

Fixes #590.