### PR TITLE
Fix verify-action-build to try 'npm run start' for actions that use it

### DIFF
--- a/utils/verify-action-build.py
+++ b/utils/verify-action-build.py
@@ -853,7 +853,7 @@ RUN BUILD_DIR=$(cat /build-dir.txt); \
     fi
 
 # Build: first try a root-level build script (some repos like gradle/actions use one),
-# then try npm/yarn/pnpm build in the build directory, then package, then ncc fallback.
+# then try npm/yarn/pnpm build in the build directory, then package, then start, then ncc fallback.
 # If the build directory is a subdirectory, copy its output dir to root afterwards.
 RUN OUT_DIR=$(cat /out-dir.txt); \
     BUILD_DIR=$(cat /build-dir.txt); \
@@ -869,6 +869,8 @@ RUN OUT_DIR=$(cat /out-dir.txt); \
         echo "build-step: $RUN_CMD run build (in $BUILD_DIR)" >> /build-info.log; \
       elif $RUN_CMD run package 2>/dev/null; then \
         echo "build-step: $RUN_CMD run package (in $BUILD_DIR)" >> /build-info.log; \
+      elif $RUN_CMD run start 2>/dev/null; then \
+        echo "build-step: $RUN_CMD run start (in $BUILD_DIR)" >> /build-info.log; \
       elif npx ncc build --source-map 2>/dev/null; then \
         echo "build-step: npx ncc build --source-map (in $BUILD_DIR)" >> /build-info.log; \
       fi && \


### PR DESCRIPTION
Some actions like editorconfig-checker/action-editorconfig-checker use "start" as their build script name. The build detection previously only tried "build" and "package" before falling back to a bare `npx ncc build` which fails for TypeScript entry points.

Generated-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>