### PR TITLE
Improve gha-find.py with better token handling, colored output, and summary

### DIFF
--- a/utils/gha-find.py
+++ b/utils/gha-find.py
@@ -32,18 +32,51 @@ import subprocess
 import os
 import argparse
 import json
+from collections import Counter
+
+# ANSI colors
+BOLD = "\033[1m"
+CYAN = "\033[36m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+RESET = "\033[0m"
+
+
+def link(url: str, text: str | None = None) -> str:
+    """Return an OSC 8 clickable hyperlink for supported terminals."""
+    text = text or url
+    return f"\033]8;;{url}\033\\{text}\033]8;;\033\\"
+
+
+def get_gh_token(args) -> str:
+    """Resolve GitHub token: -t flag > GH_TOKEN env > GITHUB_TOKEN env > `gh auth token`."""
+    if args.token:
+        return args.token
+    for var in ("GH_TOKEN", "GITHUB_TOKEN"):
+        val = os.environ.get(var)
+        if val:
+            return val
+    gh = shutil.which("gh")
+    if gh:
+        try:
+            result = subprocess.run(
+                [gh, "auth", "token"], capture_output=True, text=True, check=True
+            )
+            token = result.stdout.strip()
+            if token:
+                return token
+        except subprocess.CalledProcessError:
+            pass
+    print("No GitHub token found! Provide via -t, GH_TOKEN/GITHUB_TOKEN env, or `gh auth login`.")
+    sys.exit(1)
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-t", "--token", help="GitHub Token")
 parser.add_argument("-s", "--search", help="Action search string", required=True)
 args = parser.parse_args()
 
-if not os.environ["GH_TOKEN"]:
-    if not args.token:
-        print("No Token found!")
-        sys.exit(1)
-    else:
-        os.environ["GH_TOKEN"] = args.token
+os.environ["GH_TOKEN"] = get_gh_token(args)
 GH = shutil.which("gh")
 
 command = [
@@ -60,12 +93,8 @@ command = [
 ]
 
 try:
-    # Run the command and capture standard output
     result = subprocess.run(command, capture_output=True, text=True, check=True)
-
-    # Parse the JSON string into a Python list/dictionary
     data = json.loads(result.stdout)
-
 except subprocess.CalledProcessError as e:
     print(f"Error executing gh: {e.stderr}")
     sys.exit(1)
@@ -73,10 +102,30 @@ except FileNotFoundError:
     print("The 'gh' CLI tool is not installed or not in your PATH.")
     sys.exit(1)
 
-print(f"Usage of {args.search}:\n")
+print(f"\n{BOLD}Usage of {CYAN}{args.search}{RESET}{BOLD}:{RESET}\n")
+
+uses: Counter[str] = Counter()
+
 for item in data:
     repo = item["repository"]["nameWithOwner"]
     flow = item["path"]
+    file_url = f"https://github.com/{repo}/blob/HEAD/{flow}"
     for action in item["textMatches"]:
-        term = [a for a in action["fragment"].split() if args.search in a][0]
-        print(f"{repo} -- {flow} -- {term}")
+        matches = [a for a in action["fragment"].split() if args.search in a]
+        if not matches:
+            continue
+        term = matches[0]
+        uses[term] += 1
+        print(f"  {GREEN}{repo}{RESET} -- {link(file_url, flow)} -- {YELLOW}{term}{RESET}")
+
+print(f"\n{BOLD}Summary (de-duplicated install URLs):{RESET}\n")
+for term, count in uses.most_common():
+    action_name, _, ref = term.partition("@")
+    # Use only owner/repo for the GitHub URL (ignore subpaths in composite actions)
+    parts = action_name.split("/")
+    action_repo = "/".join(parts[:2]) if len(parts) >= 2 else action_name
+    if ref:
+        action_url = f"https://github.com/{action_repo}/commit/{ref}"
+    else:
+        action_url = f"https://github.com/{action_repo}"
+    print(f"  {YELLOW}{link(action_url, term)}{RESET}  ({count}x)")


### PR DESCRIPTION
## Summary
- Add flexible GitHub token resolution: `-t` flag > `GH_TOKEN`/`GITHUB_TOKEN` env vars > `gh auth token` fallback
- Add ANSI colored output and clickable OSC 8 hyperlinks for workflow file paths
- Add de-duplicated usage summary with counts at the end of output
- Fix crash when no text matches are found for the search term

## Test plan
- [ ] Run `utils/gha-find.py -s <action>` and verify colored output and clickable links
- [ ] Test token resolution via flag, env var, and `gh auth token`
- [ ] Verify summary section shows correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)