### PR TITLE
remove gaurav-nelson/github-action-markdown-link-check

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -331,9 +331,6 @@ erisu/apache-rat-action:
 erisu/license-checker-action:
   99cffa11264fe545fd0baa6c13bca5a00ae608f2:
     tag: v2.0.1
-gaurav-nelson/github-action-markdown-link-check:
-  '*':
-    keep: true
 geekyeggo/delete-artifact:
   '*':
     keep: true


### PR DESCRIPTION
Closes #371

Remove `gaurav-nelson/github-action-markdown-link-check` in favor of `tcort/github-action-markdown-link-check`, which is the recommended and actively maintained fork

Already helped all repos in the apache org to migrate (See #371)