### PR TITLE
Follow up on #638 - fix pypi publish action version handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,10 +217,24 @@ If you need to add a specific version of an already approved action (especially 
 ```yaml
 existing/action:
   '<exact-commit-sha>':
-    expires_at: 2025-01-01
     keep: true
     tag: vX.Y.Z
 ```
+
+if this is the newest version of the action (make sure to remove the `keep: true` from the
+previously newest version and add `expires_at: <date>` to it, if you want to set an expiration date for it),
+
+or
+
+```yaml
+existing/action:
+  '<exact-commit-sha>':
+    expires_at: 2025-01-01
+    tag: vX.Y.Z
+```
+
+If you add older version of the action and want to set an expiration date for it.
+
 
 3. **Create a PR** against the `main` branch
 4. **Include in your PR description**:

--- a/actions.yml
+++ b/actions.yml
@@ -698,7 +698,6 @@ pypa/gh-action-pypi-publish:
     keep: true
     tag: v1.13.0
   76f52bc884231f62b9a034ebfe128415bbaabdfc:
-    keep: true
     tag: v1.12.4
     expires_at: 2026-06-10
 pyTooling/Actions:


### PR DESCRIPTION
## Summary

Follow-up to #638 which was mistakenly merged too fast.

- Remove `keep: true` from the older pypa/gh-action-pypi-publish v1.12.4 — only the newest version (v1.13.0) should have `keep: true`
- Update README to better document the process of adding older vs newer versions of already approved actions

## Test plan

- [ ] Verify `actions.yml` correctly marks only v1.13.0 with `keep: true`
- [ ] Verify README documentation is clear about the two cases (newest vs older version)


🤖 Generated with [Claude Code](https://claude.com/claude-code)