### PR TITLE
Fix allowlist-check to use latest approved_patterns.yml from main

### DIFF
--- a/allowlist-check/action.yml
+++ b/allowlist-check/action.yml
@@ -34,8 +34,14 @@ runs:
     - name: Install ruyaml
       shell: bash
       run: pip install ruyaml
+    - name: Fetch latest approved_patterns.yml from main
+      shell: bash
+      run: |
+        curl -sSfL \
+          "https://raw.githubusercontent.com/apache/infrastructure-actions/main/approved_patterns.yml" \
+          -o "${{ runner.temp }}/approved_patterns.yml"
     - name: Verify all action refs are allowlisted
       shell: bash
-      run: python3 "${{ github.action_path }}/check_asf_allowlist.py" "${{ github.action_path }}/../approved_patterns.yml"
+      run: python3 "${{ github.action_path }}/check_asf_allowlist.py" "${{ runner.temp }}/approved_patterns.yml"
       env:
         GITHUB_YAML_GLOB: ${{ inputs.scan-glob }}


### PR DESCRIPTION
## Summary

- When projects pin the `allowlist-check` action to a specific commit hash (as recommended by GitHub for security), the action was reading the `approved_patterns.yml` bundled at that pinned commit. This meant any actions/versions approved **after** that commit were not recognized, causing false-positive check failures until the project bumped their pin.
- Now the action fetches `approved_patterns.yml` from the `main` branch at runtime via `curl`, so the allowlist check always uses the most up-to-date list regardless of which version of the action the caller has pinned.

## Test plan

- [ ] Verify the action fetches `approved_patterns.yml` successfully from `raw.githubusercontent.com` at runtime
- [ ] Verify that a newly added allowlist entry is recognized even when the action is pinned to an older commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)