### PR TITLE
Fix `dtolnay/rust-toolchain`: pin to commit SHA instead of branch name

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -310,8 +310,9 @@ dorny/test-reporter:
   a43b3a5f7366b97d083190328d2c652e1a8b6aa2:
     tag: v3.0.0
 dtolnay/rust-toolchain:
-  stable:
+  '29eef336d9b2848a0b548edc03f92a220660cdb8':
     keep: true
+    tag: stable
 easimon/maximize-build-space:
   '*':
     keep: true


### PR DESCRIPTION
`dtolnay/rust-toolchain` was pinned to `stable` (a branch name) instead of an exact commit SHA, violating the [pinning policy](https://github.com/apache/infrastructure-actions#adding-a-new-action-to-the-allow-list).

Updated to pin to [`29eef336d9b2848a0b548edc03f92a220660cdb8`](https://github.com/dtolnay/rust-toolchain/commit/29eef336d9b2848a0b548edc03f92a220660cdb8) (current HEAD of `stable`).