### PR TITLE
Re-add missed allowlist additions

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -162,7 +162,7 @@ jobs:
         if: false
       - uses: jrouly/scalafmt-native-action@a9c8e1032a02004c425d53ef8ce420fe2179eba7  # v5
         if: false
-      - uses: JustinBeckwith/linkinator-action@363572b2714d25a059fceb2fa332a98e7ea3baff  # v2.4
+      - uses: JustinBeckwith/linkinator-action@363572b2714d25a059fceb2fa332a98e7ea3baff  # v2.4.1
         if: false
       - uses: jwgmeligmeyling/pmd-github-action@322e346bd76a0757c4d54ff9209e245965aa066d  # v1.2
         if: false

--- a/actions.yml
+++ b/actions.yml
@@ -280,6 +280,9 @@ docker/login-action:
     expires_at: 2026-06-14
   b45d80f862d83dbcd57f89517bcf500b2ab88fb2:
     tag: v4.0.0
+    expires_at: 2026-09-14
+  4907a6ddec9925e35a0a9e82d7399ccc52663121:
+    tag: v4.1.0
 docker/metadata-action:
   c299e40c65443455700f0fdfc63efafe5b349051:
     tag: v5.10.0
@@ -349,6 +352,9 @@ erisu/apache-rat-action:
 erisu/license-checker-action:
   99cffa11264fe545fd0baa6c13bca5a00ae608f2:
     tag: v2.0.1
+    expires_at: 2026-09-14
+  04511f4c052b5773f11e1c65b42cda88235c62ae:
+    tag: v9.2.0
 geekyeggo/delete-artifact:
   '*':
     keep: true
@@ -403,6 +409,9 @@ gradle/actions/dependency-submission:
     expires_at: 2026-06-20
   39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f:
     tag: v6.0.1
+    expires_at: 2026-09-14
+  50e97c2cd7a37755bbfafc9c5b7cafaece252f6e:
+    tag: v6.1.0
 gradle/actions/setup-gradle:
   017a9effdb900e5b5b2fddfb590a105619dca3c3:
     tag: v4.4.2
@@ -415,6 +424,9 @@ gradle/actions/setup-gradle:
     expires_at: 2026-06-20
   39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f:
     tag: v6.0.1
+    expires_at: 2026-09-14
+  50e97c2cd7a37755bbfafc9c5b7cafaece252f6e:
+    tag: v6.1.0
 gradle/actions/wrapper-validation:
   017a9effdb900e5b5b2fddfb590a105619dca3c3:
     tag: v4.4.2
@@ -427,6 +439,9 @@ gradle/actions/wrapper-validation:
     expires_at: 2026-06-20
   39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f:
     tag: v6.0.1
+    expires_at: 2026-09-14
+  50e97c2cd7a37755bbfafc9c5b7cafaece252f6e:
+    tag: v6.1.0
 gradle/develocity-actions/maven-publish-build-scan:
   4a2aed82eea165ba2d5c494fc2a8730d7fdff229:
     tag: v1.4
@@ -536,7 +551,10 @@ JustinBeckwith/linkinator-action:
     tag: v2.3
     expires_at: 2026-05-22
   f62ba0c110a76effb2ee6022cc6ce4ab161085e3:
-    tag: v2.4
+    tag: v2.4.0
+    expires_at: 2026-09-14
+  363572b2714d25a059fceb2fa332a98e7ea3baff:
+    tag: v2.4.1
 jwgmeligmeyling/checkstyle-github-action:
   '*':
     keep: true
@@ -587,9 +605,15 @@ manusa/actions-setup-minikube:
 matlab-actions/run-tests:
   4a3d2e8bdc811f72defb8122e46a009312acc198:
     tag: v2.3.1
+    expires_at: 2026-09-14
+  4be3345d41da8b1bf8cc5cb01a5e19c4611cb15d:
+    tag: v3.0.0
 matlab-actions/setup-matlab:
   aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4:
     tag: v2.7.0
+    expires_at: 2026-09-14
+  c6998d116f15c400d5e16e05318e3450abdcf053:
+    tag: v3.0.0
 maxim-lobanov/setup-xcode:
   '*':
     keep: true
@@ -698,6 +722,9 @@ pypa/cibuildwheel:
     expires_at: 2026-06-14
   ee02a1537ce3071a004a6b08c41e72f0fdc42d9a:
     tag: v3.4.0
+    expires_at: 2026-09-14
+  8d2b08b68458a16aeb24b64e68a09ab1c8e82084:
+    tag: v3.4.1
 pypa/gh-action-pypi-publish:
   ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e:
     keep: true

--- a/actions.yml
+++ b/actions.yml
@@ -280,7 +280,7 @@ docker/login-action:
     expires_at: 2026-06-14
   b45d80f862d83dbcd57f89517bcf500b2ab88fb2:
     tag: v4.0.0
-    expires_at: 2026-09-14
+    expires_at: 2026-07-05
   4907a6ddec9925e35a0a9e82d7399ccc52663121:
     tag: v4.1.0
 docker/metadata-action:
@@ -352,7 +352,7 @@ erisu/apache-rat-action:
 erisu/license-checker-action:
   99cffa11264fe545fd0baa6c13bca5a00ae608f2:
     tag: v2.0.1
-    expires_at: 2026-09-14
+    expires_at: 2026-07-05
   04511f4c052b5773f11e1c65b42cda88235c62ae:
     tag: v2.1.0
 geekyeggo/delete-artifact:
@@ -409,7 +409,7 @@ gradle/actions/dependency-submission:
     expires_at: 2026-06-20
   39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f:
     tag: v6.0.1
-    expires_at: 2026-09-14
+    expires_at: 2026-07-05
   50e97c2cd7a37755bbfafc9c5b7cafaece252f6e:
     tag: v6.1.0
 gradle/actions/setup-gradle:
@@ -424,7 +424,7 @@ gradle/actions/setup-gradle:
     expires_at: 2026-06-20
   39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f:
     tag: v6.0.1
-    expires_at: 2026-09-14
+    expires_at: 2026-07-05
   50e97c2cd7a37755bbfafc9c5b7cafaece252f6e:
     tag: v6.1.0
 gradle/actions/wrapper-validation:
@@ -439,7 +439,7 @@ gradle/actions/wrapper-validation:
     expires_at: 2026-06-20
   39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f:
     tag: v6.0.1
-    expires_at: 2026-09-14
+    expires_at: 2026-07-05
   50e97c2cd7a37755bbfafc9c5b7cafaece252f6e:
     tag: v6.1.0
 gradle/develocity-actions/maven-publish-build-scan:
@@ -551,10 +551,10 @@ JustinBeckwith/linkinator-action:
     tag: v2.3
     expires_at: 2026-05-22
   f62ba0c110a76effb2ee6022cc6ce4ab161085e3:
-    tag: v2.4.0
-    expires_at: 2026-09-14
+    tag: v2.4
+    expires_at: 2026-07-05
   363572b2714d25a059fceb2fa332a98e7ea3baff:
-    tag: v2.4.1
+    tag: v2.4
 jwgmeligmeyling/checkstyle-github-action:
   '*':
     keep: true
@@ -605,13 +605,13 @@ manusa/actions-setup-minikube:
 matlab-actions/run-tests:
   4a3d2e8bdc811f72defb8122e46a009312acc198:
     tag: v2.3.1
-    expires_at: 2026-09-14
+    expires_at: 2026-07-05
   4be3345d41da8b1bf8cc5cb01a5e19c4611cb15d:
     tag: v3.0.0
 matlab-actions/setup-matlab:
   aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4:
     tag: v2.7.0
-    expires_at: 2026-09-14
+    expires_at: 2026-07-05
   c6998d116f15c400d5e16e05318e3450abdcf053:
     tag: v3.0.0
 maxim-lobanov/setup-xcode:
@@ -722,7 +722,7 @@ pypa/cibuildwheel:
     expires_at: 2026-06-14
   ee02a1537ce3071a004a6b08c41e72f0fdc42d9a:
     tag: v3.4.0
-    expires_at: 2026-09-14
+    expires_at: 2026-07-05
   8d2b08b68458a16aeb24b64e68a09ab1c8e82084:
     tag: v3.4.1
 pypa/gh-action-pypi-publish:

--- a/actions.yml
+++ b/actions.yml
@@ -354,7 +354,7 @@ erisu/license-checker-action:
     tag: v2.0.1
     expires_at: 2026-09-14
   04511f4c052b5773f11e1c65b42cda88235c62ae:
-    tag: v9.2.0
+    tag: v2.1.0
 geekyeggo/delete-artifact:
   '*':
     keep: true


### PR DESCRIPTION
These were missed in the period that branch protection prevented the workflow from copying allowlists from the dummy workflow to `actions.yml`.

(#689 added them to `approved_patterns.yml`, but once the automated jobs were running again they were removed again because they didn't show up in `actions.yml`)