### PR TITLE
Leaving empty protected branches to actually disable it

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,8 +20,8 @@ github:
   del_branch_on_merge: true
   features:
     issues: true
+  protected_branches:
   # revert #642
-  #protected_branches:
   #  main:
   #    required_status_checks:
   #      # strict means "Require branches to be up to date before merging".


### PR DESCRIPTION
The protected branches have not been removed by #692 because it just skipped the whole protected brnaches. Empty protected branches should cleanup all of them.