### PR TITLE
Prevent workflow command injection in verify action build output

### DIFF
--- a/.github/workflows/verify_dependabot_action.yml
+++ b/.github/workflows/verify_dependabot_action.yml
@@ -39,6 +39,15 @@ jobs:
       - run: pipx install uv
 
       - name: Verify action build
-        run: uv run utils/verify-action-build.py --ci --from-pr "${{ github.event.pull_request.number }}"
+        run: |
+          # Disable workflow command processing so that strings like
+          # "##[add-matcher]" or "::error::" in action diffs are not
+          # interpreted as GitHub Actions commands.
+          stop_token="$(uuidgen)"
+          echo "::stop-commands::${stop_token}"
+          uv run utils/verify-action-build.py --ci --from-pr "${{ github.event.pull_request.number }}"
+          rc=$?
+          echo "::${stop_token}::"
+          exit $rc
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

- Wrap `verify-action-build.py` invocation with `::stop-commands::<token>` / `::<token>::` using a random UUID
- Prevents strings like `##[add-matcher]`, `::error::`, `::warning::` in action diff output from being interpreted as GitHub Actions workflow commands

## Test plan

- [ ] Trigger the verify workflow on a dependabot PR and confirm diff output containing workflow-command-like strings is printed as plain text

Generated with [Claude Code](https://claude.com/claude-code)