### PR TITLE
Add CI check for approved actions count approaching 1000 limit

### DIFF
--- a/.github/workflows/check_approved_limit.yml
+++ b/.github/workflows/check_approved_limit.yml
@@ -1,0 +1,36 @@
+name: Check Approved Actions Limit
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - approved_patterns.yml
+  pull_request:
+    paths:
+      - approved_patterns.yml
+      - .github/workflows/check_approved_limit.yml
+
+permissions:
+  contents: read
+
+jobs:
+  check-limit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Check approved actions count
+        run: |
+          # The org-wide approved_patterns list has a hard limit of 1000 entries.
+          # We fail at 800 to give ourselves room to act before hitting the wall.
+          # See https://github.com/apache/infrastructure-actions/issues/602
+          LIMIT=800
+          COUNT=$(grep -c '^- ' approved_patterns.yml)
+          echo "Approved actions count: $COUNT / 1000 (warning threshold: $LIMIT)"
+          if [ "$COUNT" -ge "$LIMIT" ]; then
+            echo "::error::Approved actions count ($COUNT) has reached the warning threshold of $LIMIT. The org-wide limit is 1000. Time to clean up unused actions or explore workarounds. See https://github.com/apache/infrastructure-actions/issues/602"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Adds a workflow that counts entries in `approved_patterns.yml` and fails at 800 (out of a hard limit of 1000 org-wide approved actions)
- Runs on pushes to main and PRs that modify `approved_patterns.yml`
- Gives clear error message explaining the situation and linking to #602

Currently at ~280 entries, so plenty of headroom, but this ensures we get early warning.

Closes #602

## Test plan

- [ ] Verify workflow runs on PR and passes (current count ~280, well under 800)
- [ ] Verify the error message is clear if threshold is exceeded

Generated-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>