### PR TITLE
Request to add `matlab-actions/run-tests` Action to allow list 

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -563,15 +563,15 @@ manusa/actions-setup-minikube:
     expires_at: 2026-06-14
   96202dee4ae1c2f46a62fe197273aaf22b83f42d:
     tag: v2.16.1
+matlab-actions/run-tests:
+  4a3d2e8bdc811f72defb8122e46a009312acc198:
+    tag: v2.3.1
 matlab-actions/setup-matlab:
   aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4:
     tag: v2.7.0
 maxim-lobanov/setup-xcode:
   '*':
     keep: true
-matlab-actions/run-tests:
-  4a3d2e8bdc811f72defb8122e46a009312acc198:
-    tag: v2.3.1
 medyagh/setup-minikube:
   '*':
     keep: true


### PR DESCRIPTION
# Overview

**Action name:** run-tests
**Action URL:** https://github.com/matlab-actions/run-tests
**Version to pin:** [4a3d2e8bdc811f72defb8122e46a009312acc198](https://github.com/matlab-actions/run-tests/commit/4a3d2e8bdc811f72defb8122e46a009312acc198)

# Action Description

From the Run Tests README.md:

>The [Run MATLAB Tests](https://github.com/matlab-actions/run-tests#run-matlab-tests) action enables you to run MATLAB® and Simulink® tests and generate test and coverage artifacts on a [GitHub®-hosted](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners) or [self-hosted](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners) runner.

# Motivation

The apache/arrow repository uses the `matlab-actions/run-tests` action to run automated MATLAB unit tests in its CI/CD pipeline to test the MATLAB Apache Arrow bindings. However, beginning on March 20th, the MATLAB CI checks have not been able to run because `matlab-actions/run-tests` is not on the allow list.

# Related PRs

- https://github.com/apache/infrastructure-actions/pull/643

---
# Checklist 

- [x]  The action is listed in the GitHub Actions Marketplace
- [x]  The action is not already on the list of approved actions
- [ ] The action has a sufficient number of contributors or has contributors within the ASF community (It is actively maintained by MathWorks/has 9 contributors)
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
- [ ] Compiled JavaScript in dist/ matches a clean rebuild (verify with uv run utils/verify-action-build.py org/repo@hash) (Don't think this applies since matlab-actions/setup-matlab does not have a dist folder).

