### PR TITLE
Request to add `matlab-actions/setup-matlab` Action to allow list 

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -563,6 +563,9 @@ manusa/actions-setup-minikube:
     expires_at: 2026-06-14
   96202dee4ae1c2f46a62fe197273aaf22b83f42d:
     tag: v2.16.1
+matlab-actions/setup-matlab:
+  aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4:
+    tag: v2.7.0
 maxim-lobanov/setup-xcode:
   '*':
     keep: true


### PR DESCRIPTION
# Overview

**Action name:** setup-matlab
**Action URL:** https://github.com/matlab-actions/setup-matlab
**Version to pin:** [aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4](https://github.com/matlab-actions/setup-matlab/commit/aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4)

# Action Description

From the Setup MATLAB README.md:

> The [Setup MATLAB](https://github.com/matlab-actions/setup-matlab#set-up-matlab) action enables you to set up MATLAB® and other MathWorks® products on a [GitHub®-hosted](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners) (Linux®, Windows®, or macOS) runner or [self-hosted](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners) UNIX® (Linux or macOS) runner.

# Motivation

The apache/arrow repository uses `matlab-actions/setup-matlab` and `matlab-actions/run-tests`, which I will add to the allow list in a separate PR, to build and test the MATLAB Apache Arrow bindings. However, beginning on March 20th, the MATLAB CI checks have not been able to run because `matlab-actions/setup-matlab` is not on the allow list.

# Related Actions

I will create a separate PR to add `matlab-actions/run-tests` to the allow list.

---
# Checklist 

- [x]  The action is listed in the GitHub Actions Marketplace
- [x]  The action is not already on the list of approved actions
- [ ] The action has a sufficient number of contributors or has contributors within the ASF community (It is actively maintained by MathWorks/has 9 contributors)
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
- [ ] Compiled JavaScript in dist/ matches a clean rebuild (verify with uv run utils/verify-action-build.py org/repo@hash) (In progress)
