### PR TITLE
Add --no-gh mode to verify-action-build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,10 +36,10 @@ updates:
         versions: ">=2.16"
     open-pull-requests-limit: 50
     cooldown:
-      default: 4
+      default-days: 4
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
-      default: 4
+      default-days: 4

--- a/README.md
+++ b/README.md
@@ -141,9 +141,23 @@ This will:
 5. If verification passes, ask whether to approve and merge the PR
 6. On merge, add a review comment documenting what was verified
 
+#### Running Without the `gh` CLI
+
+If you prefer not to install the `gh` CLI, you can use `--no-gh` to make all GitHub API calls via Python `requests` instead. In this mode you must provide a GitHub token either via `--github-token` or the `GITHUB_TOKEN` environment variable:
+
+```bash
+# Using the flag:
+uv run utils/verify-action-build.py --no-gh --github-token ghp_... org/repo@commit_hash
+
+# Or via environment variable:
+export GITHUB_TOKEN=ghp_...
+uv run utils/verify-action-build.py --no-gh --check-dependabot-prs
+```
+
+The `--no-gh` mode supports all the same features as the default `gh`-based mode.
+
 > [!NOTE]
-> **Prerequisites:** `docker`, `uv`, and `gh` (GitHub CLI, authenticated via `gh auth login`).
-> The build runs in a `node:20-slim` container so no local Node.js installation is needed.
+> **Prerequisites:** `docker` and `uv`. When using the default mode (without `--no-gh`), `gh` (GitHub CLI, authenticated via `gh auth login`) is also required. The build runs in a `node:20-slim` container so no local Node.js installation is needed.
 
 #### Dependabot Cooldown Period
 

--- a/utils/pyproject.toml
+++ b/utils/pyproject.toml
@@ -5,6 +5,7 @@ description = "Utility scripts for ASF GitHub Actions management"
 requires-python = ">=3.11"
 dependencies = [
     "jsbeautifier>=1.15",
+    "requests>=2.31",
     "rich>=13.0",
 ]
 

--- a/utils/uv.lock
+++ b/utils/uv.lock
@@ -3,6 +3,104 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/60/e3bec1881450851b087e301bedc3daa9377a4d45f1c26aa90b0b235e38aa/charset_normalizer-3.4.6.tar.gz", hash = "sha256:1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6", size = 143363, upload-time = "2026-03-15T18:53:25.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/28/ff6f234e628a2de61c458be2779cb182bc03f6eec12200d4a525bbfc9741/charset_normalizer-3.4.6-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:82060f995ab5003a2d6e0f4ad29065b7672b6593c8c63559beefe5b443242c3e", size = 293582, upload-time = "2026-03-15T18:50:25.454Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/b7/b1a117e5385cbdb3205f6055403c2a2a220c5ea80b8716c324eaf75c5c95/charset_normalizer-3.4.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60c74963d8350241a79cb8feea80e54d518f72c26db618862a8f53e5023deaf9", size = 197240, upload-time = "2026-03-15T18:50:27.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5f/2574f0f09f3c3bc1b2f992e20bce6546cb1f17e111c5be07308dc5427956/charset_normalizer-3.4.6-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6e4333fb15c83f7d1482a76d45a0818897b3d33f00efd215528ff7c51b8e35d", size = 217363, upload-time = "2026-03-15T18:50:28.601Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d1/0ae20ad77bc949ddd39b51bf383b6ca932f2916074c95cad34ae465ab71f/charset_normalizer-3.4.6-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bc72863f4d9aba2e8fd9085e63548a324ba706d2ea2c83b260da08a59b9482de", size = 212994, upload-time = "2026-03-15T18:50:30.102Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ac/3233d262a310c1b12633536a07cde5ddd16985e6e7e238e9f3f9423d8eb9/charset_normalizer-3.4.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9cc4fc6c196d6a8b76629a70ddfcd4635a6898756e2d9cac5565cf0654605d73", size = 204697, upload-time = "2026-03-15T18:50:31.654Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3c/8a18fc411f085b82303cfb7154eed5bd49c77035eb7608d049468b53f87c/charset_normalizer-3.4.6-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:0c173ce3a681f309f31b87125fecec7a5d1347261ea11ebbb856fa6006b23c8c", size = 191673, upload-time = "2026-03-15T18:50:33.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/a7/11cfe61d6c5c5c7438d6ba40919d0306ed83c9ab957f3d4da2277ff67836/charset_normalizer-3.4.6-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c907cdc8109f6c619e6254212e794d6548373cc40e1ec75e6e3823d9135d29cc", size = 201120, upload-time = "2026-03-15T18:50:35.105Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/10/cf491fa1abd47c02f69687046b896c950b92b6cd7337a27e6548adbec8e4/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:404a1e552cf5b675a87f0651f8b79f5f1e6fd100ee88dc612f89aa16abd4486f", size = 200911, upload-time = "2026-03-15T18:50:36.819Z" },
+    { url = "https://files.pythonhosted.org/packages/28/70/039796160b48b18ed466fde0af84c1b090c4e288fae26cd674ad04a2d703/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e3c701e954abf6fc03a49f7c579cc80c2c6cc52525340ca3186c41d3f33482ef", size = 192516, upload-time = "2026-03-15T18:50:38.228Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/34/c56f3223393d6ff3124b9e78f7de738047c2d6bc40a4f16ac0c9d7a1cb3c/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7a6967aaf043bceabab5412ed6bd6bd26603dae84d5cb75bf8d9a74a4959d398", size = 218795, upload-time = "2026-03-15T18:50:39.664Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/3b/ce2d4f86c5282191a041fdc5a4ce18f1c6bd40a5bd1f74cf8625f08d51c1/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5feb91325bbceade6afab43eb3b508c63ee53579fe896c77137ded51c6b6958e", size = 201833, upload-time = "2026-03-15T18:50:41.552Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/9b/b6a9f76b0fd7c5b5ec58b228ff7e85095370282150f0bd50b3126f5506d6/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:f820f24b09e3e779fe84c3c456cb4108a7aa639b0d1f02c28046e11bfcd088ed", size = 213920, upload-time = "2026-03-15T18:50:43.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/98/7bc23513a33d8172365ed30ee3a3b3fe1ece14a395e5fc94129541fc6003/charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b35b200d6a71b9839a46b9b7fff66b6638bb52fc9658aa58796b0326595d3021", size = 206951, upload-time = "2026-03-15T18:50:44.789Z" },
+    { url = "https://files.pythonhosted.org/packages/32/73/c0b86f3d1458468e11aec870e6b3feac931facbe105a894b552b0e518e79/charset_normalizer-3.4.6-cp311-cp311-win32.whl", hash = "sha256:9ca4c0b502ab399ef89248a2c84c54954f77a070f28e546a85e91da627d1301e", size = 143703, upload-time = "2026-03-15T18:50:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e3/76f2facfe8eddee0bbd38d2594e709033338eae44ebf1738bcefe0a06185/charset_normalizer-3.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:a9e68c9d88823b274cf1e72f28cb5dc89c990edf430b0bfd3e2fb0785bfeabf4", size = 153857, upload-time = "2026-03-15T18:50:47.563Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/dc/9abe19c9b27e6cd3636036b9d1b387b78c40dedbf0b47f9366737684b4b0/charset_normalizer-3.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:97d0235baafca5f2b09cf332cc275f021e694e8362c6bb9c96fc9a0eb74fc316", size = 142751, upload-time = "2026-03-15T18:50:49.234Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/62/c0815c992c9545347aeea7859b50dc9044d147e2e7278329c6e02ac9a616/charset_normalizer-3.4.6-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2ef7fedc7a6ecbe99969cd09632516738a97eeb8bd7258bf8a0f23114c057dab", size = 295154, upload-time = "2026-03-15T18:50:50.88Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/bdca6613c2e3c58c7421891d80cc3efa1d32e882f7c4a7ee6039c3fc951a/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4ea868bc28109052790eb2b52a9ab33f3aa7adc02f96673526ff47419490e21", size = 199191, upload-time = "2026-03-15T18:50:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/92/9934d1bbd69f7f398b38c5dae1cbf9cc672e7c34a4adf7b17c0a9c17d15d/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:836ab36280f21fc1a03c99cd05c6b7af70d2697e374c7af0b61ed271401a72a2", size = 218674, upload-time = "2026-03-15T18:50:54.102Z" },
+    { url = "https://files.pythonhosted.org/packages/af/90/25f6ab406659286be929fd89ab0e78e38aa183fc374e03aa3c12d730af8a/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f1ce721c8a7dfec21fcbdfe04e8f68174183cf4e8188e0645e92aa23985c57ff", size = 215259, upload-time = "2026-03-15T18:50:55.616Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ef/79a463eb0fff7f96afa04c1d4c51f8fc85426f918db467854bfb6a569ce3/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e28d62a8fc7a1fa411c43bd65e346f3bce9716dc51b897fbe930c5987b402d5", size = 207276, upload-time = "2026-03-15T18:50:57.054Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/72/d0426afec4b71dc159fa6b4e68f868cd5a3ecd918fec5813a15d292a7d10/charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:530d548084c4a9f7a16ed4a294d459b4f229db50df689bfe92027452452943a0", size = 195161, upload-time = "2026-03-15T18:50:58.686Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/18/c82b06a68bfcb6ce55e508225d210c7e6a4ea122bfc0748892f3dc4e8e11/charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:30f445ae60aad5e1f8bdbb3108e39f6fbc09f4ea16c815c66578878325f8f15a", size = 203452, upload-time = "2026-03-15T18:51:00.196Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d6/0c25979b92f8adafdbb946160348d8d44aa60ce99afdc27df524379875cb/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ac2393c73378fea4e52aa56285a3d64be50f1a12395afef9cce47772f60334c2", size = 202272, upload-time = "2026-03-15T18:51:01.703Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/7fea3e8fe84136bebbac715dd1221cc25c173c57a699c030ab9b8900cbb7/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:90ca27cd8da8118b18a52d5f547859cc1f8354a00cd1e8e5120df3e30d6279e5", size = 195622, upload-time = "2026-03-15T18:51:03.526Z" },
+    { url = "https://files.pythonhosted.org/packages/57/8a/d6f7fd5cb96c58ef2f681424fbca01264461336d2a7fc875e4446b1f1346/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e5a94886bedca0f9b78fecd6afb6629142fd2605aa70a125d49f4edc6037ee6", size = 220056, upload-time = "2026-03-15T18:51:05.269Z" },
+    { url = "https://files.pythonhosted.org/packages/16/50/478cdda782c8c9c3fb5da3cc72dd7f331f031e7f1363a893cdd6ca0f8de0/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:695f5c2823691a25f17bc5d5ffe79fa90972cc34b002ac6c843bb8a1720e950d", size = 203751, upload-time = "2026-03-15T18:51:06.858Z" },
+    { url = "https://files.pythonhosted.org/packages/75/fc/cc2fcac943939c8e4d8791abfa139f685e5150cae9f94b60f12520feaa9b/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:231d4da14bcd9301310faf492051bee27df11f2bc7549bc0bb41fef11b82daa2", size = 216563, upload-time = "2026-03-15T18:51:08.564Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b7/a4add1d9a5f68f3d037261aecca83abdb0ab15960a3591d340e829b37298/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a056d1ad2633548ca18ffa2f85c202cfb48b68615129143915b8dc72a806a923", size = 209265, upload-time = "2026-03-15T18:51:10.312Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/18/c094561b5d64a24277707698e54b7f67bd17a4f857bbfbb1072bba07c8bf/charset_normalizer-3.4.6-cp312-cp312-win32.whl", hash = "sha256:c2274ca724536f173122f36c98ce188fd24ce3dad886ec2b7af859518ce008a4", size = 144229, upload-time = "2026-03-15T18:51:11.694Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/20/0567efb3a8fd481b8f34f739ebddc098ed062a59fed41a8d193a61939e8f/charset_normalizer-3.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:c8ae56368f8cc97c7e40a7ee18e1cedaf8e780cd8bc5ed5ac8b81f238614facb", size = 154277, upload-time = "2026-03-15T18:51:13.004Z" },
+    { url = "https://files.pythonhosted.org/packages/15/57/28d79b44b51933119e21f65479d0864a8d5893e494cf5daab15df0247c17/charset_normalizer-3.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:899d28f422116b08be5118ef350c292b36fc15ec2daeb9ea987c89281c7bb5c4", size = 142817, upload-time = "2026-03-15T18:51:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/1d/4fdabeef4e231153b6ed7567602f3b68265ec4e5b76d6024cf647d43d981/charset_normalizer-3.4.6-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11afb56037cbc4b1555a34dd69151e8e069bee82e613a73bef6e714ce733585f", size = 294823, upload-time = "2026-03-15T18:51:15.755Z" },
+    { url = "https://files.pythonhosted.org/packages/47/7b/20e809b89c69d37be748d98e84dce6820bf663cf19cf6b942c951a3e8f41/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:423fb7e748a08f854a08a222b983f4df1912b1daedce51a72bd24fe8f26a1843", size = 198527, upload-time = "2026-03-15T18:51:17.177Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/4f8d27527d59c039dce6f7622593cdcd3d70a8504d87d09eb11e9fdc6062/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d73beaac5e90173ac3deb9928a74763a6d230f494e4bfb422c217a0ad8e629bf", size = 218388, upload-time = "2026-03-15T18:51:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/9b/4770ccb3e491a9bacf1c46cc8b812214fe367c86a96353ccc6daf87b01ec/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d60377dce4511655582e300dc1e5a5f24ba0cb229005a1d5c8d0cb72bb758ab8", size = 214563, upload-time = "2026-03-15T18:51:20.374Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/58/a199d245894b12db0b957d627516c78e055adc3a0d978bc7f65ddaf7c399/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:530e8cebeea0d76bdcf93357aa5e41336f48c3dc709ac52da2bb167c5b8271d9", size = 206587, upload-time = "2026-03-15T18:51:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/70/3def227f1ec56f5c69dfc8392b8bd63b11a18ca8178d9211d7cc5e5e4f27/charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:a26611d9987b230566f24a0a125f17fe0de6a6aff9f25c9f564aaa2721a5fb88", size = 194724, upload-time = "2026-03-15T18:51:23.508Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ab/9318352e220c05efd31c2779a23b50969dc94b985a2efa643ed9077bfca5/charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:34315ff4fc374b285ad7f4a0bf7dcbfe769e1b104230d40f49f700d4ab6bbd84", size = 202956, upload-time = "2026-03-15T18:51:25.239Z" },
+    { url = "https://files.pythonhosted.org/packages/75/13/f3550a3ac25b70f87ac98c40d3199a8503676c2f1620efbf8d42095cfc40/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ddd609f9e1af8c7bd6e2aca279c931aefecd148a14402d4e368f3171769fd", size = 201923, upload-time = "2026-03-15T18:51:26.682Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/db/c5c643b912740b45e8eec21de1bbab8e7fc085944d37e1e709d3dcd9d72f/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:80d0a5615143c0b3225e5e3ef22c8d5d51f3f72ce0ea6fb84c943546c7b25b6c", size = 195366, upload-time = "2026-03-15T18:51:28.129Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/3b1c62744f9b2448443e0eb160d8b001c849ec3fef591e012eda6484787c/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:92734d4d8d187a354a556626c221cd1a892a4e0802ccb2af432a1d85ec012194", size = 219752, upload-time = "2026-03-15T18:51:29.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/98/32ffbaf7f0366ffb0445930b87d103f6b406bc2c271563644bde8a2b1093/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:613f19aa6e082cf96e17e3ffd89383343d0d589abda756b7764cf78361fd41dc", size = 203296, upload-time = "2026-03-15T18:51:30.921Z" },
+    { url = "https://files.pythonhosted.org/packages/41/12/5d308c1bbe60cabb0c5ef511574a647067e2a1f631bc8634fcafaccd8293/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:2b1a63e8224e401cafe7739f77efd3f9e7f5f2026bda4aead8e59afab537784f", size = 215956, upload-time = "2026-03-15T18:51:32.399Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e9/5f85f6c5e20669dbe56b165c67b0260547dea97dba7e187938833d791687/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cceb5473417d28edd20c6c984ab6fee6c6267d38d906823ebfe20b03d607dc2", size = 208652, upload-time = "2026-03-15T18:51:34.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/11/897052ea6af56df3eef3ca94edafee410ca699ca0c7b87960ad19932c55e/charset_normalizer-3.4.6-cp313-cp313-win32.whl", hash = "sha256:d7de2637729c67d67cf87614b566626057e95c303bc0a55ffe391f5205e7003d", size = 143940, upload-time = "2026-03-15T18:51:36.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5c/724b6b363603e419829f561c854b87ed7c7e31231a7908708ac086cdf3e2/charset_normalizer-3.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:572d7c822caf521f0525ba1bce1a622a0b85cf47ffbdae6c9c19e3b5ac3c4389", size = 154101, upload-time = "2026-03-15T18:51:37.876Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a5/7abf15b4c0968e47020f9ca0935fb3274deb87cb288cd187cad92e8cdffd/charset_normalizer-3.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a4474d924a47185a06411e0064b803c68be044be2d60e50e8bddcc2649957c1f", size = 143109, upload-time = "2026-03-15T18:51:39.565Z" },
+    { url = "https://files.pythonhosted.org/packages/25/6f/ffe1e1259f384594063ea1869bfb6be5cdb8bc81020fc36c3636bc8302a1/charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8", size = 294458, upload-time = "2026-03-15T18:51:41.134Z" },
+    { url = "https://files.pythonhosted.org/packages/56/60/09bb6c13a8c1016c2ed5c6a6488e4ffef506461aa5161662bd7636936fb1/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421", size = 199277, upload-time = "2026-03-15T18:51:42.953Z" },
+    { url = "https://files.pythonhosted.org/packages/00/50/dcfbb72a5138bbefdc3332e8d81a23494bf67998b4b100703fd15fa52d81/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2", size = 218758, upload-time = "2026-03-15T18:51:44.339Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b3/d79a9a191bb75f5aa81f3aaaa387ef29ce7cb7a9e5074ba8ea095cc073c2/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30", size = 215299, upload-time = "2026-03-15T18:51:45.871Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7e/bc8911719f7084f72fd545f647601ea3532363927f807d296a8c88a62c0d/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db", size = 206811, upload-time = "2026-03-15T18:51:47.308Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/40/c430b969d41dda0c465aa36cc7c2c068afb67177bef50905ac371b28ccc7/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8", size = 193706, upload-time = "2026-03-15T18:51:48.849Z" },
+    { url = "https://files.pythonhosted.org/packages/48/15/e35e0590af254f7df984de1323640ef375df5761f615b6225ba8deb9799a/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815", size = 202706, upload-time = "2026-03-15T18:51:50.257Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bd/f736f7b9cc5e93a18b794a50346bb16fbfd6b37f99e8f306f7951d27c17c/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a", size = 202497, upload-time = "2026-03-15T18:51:52.012Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ba/2cc9e3e7dfdf7760a6ed8da7446d22536f3d0ce114ac63dee2a5a3599e62/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43", size = 193511, upload-time = "2026-03-15T18:51:53.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cb/5be49b5f776e5613be07298c80e1b02a2d900f7a7de807230595c85a8b2e/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0", size = 220133, upload-time = "2026-03-15T18:51:55.333Z" },
+    { url = "https://files.pythonhosted.org/packages/83/43/99f1b5dad345accb322c80c7821071554f791a95ee50c1c90041c157ae99/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1", size = 203035, upload-time = "2026-03-15T18:51:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9a/62c2cb6a531483b55dddff1a68b3d891a8b498f3ca555fbcf2978e804d9d/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f", size = 216321, upload-time = "2026-03-15T18:51:58.17Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/79/94a010ff81e3aec7c293eb82c28f930918e517bc144c9906a060844462eb/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815", size = 208973, upload-time = "2026-03-15T18:51:59.998Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/57/4ecff6d4ec8585342f0c71bc03efaa99cb7468f7c91a57b105bcd561cea8/charset_normalizer-3.4.6-cp314-cp314-win32.whl", hash = "sha256:b4ff1d35e8c5bd078be89349b6f3a845128e685e751b6ea1169cf2160b344c4d", size = 144610, upload-time = "2026-03-15T18:52:02.213Z" },
+    { url = "https://files.pythonhosted.org/packages/80/94/8434a02d9d7f168c25767c64671fead8d599744a05d6a6c877144c754246/charset_normalizer-3.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:74119174722c4349af9708993118581686f343adc1c8c9c007d59be90d077f3f", size = 154962, upload-time = "2026-03-15T18:52:03.658Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4c/48f2cdbfd923026503dfd67ccea45c94fd8fe988d9056b468579c66ed62b/charset_normalizer-3.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:e5bcc1a1ae744e0bb59641171ae53743760130600da8db48cbb6e4918e186e4e", size = 143595, upload-time = "2026-03-15T18:52:05.123Z" },
+    { url = "https://files.pythonhosted.org/packages/31/93/8878be7569f87b14f1d52032946131bcb6ebbd8af3e20446bc04053dc3f1/charset_normalizer-3.4.6-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ad8faf8df23f0378c6d527d8b0b15ea4a2e23c89376877c598c4870d1b2c7866", size = 314828, upload-time = "2026-03-15T18:52:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b6/fae511ca98aac69ecc35cde828b0a3d146325dd03d99655ad38fc2cc3293/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc", size = 208138, upload-time = "2026-03-15T18:52:08.239Z" },
+    { url = "https://files.pythonhosted.org/packages/54/57/64caf6e1bf07274a1e0b7c160a55ee9e8c9ec32c46846ce59b9c333f7008/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e", size = 224679, upload-time = "2026-03-15T18:52:10.043Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cb/9ff5a25b9273ef160861b41f6937f86fae18b0792fe0a8e75e06acb08f1d/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077", size = 223475, upload-time = "2026-03-15T18:52:11.854Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/97/440635fc093b8d7347502a377031f9605a1039c958f3cd18dcacffb37743/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f", size = 215230, upload-time = "2026-03-15T18:52:13.325Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/24/afff630feb571a13f07c8539fbb502d2ab494019492aaffc78ef41f1d1d0/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e", size = 199045, upload-time = "2026-03-15T18:52:14.752Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/17/d1399ecdaf7e0498c327433e7eefdd862b41236a7e484355b8e0e5ebd64b/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484", size = 211658, upload-time = "2026-03-15T18:52:16.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/38/16baa0affb957b3d880e5ac2144caf3f9d7de7bc4a91842e447fbb5e8b67/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7", size = 210769, upload-time = "2026-03-15T18:52:17.782Z" },
+    { url = "https://files.pythonhosted.org/packages/05/34/c531bc6ac4c21da9ddfddb3107be2287188b3ea4b53b70fc58f2a77ac8d8/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff", size = 201328, upload-time = "2026-03-15T18:52:19.553Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/73/a5a1e9ca5f234519c1953608a03fe109c306b97fdfb25f09182babad51a7/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e", size = 225302, upload-time = "2026-03-15T18:52:21.043Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/f6/cd782923d112d296294dea4bcc7af5a7ae0f86ab79f8fefbda5526b6cfc0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659", size = 211127, upload-time = "2026-03-15T18:52:22.491Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/c5/0b6898950627af7d6103a449b22320372c24c6feda91aa24e201a478d161/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602", size = 222840, upload-time = "2026-03-15T18:52:24.113Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/25/c4bba773bef442cbdc06111d40daa3de5050a676fa26e85090fc54dd12f0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407", size = 216890, upload-time = "2026-03-15T18:52:25.541Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1a/05dacadb0978da72ee287b0143097db12f2e7e8d3ffc4647da07a383b0b7/charset_normalizer-3.4.6-cp314-cp314t-win32.whl", hash = "sha256:2a24157fa36980478dd1770b585c0f30d19e18f4fb0c47c13aa568f871718579", size = 155379, upload-time = "2026-03-15T18:52:27.05Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7a/d269d834cb3a76291651256f3b9a5945e81d0a49ab9f4a498964e83c0416/charset_normalizer-3.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:cd5e2801c89992ed8c0a3f0293ae83c159a60d9a5d685005383ef4caca77f2c4", size = 169043, upload-time = "2026-03-15T18:52:28.502Z" },
+    { url = "https://files.pythonhosted.org/packages/23/06/28b29fba521a37a8932c6a84192175c34d49f84a6d4773fa63d05f9aff22/charset_normalizer-3.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:47955475ac79cc504ef2704b192364e51d0d473ad452caedd0002605f780101c", size = 148523, upload-time = "2026-03-15T18:52:29.956Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/68/687187c7e26cb24ccbd88e5069f5ef00eba804d36dde11d99aad0838ab45/charset_normalizer-3.4.6-py3-none-any.whl", hash = "sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69", size = 61455, upload-time = "2026-03-15T18:53:23.833Z" },
+]
+
+[[package]]
 name = "editorconfig"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -12,15 +110,30 @@ wheels = [
 ]
 
 [[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
 name = "infrastructure-actions-utils"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "jsbeautifier" },
+    { name = "requests" },
+    { name = "rich" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "jsbeautifier", specifier = ">=1.15" }]
+requires-dist = [
+    { name = "jsbeautifier", specifier = ">=1.15" },
+    { name = "requests", specifier = ">=2.31" },
+    { name = "rich", specifier = ">=13.0" },
+]
 
 [[package]]
 name = "jsbeautifier"
@@ -36,10 +149,77 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]

--- a/utils/verify-action-build.py
+++ b/utils/verify-action-build.py
@@ -2,6 +2,7 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #     "jsbeautifier>=1.15",
+#     "requests>=2.31",
 #     "rich>=13.0",
 # ]
 # ///
@@ -19,6 +20,8 @@ Usage:
 import argparse
 import difflib
 import json
+import os
+import re
 import shutil
 import subprocess
 import sys
@@ -26,6 +29,7 @@ import tempfile
 from pathlib import Path
 
 import jsbeautifier
+import requests
 from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Confirm
@@ -37,6 +41,227 @@ output = Console()
 
 # Path to the actions.yml file relative to the script
 ACTIONS_YML = Path(__file__).resolve().parent.parent / "actions.yml"
+
+GITHUB_API = "https://api.github.com"
+
+
+def _detect_repo() -> str:
+    """Detect the GitHub repo from the git remote origin URL."""
+    result = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        capture_output=True, text=True, cwd=ACTIONS_YML.parent,
+    )
+    if result.returncode == 0:
+        url = result.stdout.strip()
+        # Handle SSH (git@github.com:org/repo.git) and HTTPS (https://github.com/org/repo.git)
+        match = re.search(r"github\.com[:/](.+?)(?:\.git)?$", url)
+        if match:
+            return match.group(1)
+    return "apache/infrastructure-actions"
+
+
+class GitHubClient:
+    """Abstraction over GitHub API — uses either gh CLI or requests with a token."""
+
+    def __init__(self, token: str | None = None, repo: str | None = None):
+        self.repo = repo or _detect_repo()
+        self.token = token
+        self._use_requests = token is not None
+
+    def _headers(self) -> dict:
+        return {
+            "Authorization": f"token {self.token}",
+            "Accept": "application/vnd.github+json",
+        }
+
+    def _gh_api(self, endpoint: str) -> dict | list | None:
+        """Call gh api and return parsed JSON, or None on failure."""
+        result = subprocess.run(
+            ["gh", "api", endpoint],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return json.loads(result.stdout)
+        return None
+
+    def _get(self, endpoint: str) -> dict | list | None:
+        """GET from GitHub API using requests or gh CLI."""
+        if self._use_requests:
+            resp = requests.get(f"{GITHUB_API}/{endpoint}", headers=self._headers())
+            if resp.ok:
+                return resp.json()
+            return None
+        return self._gh_api(endpoint)
+
+    def get_commit_pulls(self, owner: str, repo: str, commit_sha: str) -> list[dict]:
+        """Get PRs associated with a commit."""
+        data = self._get(f"repos/{owner}/{repo}/commits/{commit_sha}/pulls")
+        return data if isinstance(data, list) else []
+
+    def compare_commits(self, owner: str, repo: str, base: str, head: str) -> list[dict]:
+        """Get commits between two refs."""
+        data = self._get(f"repos/{owner}/{repo}/compare/{base}...{head}")
+        if isinstance(data, dict):
+            return data.get("commits", [])
+        return []
+
+    def get_pr_diff(self, pr_number: int) -> str | None:
+        """Get the diff for a PR."""
+        if self._use_requests:
+            resp = requests.get(
+                f"{GITHUB_API}/repos/{self.repo}/pulls/{pr_number}",
+                headers={**self._headers(), "Accept": "application/vnd.github.v3.diff"},
+            )
+            return resp.text if resp.ok else None
+        result = subprocess.run(
+            ["gh", "pr", "diff", str(pr_number)],
+            capture_output=True, text=True,
+        )
+        return result.stdout if result.returncode == 0 else None
+
+    def get_authenticated_user(self) -> str:
+        """Get the login of the authenticated user."""
+        if self._use_requests:
+            resp = requests.get(f"{GITHUB_API}/user", headers=self._headers())
+            if resp.ok:
+                return resp.json().get("login", "unknown")
+            return "unknown"
+        result = subprocess.run(
+            ["gh", "api", "user", "--jq", ".login"],
+            capture_output=True, text=True,
+        )
+        return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+    def list_open_prs(self, author: str = "app/dependabot") -> list[dict]:
+        """List open PRs by author with status check info."""
+        if self._use_requests:
+            prs = []
+            page = 1
+            while True:
+                resp = requests.get(
+                    f"{GITHUB_API}/repos/{self.repo}/pulls",
+                    headers=self._headers(),
+                    params={"state": "open", "per_page": 50, "page": page},
+                )
+                if not resp.ok:
+                    break
+                batch = resp.json()
+                if not batch:
+                    break
+                for pr in batch:
+                    pr_login = pr.get("user", {}).get("login", "")
+                    if author.startswith("app/"):
+                        expected = author.split("/", 1)[1] + "[bot]"
+                        if pr_login != expected:
+                            continue
+                    elif pr_login != author:
+                        continue
+                    prs.append({
+                        "number": pr["number"],
+                        "title": pr["title"],
+                        "headRefName": pr["head"]["ref"],
+                        "url": pr["html_url"],
+                        "reviewDecision": self._get_review_decision(pr["number"]),
+                        "statusCheckRollup": self._get_status_checks(pr["head"]["sha"]),
+                    })
+                page += 1
+            return prs
+        result = subprocess.run(
+            [
+                "gh", "pr", "list",
+                "--author", author,
+                "--state", "open",
+                "--json", "number,title,headRefName,url,reviewDecision,statusCheckRollup",
+                "--limit", "50",
+            ],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return json.loads(result.stdout)
+        return []
+
+    def _get_review_decision(self, pr_number: int) -> str | None:
+        """Get the review decision for a PR via GraphQL."""
+        resp = requests.post(
+            f"{GITHUB_API}/graphql",
+            headers=self._headers(),
+            json={
+                "query": """query($owner:String!, $repo:String!, $number:Int!) {
+                    repository(owner:$owner, name:$repo) {
+                        pullRequest(number:$number) { reviewDecision }
+                    }
+                }""",
+                "variables": {
+                    "owner": self.repo.split("/")[0],
+                    "repo": self.repo.split("/")[1],
+                    "number": pr_number,
+                },
+            },
+        )
+        if resp.ok:
+            data = resp.json()
+            return (
+                data.get("data", {})
+                .get("repository", {})
+                .get("pullRequest", {})
+                .get("reviewDecision")
+            )
+        return None
+
+    def _get_status_checks(self, sha: str) -> list[dict]:
+        """Get combined status checks for a commit SHA."""
+        data = self._get(f"repos/{self.repo}/commits/{sha}/check-runs")
+        if isinstance(data, dict):
+            return [
+                {
+                    "name": cr.get("name"),
+                    "conclusion": (cr.get("conclusion") or "").upper(),
+                    "status": (cr.get("status") or "").upper(),
+                }
+                for cr in data.get("check_runs", [])
+            ]
+        return []
+
+    def approve_pr(self, pr_number: int, comment: str) -> bool:
+        """Approve a PR with a review comment."""
+        if self._use_requests:
+            resp = requests.post(
+                f"{GITHUB_API}/repos/{self.repo}/pulls/{pr_number}/reviews",
+                headers=self._headers(),
+                json={"body": comment, "event": "APPROVE"},
+            )
+            return resp.ok
+        result = subprocess.run(
+            ["gh", "pr", "review", str(pr_number), "--approve", "--body", comment],
+            capture_output=True, text=True,
+        )
+        return result.returncode == 0
+
+    def merge_pr(self, pr_number: int) -> tuple[bool, str]:
+        """Merge a PR and delete the branch. Returns (success, error_msg)."""
+        if self._use_requests:
+            resp = requests.put(
+                f"{GITHUB_API}/repos/{self.repo}/pulls/{pr_number}/merge",
+                headers=self._headers(),
+                json={"merge_method": "merge"},
+            )
+            if not resp.ok:
+                return False, resp.text
+            # Delete the head branch
+            pr_data = self._get(f"repos/{self.repo}/pulls/{pr_number}")
+            if isinstance(pr_data, dict):
+                branch = pr_data.get("head", {}).get("ref")
+                if branch:
+                    requests.delete(
+                        f"{GITHUB_API}/repos/{self.repo}/git/refs/heads/{branch}",
+                        headers=self._headers(),
+                    )
+            return True, ""
+        result = subprocess.run(
+            ["gh", "pr", "merge", str(pr_number), "--merge", "--delete-branch"],
+            capture_output=True, text=True,
+        )
+        return result.returncode == 0, result.stderr.strip()
 
 
 def parse_action_ref(ref: str) -> tuple[str, str, str, str]:
@@ -83,8 +308,6 @@ def find_approved_versions(org: str, repo: str) -> list[dict]:
     if not ACTIONS_YML.exists():
         return []
 
-    import re
-
     content = ACTIONS_YML.read_text()
     lines = content.splitlines()
 
@@ -129,7 +352,7 @@ def find_approved_versions(org: str, repo: str) -> list[dict]:
     return approved
 
 
-def find_approval_info(action_hash: str) -> dict | None:
+def find_approval_info(action_hash: str, gh: GitHubClient | None = None) -> dict | None:
     """Find who approved a hash and when, by searching git history and PRs."""
     # Find the commit that added this hash to actions.yml
     result = subprocess.run(
@@ -152,29 +375,26 @@ def find_approval_info(action_hash: str) -> dict | None:
         "subject": subject,
     }
 
+    if gh is None:
+        return info
+
     # Try to find the PR that merged this commit
-    pr_result = subprocess.run(
-        ["gh", "api", f"repos/apache/infrastructure-actions/commits/{commit_hash}/pulls",
-         "--jq", ".[0] | {number, title, merged_by: .merged_by.login, merged_at: .merged_at}"],
-        capture_output=True,
-        text=True,
-    )
-    if pr_result.returncode == 0 and pr_result.stdout.strip():
-        try:
-            pr_info = json.loads(pr_result.stdout.strip())
-            if pr_info.get("number"):
-                info["pr_number"] = pr_info["number"]
-                info["pr_title"] = pr_info.get("title", "")
-                info["merged_by"] = pr_info.get("merged_by", "")
-                info["merged_at"] = pr_info.get("merged_at", "")
-        except json.JSONDecodeError:
-            pass
+    owner, repo_name = gh.repo.split("/", 1)
+    pulls = gh.get_commit_pulls(owner, repo_name, commit_hash)
+    if pulls:
+        pr_info = pulls[0]
+        if pr_info.get("number"):
+            info["pr_number"] = pr_info["number"]
+            info["pr_title"] = pr_info.get("title", "")
+            info["merged_by"] = (pr_info.get("merged_by") or {}).get("login", "")
+            info["merged_at"] = pr_info.get("merged_at", "")
 
     return info
 
 
 def show_approved_versions(
-    org: str, repo: str, new_hash: str, approved: list[dict]
+    org: str, repo: str, new_hash: str, approved: list[dict],
+    gh: GitHubClient | None = None,
 ) -> str | None:
     """Display approved versions and ask if user wants to diff against one.
 
@@ -194,7 +414,7 @@ def show_approved_versions(
         if entry["hash"] == new_hash:
             continue
 
-        approval = find_approval_info(entry["hash"])
+        approval = find_approval_info(entry["hash"], gh=gh)
 
         tag = entry.get("tag", "")
         hash_link = f"[link=https://github.com/{org}/{repo}/commit/{entry['hash']}]{entry['hash'][:12]}[/link]"
@@ -257,31 +477,30 @@ def show_approved_versions(
 
 
 def show_commits_between(
-    org: str, repo: str, old_hash: str, new_hash: str
+    org: str, repo: str, old_hash: str, new_hash: str,
+    gh: GitHubClient | None = None,
 ) -> None:
     """Show the list of commits between two hashes using GitHub compare API."""
     console.print()
     compare_url = f"https://github.com/{org}/{repo}/compare/{old_hash[:12]}...{new_hash[:12]}?file-filters%5B%5D=%21dist"
     console.rule("[bold]Commits Between Versions[/bold]")
 
-    result = subprocess.run(
-        ["gh", "api", f"repos/{org}/{repo}/compare/{old_hash}...{new_hash}",
-         "--jq", ".commits[] | {sha: .sha, message: (.commit.message | split(\"\\n\") | .[0]), author: .commit.author.name, date: .commit.author.date}"],
-        capture_output=True,
-        text=True,
-    )
-
-    if result.returncode != 0 or not result.stdout.strip():
+    raw_commits = gh.compare_commits(org, repo, old_hash, new_hash) if gh else []
+    if not raw_commits and not gh:
+        # Fallback: should not happen if gh is always provided, but kept for safety
         console.print(f"  [yellow]Could not fetch commits. View on GitHub:[/yellow]")
         console.print(f"  [link={compare_url}]{compare_url}[/link]")
         return
 
-    commits = []
-    for line in result.stdout.strip().splitlines():
-        try:
-            commits.append(json.loads(line))
-        except json.JSONDecodeError:
-            continue
+    commits = [
+        {
+            "sha": c.get("sha", ""),
+            "message": (c.get("commit", {}).get("message", "") or "").split("\n")[0],
+            "author": c.get("commit", {}).get("author", {}).get("name", ""),
+            "date": c.get("commit", {}).get("author", {}).get("date", ""),
+        }
+        for c in raw_commits
+    ]
 
     if not commits:
         console.print(f"  [dim]No commits found between these versions[/dim]")
@@ -982,7 +1201,7 @@ def _format_diff_text(lines: list[str]) -> Text:
     return diff_text
 
 
-def verify_single_action(action_ref: str) -> bool:
+def verify_single_action(action_ref: str, gh: GitHubClient | None = None) -> bool:
     """Verify a single action reference. Returns True if verification passed."""
     org, repo, sub_path, commit_hash = parse_action_ref(action_ref)
 
@@ -1013,9 +1232,9 @@ def verify_single_action(action_ref: str) -> bool:
         # Check for previously approved versions and offer to diff
         approved = find_approved_versions(org, repo)
         if approved:
-            selected_hash = show_approved_versions(org, repo, commit_hash, approved)
+            selected_hash = show_approved_versions(org, repo, commit_hash, approved, gh=gh)
             if selected_hash:
-                show_commits_between(org, repo, selected_hash, commit_hash)
+                show_commits_between(org, repo, selected_hash, commit_hash, gh=gh)
                 diff_approved_vs_new(org, repo, selected_hash, commit_hash, work_dir)
         elif not is_js_action:
             console.print(
@@ -1042,24 +1261,20 @@ def verify_single_action(action_ref: str) -> bool:
     return all_match
 
 
-def extract_action_refs_from_pr(pr_number: int) -> list[str]:
+def extract_action_refs_from_pr(pr_number: int, gh: GitHubClient | None = None) -> list[str]:
     """Extract all new action org/repo[/sub]@hash refs from a dependabot PR diff.
 
     Returns a deduplicated list of action references found in added lines.
     """
-    result = subprocess.run(
-        ["gh", "pr", "diff", str(pr_number)],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
+    if gh is None:
         return []
-
-    import re
+    diff_text = gh.get_pr_diff(pr_number)
+    if not diff_text:
+        return []
 
     seen: set[str] = set()
     refs: list[str] = []
-    for line in result.stdout.splitlines():
+    for line in diff_text.splitlines():
         # Match lines like: +      - uses: org/repo/sub@hash  # tag
         match = re.search(r"^\+.*uses:\s+([^@\s]+)@([0-9a-f]{40})", line)
         if match:
@@ -1073,41 +1288,20 @@ def extract_action_refs_from_pr(pr_number: int) -> list[str]:
     return refs
 
 
-def get_gh_user() -> str:
+def get_gh_user(gh: GitHubClient | None = None) -> str:
     """Get the currently authenticated GitHub username."""
-    result = subprocess.run(
-        ["gh", "api", "user", "--jq", ".login"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode == 0:
-        return result.stdout.strip()
-    return "unknown"
+    if gh is None:
+        return "unknown"
+    return gh.get_authenticated_user()
 
 
-def check_dependabot_prs() -> None:
+def check_dependabot_prs(gh: GitHubClient) -> None:
     """List open dependabot PRs, verify each, and optionally merge."""
     console.print()
     console.rule("[bold]Dependabot PR Review[/bold]")
 
     with console.status("[bold blue]Fetching open dependabot PRs...[/bold blue]"):
-        result = subprocess.run(
-            [
-                "gh", "pr", "list",
-                "--author", "app/dependabot",
-                "--state", "open",
-                "--json", "number,title,headRefName,url,reviewDecision,statusCheckRollup",
-                "--limit", "50",
-            ],
-            capture_output=True,
-            text=True,
-        )
-
-    if result.returncode != 0 or not result.stdout.strip():
-        console.print("[yellow]Could not fetch dependabot PRs[/yellow]")
-        return
-
-    all_prs = json.loads(result.stdout)
+        all_prs = gh.list_open_prs(author="app/dependabot")
 
     if not all_prs:
         console.print("[green]No open dependabot PRs found[/green]")
@@ -1184,7 +1378,7 @@ def check_dependabot_prs() -> None:
     ):
         return
 
-    gh_user = get_gh_user()
+    gh_user = get_gh_user(gh=gh)
     reviewed: list[dict] = []
     failed: list[dict] = []
 
@@ -1194,7 +1388,7 @@ def check_dependabot_prs() -> None:
 
         # Extract all action references from PR diff
         with console.status("[bold blue]Extracting action references from PR...[/bold blue]"):
-            action_refs = extract_action_refs_from_pr(pr["number"])
+            action_refs = extract_action_refs_from_pr(pr["number"], gh=gh)
 
         if not action_refs:
             console.print(
@@ -1235,11 +1429,11 @@ def check_dependabot_prs() -> None:
                         sub_ref = f"{org_repo}/{sp}@{commit_hash}"
                     else:
                         sub_ref = f"{org_repo}@{commit_hash}"
-                    if not verify_single_action(sub_ref):
+                    if not verify_single_action(sub_ref, gh=gh):
                         passed = False
             else:
                 # Simple single action (no sub-path)
-                if not verify_single_action(f"{org_repo}@{commit_hash}"):
+                if not verify_single_action(f"{org_repo}@{commit_hash}", gh=gh):
                     passed = False
 
         if not passed:
@@ -1273,26 +1467,17 @@ def check_dependabot_prs() -> None:
         )
 
         console.print(f"  [dim]Adding review comment...[/dim]")
-        comment_result = subprocess.run(
-            ["gh", "pr", "review", str(pr["number"]), "--approve", "--body", comment],
-            capture_output=True,
-            text=True,
-        )
-        if comment_result.returncode != 0:
-            console.print(f"  [yellow]Warning: could not add review comment: {comment_result.stderr.strip()}[/yellow]")
+        if not gh.approve_pr(pr["number"], comment):
+            console.print(f"  [yellow]Warning: could not add review comment[/yellow]")
 
         console.print(f"  [dim]Merging PR #{pr['number']}...[/dim]")
-        merge_result = subprocess.run(
-            ["gh", "pr", "merge", str(pr["number"]), "--merge", "--delete-branch"],
-            capture_output=True,
-            text=True,
-        )
-        if merge_result.returncode == 0:
+        success, err = gh.merge_pr(pr["number"])
+        if success:
             console.print(f"  [green]✓ PR #{pr['number']} merged successfully[/green]")
             reviewed.append(pr)
         else:
             console.print(
-                f"  [red]Failed to merge PR #{pr['number']}: {merge_result.stderr.strip()}[/red]"
+                f"  [red]Failed to merge PR #{pr['number']}: {err}[/red]"
             )
             failed.append(pr)
 
@@ -1334,19 +1519,44 @@ def main() -> None:
         action="store_true",
         help="Review open dependabot PRs: verify each action, optionally approve and merge",
     )
+    parser.add_argument(
+        "--no-gh",
+        action="store_true",
+        help="Use the GitHub REST API via requests instead of the gh CLI",
+    )
+    parser.add_argument(
+        "--github-token",
+        default=os.environ.get("GITHUB_TOKEN"),
+        help="GitHub token for API access (default: $GITHUB_TOKEN env var). Required with --no-gh",
+    )
     args = parser.parse_args()
 
     if not shutil.which("docker"):
         console.print("[red]Error:[/red] docker is required but not found in PATH")
         sys.exit(1)
 
-    if args.check_dependabot_prs:
-        if not shutil.which("gh"):
-            console.print("[red]Error:[/red] gh (GitHub CLI) is required for --check-dependabot-prs")
+    # Build the GitHub client
+    if args.no_gh:
+        if not args.github_token:
+            console.print(
+                "[red]Error:[/red] --no-gh requires a GitHub token. "
+                "Pass --github-token TOKEN or set the GITHUB_TOKEN environment variable."
+            )
             sys.exit(1)
-        check_dependabot_prs()
+        gh = GitHubClient(token=args.github_token)
+    else:
+        if not shutil.which("gh"):
+            console.print(
+                "[red]Error:[/red] gh (GitHub CLI) is not installed. "
+                "Either install gh or use --no-gh with a --github-token."
+            )
+            sys.exit(1)
+        gh = GitHubClient(token=args.github_token)
+
+    if args.check_dependabot_prs:
+        check_dependabot_prs(gh=gh)
     elif args.action_ref:
-        passed = verify_single_action(args.action_ref)
+        passed = verify_single_action(args.action_ref, gh=gh)
         sys.exit(0 if passed else 1)
     else:
         parser.print_help()


### PR DESCRIPTION
## Summary

- Adds `GitHubClient` class abstracting all GitHub API calls behind a unified interface
- Adds `--no-gh` flag to use Python `requests` instead of the `gh` CLI
- Adds `--github-token` flag (defaults to `$GITHUB_TOKEN` env var) for API authentication
- Adds `requests>=2.31` to utils dependencies
- Documents the new mode in README under "Running Without the `gh` CLI"

Some users may not have or want to install the `gh` CLI. This gives them a fully functional alternative using just a GitHub token.

## Test plan

- [ ] Verify `--no-gh --github-token` works for single action verification
- [ ] Verify `--no-gh --check-dependabot-prs` lists and processes PRs correctly
- [ ] Verify default `gh` CLI mode still works unchanged
- [ ] Verify `--no-gh` without token shows clear error message

Generated-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>