### PR TITLE
Fix `pypa/gh-action-pypi-publish`: pin to commit SHA instead of branch pattern

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -675,7 +675,7 @@ pypa/gh-action-pip-audit:
     tag: v1.1.0
     expires_at: 2026-03-31
 pypa/gh-action-pypi-publish:
-  'ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e':
+  ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e:
     keep: true
     tag: v1.13.0
 pyTooling/Actions:


### PR DESCRIPTION
`pypa/gh-action-pypi-publish` was pinned to `release/v1*` (a branch pattern) instead of an exact commit SHA, violating the [pinning policy](https://github.com/apache/infrastructure-actions#adding-a-new-action-to-the-allow-list).

Updated to pin to [`ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e`](https://github.com/pypa/gh-action-pypi-publish/commit/ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e) (v1.13.0).