### PR TITLE
Add pyproject.toml and requirements.txt to verify_dependabot_action paths

### DIFF
--- a/.github/workflows/verify_dependabot_action.yml
+++ b/.github/workflows/verify_dependabot_action.yml
@@ -22,6 +22,10 @@ on:
   pull_request:
     paths:
       - .github/workflows/dummy.yml
+      - pyproject.toml
+      - utils/pyproject.toml
+      - pelican/requirements.txt
+      - pelican/migration/requirements.txt
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `pyproject.toml`, `utils/pyproject.toml`, `pelican/requirements.txt`, and `pelican/migration/requirements.txt` to the `paths` trigger in the verify dependabot action workflow so dependency changes in these files also trigger the verification.

## Test plan
- [ ] Verify the workflow triggers on PRs touching these files

Generated-by: Claude Opus 4.6 (1M context)