### PR TITLE
allowlist-check: verbose output and gh command to create allowlist PR

### DIFF
--- a/allowlist-check/check_asf_allowlist.py
+++ b/allowlist-check/check_asf_allowlist.py
@@ -149,58 +149,49 @@ def is_allowed(action_ref: str, allowlist: list[str]) -> bool:
     return any(fnmatch.fnmatch(action_ref, pattern) for pattern in allowlist)
 
 
-def build_gh_pr_command(missing_refs: list[str], repo_name: str) -> str:
-    """Build a shell command that creates a PR adding missing actions to the allowlist.
+def build_gh_pr_command(action_name: str, refs: list[str], repo_name: str) -> str:
+    """Build a shell command that creates a PR adding one action to the allowlist.
 
-    The generated script forks ``apache/infrastructure-actions``, appends
-    wildcard entries to ``actions.yml``, and opens a pull request — all via
-    the ``gh`` CLI with no manual file editing required.
+    The generated script forks ``apache/infrastructure-actions``, inserts
+    pinned version entries into ``actions.yml`` in alphabetical order, and
+    opens a pull request — all via the ``gh`` CLI with no manual file editing
+    required.
 
     Args:
-        missing_refs: Action refs not on the allowlist (e.g. ``["owner/act@sha"]``).
+        action_name: The action name (e.g. ``"owner/action"``).
+        refs: Full action refs for this action (e.g. ``["owner/action@sha"]``).
         repo_name: Value of ``$GITHUB_REPOSITORY`` (may be empty).
 
     Returns:
         str: A copy-pasteable shell script.
     """
-    action_names = sorted({ref.split("@")[0] for ref in missing_refs})
+    branch = f"allowlist-add-{action_name.replace('/', '-')}"
+    title = f"Add {action_name} to the GitHub Actions allowlist"
 
-    # Branch name from first action, sanitised for git
-    sanitized = action_names[0].replace("/", "-")
-    if len(action_names) > 1:
-        sanitized += f"-and-{len(action_names) - 1}-more"
-    branch = f"allowlist-add-{sanitized}"
-
-    # YAML entries to append (wildcard — maintainers can pin later)
-    yaml_lines: list[str] = []
-    for name in action_names:
-        yaml_lines.append(f"{name}:")
-        yaml_lines.append("  '*':")
-        yaml_lines.append("    keep: true")
-    yaml_block = "\n".join(yaml_lines)
-
-    summary = ", ".join(action_names)
-    title = f"Add {summary} to the GitHub Actions allowlist"
-
-    body_lines = ["Add the following action(s) to the allowlist:", ""]
-    for name in action_names:
-        body_lines.append(f"- `{name}`")
+    body_lines = [f"Add `{action_name}` to the allowlist:", ""]
+    for ref in sorted(refs):
+        body_lines.append(f"- `{ref}`")
     if repo_name:
         body_lines.extend(["", f"Needed by: `{repo_name}`"])
     body = "\n".join(body_lines)
 
+    ref_args = " ".join(shlex.quote(r) for r in sorted(refs))
+
+    inserter_url = (
+        "https://raw.githubusercontent.com/apache/infrastructure-actions/"
+        "main/allowlist-check/insert_actions.py"
+    )
+
     return (
         f"( set -e; _d=$(mktemp -d); trap 'rm -rf \"$_d\"' EXIT; cd \"$_d\"\n"
-        f"  gh repo clone apache/infrastructure-actions . -- --depth=1\n"
-        f"  gh repo fork --remote\n"
+        f"  gh repo fork apache/infrastructure-actions --clone -- --depth=1\n"
+        f"  cd infrastructure-actions\n"
         f"  git checkout -b {shlex.quote(branch)}\n"
-        f"  cat >> actions.yml << 'ALLOWLIST_YAML'\n"
-        f"{yaml_block}\n"
-        f"ALLOWLIST_YAML\n"
+        f"  curl -fsSL {shlex.quote(inserter_url)} | python3 - actions.yml {ref_args}\n"
         f"  git add actions.yml\n"
-        f"  git commit -m {shlex.quote(f'Add {summary} to allowlist')}\n"
+        f"  git commit -m {shlex.quote(f'Add {action_name} to allowlist')}\n"
         f"  git push -u origin {shlex.quote(branch)}\n"
-        f"  gh pr create --repo apache/infrastructure-actions"
+        f"  gh pr create --repo apache/infrastructure-actions --head \"$(gh api user -q .login):{shlex.quote(branch)}\""
         f" --title {shlex.quote(title)}"
         f" --body {shlex.quote(body)} )\n"
     )
@@ -248,8 +239,20 @@ def main():
 
         missing_refs = sorted({ref for _, ref in violations})
         repo_name = os.environ.get("GITHUB_REPOSITORY", "")
-        script = build_gh_pr_command(missing_refs, repo_name)
-        print(f"\n::notice::You can create a PR to add the missing entries by running:\n{script}")
+
+        # Group by action name so we can suggest one PR per action
+        by_action: dict[str, list[str]] = {}
+        for ref in missing_refs:
+            name = ref.split("@")[0]
+            by_action.setdefault(name, []).append(ref)
+
+        print(
+            "\n::notice::Please create one PR per action."
+            " You can create the PRs by running the commands below:"
+        )
+        for action_name in sorted(by_action):
+            script = build_gh_pr_command(action_name, by_action[action_name], repo_name)
+            print(f"\n# {action_name}\n{script}")
 
         sys.exit(1)
     else:

--- a/allowlist-check/insert_actions.py
+++ b/allowlist-check/insert_actions.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Insert action entries into actions.yml in alphabetical order.
+
+Usage:
+    python3 insert_actions.py <actions.yml> <ref> [<ref> ...]
+
+Each ``ref`` is an action reference in ``owner/action@version`` format.
+New entries are inserted so that the top-level keys in ``actions.yml``
+remain sorted case-insensitively.  If an action already exists in the
+file, the entry is skipped (it will *not* be overwritten).
+"""
+
+import re
+import sys
+
+
+def insert_actions(actions_yml_path: str, refs: list[str]) -> None:
+    """Insert *refs* into *actions_yml_path* in alphabetical order."""
+    # Group refs by action name: {name: [version, ...]}
+    by_action: dict[str, list[str]] = {}
+    for ref in refs:
+        name, _, version = ref.partition("@")
+        by_action.setdefault(name, []).append(version or "*")
+
+    # Build YAML blocks for the new entries
+    new_entries: dict[str, str] = {}
+    for name in sorted(by_action):
+        lines = [f"{name}:"]
+        for version in sorted(by_action[name]):
+            lines.append(f"  '{version}':")
+            lines.append("    keep: true")
+        new_entries[name] = "\n".join(lines)
+
+    # Parse existing top-level blocks
+    text = open(actions_yml_path).read()
+    blocks = re.split(r"(?m)(?=^\S)", text)
+    by_key: dict[str, str] = {}
+    for block in blocks:
+        if block.strip():
+            by_key[block.split(":", 1)[0].strip()] = block.rstrip()
+
+    # Merge — setdefault keeps existing entries untouched
+    for key, value in new_entries.items():
+        by_key.setdefault(key, value)
+
+    # Write back sorted
+    with open(actions_yml_path, "w") as f:
+        f.write(
+            "\n".join(by_key[k] for k in sorted(by_key, key=str.casefold))
+            + "\n"
+        )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <actions.yml> <ref> [<ref> ...]", file=sys.stderr)
+        sys.exit(2)
+    insert_actions(sys.argv[1], sys.argv[2:])

--- a/allowlist-check/test_check_asf_allowlist.py
+++ b/allowlist-check/test_check_asf_allowlist.py
@@ -30,6 +30,7 @@ from check_asf_allowlist import (
     load_allowlist,
     main,
 )
+from insert_actions import insert_actions
 
 
 class TestFindActionRefs(unittest.TestCase):
@@ -306,40 +307,90 @@ class TestCollectActionRefs(unittest.TestCase):
         self.assertEqual(refs, {})
 
 
+class TestInsertActions(unittest.TestCase):
+    """Tests for the insert_actions helper script."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.actions_yml = os.path.join(self.tmpdir, "actions.yml")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_inserts_alphabetically(self):
+        with open(self.actions_yml, "w") as f:
+            f.write("aaa/action:\n  'sha1':\n    keep: true\nzzz/action:\n  'sha2':\n    keep: true\n")
+        insert_actions(self.actions_yml, ["mmm/middle@sha3"])
+        content = open(self.actions_yml).read()
+        lines = content.splitlines()
+        top_keys = [l for l in lines if not l.startswith(" ") and l.endswith(":")]
+        self.assertEqual(top_keys, ["aaa/action:", "mmm/middle:", "zzz/action:"])
+
+    def test_does_not_overwrite_existing(self):
+        with open(self.actions_yml, "w") as f:
+            f.write("org/action:\n  'existing-sha':\n    keep: true\n")
+        insert_actions(self.actions_yml, ["org/action@new-sha"])
+        content = open(self.actions_yml).read()
+        self.assertIn("existing-sha", content)
+        self.assertNotIn("new-sha", content)
+
+    def test_multiple_refs_same_action(self):
+        with open(self.actions_yml, "w") as f:
+            f.write("")
+        insert_actions(self.actions_yml, ["org/act@sha1", "org/act@sha2"])
+        content = open(self.actions_yml).read()
+        self.assertIn("sha1", content)
+        self.assertIn("sha2", content)
+        self.assertEqual(content.count("org/act:"), 1)
+
+    def test_case_insensitive_sort(self):
+        with open(self.actions_yml, "w") as f:
+            f.write("Bbb/action:\n  'sha1':\n    keep: true\n")
+        insert_actions(self.actions_yml, ["aaa/action@sha2"])
+        content = open(self.actions_yml).read()
+        self.assertTrue(content.index("aaa/action:") < content.index("Bbb/action:"))
+
+
 class TestBuildGhPrCommand(unittest.TestCase):
     """Tests for the generated gh PR command."""
 
     def test_single_action(self):
         script = build_gh_pr_command(
-            ["evil-org/evil-action@abc123"], "apache/test-repo"
+            "evil-org/evil-action", ["evil-org/evil-action@abc123"], "apache/test-repo"
         )
-        self.assertIn("gh repo clone apache/infrastructure-actions", script)
-        self.assertIn("gh repo fork --remote", script)
+        self.assertIn("gh repo fork apache/infrastructure-actions --clone", script)
         self.assertIn("allowlist-add-evil-org-evil-action", script)
-        self.assertIn("evil-org/evil-action:", script)
-        self.assertIn("  '*':", script)
-        self.assertIn("    keep: true", script)
+        self.assertIn("insert_actions.py", script)
+        self.assertIn("evil-org/evil-action@abc123", script)
         self.assertIn("gh pr create --repo apache/infrastructure-actions", script)
         self.assertIn("apache/test-repo", script)
 
-    def test_multiple_actions(self):
+    def test_no_repo_name(self):
         script = build_gh_pr_command(
-            ["b-org/b-action@sha1", "a-org/a-action@sha2"], ""
+            "some-org/some-action", ["some-org/some-action@sha1"], ""
         )
-        # Actions should be sorted
-        self.assertIn("a-org/a-action:", script)
-        self.assertIn("b-org/b-action:", script)
-        # Branch name mentions first action + "and more"
-        self.assertIn("allowlist-add-a-org-a-action-and-1-more", script)
-        # No repo reference when GITHUB_REPOSITORY is empty
         self.assertNotIn("Needed by:", script)
 
-    def test_deduplicates_same_action_different_shas(self):
+    def test_multiple_shas_same_action(self):
         script = build_gh_pr_command(
-            ["org/action@sha1", "org/action@sha2"], ""
+            "org/action", ["org/action@sha1", "org/action@sha2"], ""
         )
-        # Should appear only once in the YAML block
-        self.assertEqual(script.count("org/action:"), 1)
+        self.assertIn("org/action@sha1", script)
+        self.assertIn("org/action@sha2", script)
+        self.assertIn("allowlist-add-org-action", script)
+
+    def test_downloads_inserter_from_raw_github(self):
+        """The generated script must download insert_actions.py."""
+        script = build_gh_pr_command(
+            "zoo/action", ["zoo/action@abc123"], ""
+        )
+        self.assertIn(
+            "https://raw.githubusercontent.com/apache/infrastructure-actions/"
+            "main/allowlist-check/insert_actions.py",
+            script,
+        )
+        self.assertIn("curl -fsSL", script)
+        self.assertIn("python3 -", script)
 
 
 class TestMainGhPrCommand(unittest.TestCase):
@@ -392,6 +443,7 @@ class TestMainGhPrCommand(unittest.TestCase):
         self.assertIn("gh pr create --repo apache/infrastructure-actions", output)
         self.assertIn("evil-org/evil-action", output)
         self.assertIn("apache/test-repo", output)
+        self.assertIn("Please create one PR per action", output)
 
     @patch.dict(os.environ, {"GITHUB_REPOSITORY": "apache/test-repo"})
     def test_main_prints_verbose_check_output(self):


### PR DESCRIPTION
## Summary

Two improvements to the allowlist-check action:

- **Verbose output**: Each action ref is now printed as it is checked, showing its
  status and the reason it was allowed or rejected. This makes it easy to see exactly
  what the check is doing without digging through workflow files.

  ```
  Checking 3 unique action ref(s) against the ASF allowlist:

    ✅ actions/checkout@v4 — trusted owner (actions)  (.github/workflows/ci.yml)
    ✅ codecov/codecov-action@v4 — matches allowlist  (.github/workflows/ci.yml)
    ❌ evil-org/evil-action@abc123 — NOT ON ALLOWLIST  (.github/workflows/ci.yml)
  ```

- **Ready-to-run `gh` command**: On failure, the check now prints a copy-pasteable
  shell script that forks the repo, appends wildcard entries to `actions.yml`, and
  opens a PR — no manual file editing required.

  ```
  ::notice::You can create a PR to add the missing entries by running:
  ( set -e; _d=$(mktemp -d); trap 'rm -rf "$_d"' EXIT; cd "$_d"
    gh repo clone apache/infrastructure-actions . -- --depth=1
    gh repo fork --remote
    git checkout -b allowlist-add-evil-org-evil-action
    cat >> actions.yml << 'ALLOWLIST_YAML'
  evil-org/evil-action:
    '*':
      keep: true
  ALLOWLIST_YAML
    git add actions.yml
    git commit -m 'Add evil-org/evil-action to allowlist'
    git push -u origin allowlist-add-evil-org-evil-action
    gh pr create --repo apache/infrastructure-actions \
      --title 'Add evil-org/evil-action to the GitHub Actions allowlist' \
      --body '...' )
  ```

## Test plan

- `TestBuildGhPrCommand` (3 tests): single action, multiple actions with dedup, same action with different SHAs.
- `TestMainGhPrCommand` (2 tests): verifies main() includes the PR command and verbose check output.
- All 32 tests pass (27 existing + 5 new).