### PR TITLE
Fix verify-action-build.py Node.js version detection

### DIFF
--- a/utils/verify-action-build.py
+++ b/utils/verify-action-build.py
@@ -722,7 +722,8 @@ def diff_approved_vs_new(
 
 
 DOCKERFILE_TEMPLATE = """\
-FROM node:20-slim
+ARG NODE_VERSION=20
+FROM node:${NODE_VERSION}-slim
 
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 RUN corepack enable
@@ -855,9 +856,42 @@ RUN OUT_DIR=$(cat /out-dir.txt); \
 """
 
 
+def detect_node_version(
+    org: str, repo: str, commit_hash: str, sub_path: str = "",
+    gh: GitHubClient | None = None,
+) -> str:
+    """Detect the Node.js major version from the action's using: field.
+
+    Fetches action.yml from GitHub at the given commit and extracts the
+    node version (e.g. 'node20' -> '20').  Falls back to '20' if detection fails.
+    """
+    # Try action.yml then action.yaml, in sub_path first if given
+    candidates = []
+    if sub_path:
+        candidates.extend([f"{sub_path}/action.yml", f"{sub_path}/action.yaml"])
+    candidates.extend(["action.yml", "action.yaml"])
+
+    for path in candidates:
+        url = f"https://raw.githubusercontent.com/{org}/{repo}/{commit_hash}/{path}"
+        try:
+            resp = requests.get(url, timeout=10)
+            if not resp.ok:
+                continue
+            for line in resp.text.splitlines():
+                match = re.match(r"\s+using:\s*['\"]?(node\d+)['\"]?", line)
+                if match:
+                    version = match.group(1).replace("node", "")
+                    return version
+        except requests.RequestException:
+            continue
+
+    return "20"
+
+
 def build_in_docker(
     org: str, repo: str, commit_hash: str, work_dir: Path,
     sub_path: str = "",
+    gh: GitHubClient | None = None,
 ) -> tuple[Path, Path, str, str]:
     """Build the action in a Docker container and extract original + rebuilt dist.
 
@@ -891,6 +925,11 @@ def build_in_docker(
     console.print()
     console.print(Panel(info_table, title="Action Build Verification", border_style="blue"))
 
+    # Detect Node.js version from action.yml before building
+    node_version = detect_node_version(org, repo, commit_hash, sub_path, gh=gh)
+    if node_version != "20":
+        console.print(f"  [green]✓[/green] Detected Node.js version: [bold]node{node_version}[/bold]")
+
     with console.status("[bold blue]Building Docker image...[/bold blue]") as status:
         # Build Docker image
         status.update("[bold blue]Cloning repository and building action...[/bold blue]")
@@ -898,6 +937,8 @@ def build_in_docker(
             [
                 "docker",
                 "build",
+                "--build-arg",
+                f"NODE_VERSION={node_version}",
                 "--build-arg",
                 f"REPO_URL={repo_url}",
                 "--build-arg",
@@ -1219,7 +1260,7 @@ def verify_single_action(action_ref: str, gh: GitHubClient | None = None, ci_mod
     with tempfile.TemporaryDirectory(prefix="verify-action-") as tmp:
         work_dir = Path(tmp)
         original_dir, rebuilt_dir, action_type, out_dir_name = build_in_docker(
-            org, repo, commit_hash, work_dir, sub_path=sub_path,
+            org, repo, commit_hash, work_dir, sub_path=sub_path, gh=gh,
         )
 
         # Non-JavaScript actions (docker, composite) don't have compiled JS to verify
@@ -1287,7 +1328,8 @@ def extract_action_refs_from_pr(pr_number: int, gh: GitHubClient | None = None) 
     refs: list[str] = []
     for line in diff_text.splitlines():
         # Match lines like: +      - uses: org/repo/sub@hash  # tag
-        match = re.search(r"^\+.*uses:\s+([^@\s]+)@([0-9a-f]{40})", line)
+        # Also match 'use:' (common typo for 'uses:')
+        match = re.search(r"^\+.*uses?:\s+([^@\s]+)@([0-9a-f]{40})", line)
         if match:
             action_path = match.group(1)
             commit_hash = match.group(2)


### PR DESCRIPTION
## Summary

- **Fix Node.js version mismatch in Docker rebuild** — the container was hardcoded to `node:20-slim`, so actions built with a different Node.js version (e.g. `node24`) produced large spurious diffs. Now detects the version from the action's `using:` field before building.
- **Fix PR extraction regex** — the regex only matched `uses:` but PR #491 had a `use:` typo in `dummy.yml`, preventing ref extraction. Changed to `uses?:` to handle both.

## Root cause

**PR #576** (`azure/setup-helm` v4.3.1 → v5.0.0): v5.0.0 switched from `node20` to `node24` ([azure/setup-helm#259](https://github.com/Azure/setup-helm/pull/259)). The verify script rebuilt the action inside a `node:20-slim` container, so the compiled JS differed from the original (built with node24), producing a large false-positive diff.

**PR #566** (`editorconfig-checker/action-editorconfig-checker` v2.1.0 → v2.2.0): same issue — v2.2.0 switched from `node20` to `node24` ([editorconfig-checker/action-editorconfig-checker#252](https://github.com/editorconfig-checker/action-editorconfig-checker/pull/252)).

**PR #491** (`editorconfig-checker/action-editorconfig-checker`): the `dummy.yml` entry was submitted with `use:` instead of `uses:`. The extraction regex `^\+.*uses:\s+` didn't match, so `--from-pr 491` found no action refs.

## Changes

1. `DOCKERFILE_TEMPLATE` now accepts a `NODE_VERSION` build arg (defaults to `20`)
2. New `detect_node_version()` function fetches `action.yml` from GitHub at the target commit and parses the `using:` field to determine the correct Node.js major version
3. `build_in_docker()` passes the detected version to Docker
4. `extract_action_refs_from_pr()` regex changed from `uses:` to `uses?:` to also match the `use:` typo

## Test plan

- [ ] Run `uv run utils/verify-action-build.py --from-pr 576` — should now use `node:24-slim` and show minimal/no JS diffs
- [ ] Run `uv run utils/verify-action-build.py --from-pr 566` — should now use `node:24-slim` and show minimal/no JS diffs
- [ ] Run against a node20 action to verify the default still works

Generated-by: Claude