### PR TITLE
Add multiple PR templates for different contribution types

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/action_approval.md
+++ b/.github/PULL_REQUEST_TEMPLATE/action_approval.md
@@ -1,3 +1,21 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
 # Request for adding a new GitHub Action to the allow list
 
 ## Overview

--- a/.github/PULL_REQUEST_TEMPLATE/code_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/code_change.md
@@ -1,3 +1,21 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
 # Code change
 
 ## Summary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,9 @@ This repository uses multiple PR templates located in `.github/PULL_REQUEST_TEMP
 When creating a PR via `gh pr create --web`, GitHub will present a template chooser. Select the
 template that matches the type of change. When opening a PR URL directly, you can append
 `&template=action_approval.md` or `&template=code_change.md` to pre-fill the appropriate template.
+
+## License headers
+
+All files must include the Apache License 2.0 header where the file format supports it. Use the
+appropriate comment syntax for the file type (e.g., `<!-- -->` for Markdown/HTML, `#` for YAML/Python,
+`//` for JavaScript/Go). See existing files in the repository for examples of the correct format.


### PR DESCRIPTION
## Summary

- Replace the single `PULL_REQUEST_TEMPLATE.md` (action-approval only) with a `.github/PULL_REQUEST_TEMPLATE/` directory containing two templates
- **`action_approval.md`** — for requests to add new GitHub Actions to the allow list (existing template, unchanged)
- **`code_change.md`** — for utilities, bug fixes, workflow changes, and other code contributions
- Update `AGENTS.md` to document the available templates

GitHub will now present a template chooser when opening a new PR, so contributors no longer need to erase the action approval template for non-approval PRs.

Closes #634

## Test plan

- [x] Open a new PR on this repo and verify the template chooser appears
- [x] Verify `action_approval.md` matches the previous template content
- [x] Verify `code_change.md` renders correctly

Generated-by: Claude Code (claude-opus-4-6)