### PR TITLE
Add zizmorcore/zizmor-action to the allowlist

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -836,3 +836,6 @@ wei/curl:
 xpol/setup-lua:
   '*':
     keep: true
+zizmorcore/zizmor-action:
+  71321a20a9ded102f6e9ce5718a2fcec2c4f70d8:
+    tag: v0.5.2


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

**Name of action:** zizmor-action

**URL of action:** https://github.com/zizmorcore/zizmor-action

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** [71321a20a9ded102f6e9ce5718a2fcec2c4f70d8](https://github.com/zizmorcore/zizmor-action/commit/71321a20a9ded102f6e9ce5718a2fcec2c4f70d8)

zizmor-action runs [zizmor](https://docs.zizmor.sh/), a static analysis tool for GitHub Actions workflows, directly from GitHub Actions. It finds security issues and potential bugs in workflow files, helping projects maintain secure CI/CD pipelines by catching common misconfigurations and vulnerabilities. It integrates with GitHub Advanced Security for stateful analysis and incremental triage.

## Permissions

When used with Advanced Security (default), requires `security-events: write` to upload SARIF results. For private repos, also needs `contents: read` and `actions: read`. Does not require write access to code or credentials.

## Related Actions

There is no existing equivalent action on the allowlist for GitHub Actions workflow static analysis.

## Checklist

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
- [ ] Compiled JavaScript in `dist/` matches a clean rebuild (verify with `uv run utils/verify-action-build.py org/repo@hash`)
