### PR TITLE
Pin all workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/check_approved_limit.yml
+++ b/.github/workflows/check_approved_limit.yml
@@ -36,7 +36,7 @@ jobs:
   check-limit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,17 +47,17 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -33,12 +33,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Python environment
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/pelican-action-test.yml
+++ b/.github/workflows/pelican-action-test.yml
@@ -38,14 +38,14 @@ jobs:
       group: testsite-${{ github.ref_name }} # must agree with TARGET
     steps:
       - name: Checkout the test site
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.SOURCE }}
       - name: Ignore the action checkout
         run: |
           echo "self/" >> .git/info/exclude
       - name: Checkout self
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: self
       - name: Reset output directory ${{ env.TARGET }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,7 +28,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/remove_expired.yml
+++ b/.github/workflows/remove_expired.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: true
           # Use PAT so the commit triggers other actions

--- a/.github/workflows/stash-action-test.yml
+++ b/.github/workflows/stash-action-test.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     container: quay.io/centos/centos:stream8
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Run action
         continue-on-error: true
@@ -58,7 +58,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-15-intel, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Run unittests
         shell: bash
@@ -135,7 +135,7 @@ jobs:
     needs: test-save
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Test intra-workflow stash
         uses: ./stash/restore

--- a/.github/workflows/update_actions.yml
+++ b/.github/workflows/update_actions.yml
@@ -43,7 +43,7 @@ jobs:
       contents: write
     steps:
 
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: true
           token: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN || github.token }}

--- a/.github/workflows/update_dummy.yml
+++ b/.github/workflows/update_dummy.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: true
           # We have to use a PAT to commit the workflow file

--- a/.github/workflows/verify_dependabot_action.yml
+++ b/.github/workflows/verify_dependabot_action.yml
@@ -32,7 +32,7 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

Pin every third-party action reference in the repo's real workflow files to
an immutable commit SHA, with the human-readable version in a trailing
comment. This follows the GitHub Actions security-hardening guidance: once
a workflow is pinned by SHA, a compromised upstream tag cannot silently
change what our workflows run, and Dependabot treats the trailing `# v…`
comment as part of the reference so it will bump both the SHA and the
comment when a new release lands.

### What changed

| Action | Before | After | Where |
| ------ | ------ | ----- | ----- |
| `actions/checkout` | `@v6.0.2` | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2` | check_approved_limit, pelican-action-test (×2), update_actions, linting, remove_expired, update_dummy, codeql-analysis, verify_dependabot_action, pytest, stash-action-test (×3) |
| `actions/setup-python` | `@v6` | `@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0` | linting |
| `github/codeql-action/{init,autobuild,analyze}` | `@v4` | `@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1` | codeql-analysis |

10 workflow files touched, 17 line swaps — no workflow logic changed.

### Scope / what is intentionally NOT touched

- **`.github/workflows/dummy.yml`** is generated from `/actions.yml` by
  `gateway/gateway.py` and regenerated via `.github/workflows/update_dummy.yml`.
  It has its own pinning convention and any manual edits there would be
  clobbered on the next regeneration.
- **`gateway/test_out_dummy.yml`** and the other `gateway/*.yml` fixtures
  are test data for the gateway generator, not real workflows.
- **README example workflow snippets** (e.g. `pelican/README.md`) still
  use floating tags because they are teaching material for end users, not
  production workflows.
- **Composite action definitions** (`stash/{save,restore}/action.yml`,
  `allowlist-check/action.yml`, `pelican/action.yml`) contain no `uses:`
  references to third-party actions — they are pure `shell: bash` run
  steps.

### Dependabot coverage

No dependabot.yml change is required. The existing
`package-ecosystem: "github-actions"` entry already lists `/` in its
`directories` list, which covers every workflow file under
`.github/workflows/`. Dependabot will start proposing version bumps for
the newly-pinned references on its next scheduled run (currently a daily
cron, `15 13 * * *`), and it will update both the SHA and the `# v…`
version comment in place.

## Test plan

- [x] Grep confirms no unpinned third-party action references remain in
      any real workflow file — only the two `docker://…@sha256:…` image
      digests in the `dummy.yml` fixture, which are already pinned the
      Docker way.
- [x] SHAs resolved via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`
      and cross-checked against `gh api repos/<owner>/<repo>/tags` to
      confirm the tag → SHA mapping and pick the right human-readable
      version for the trailing comment.
- [ ] One dependabot cycle after merge to confirm it successfully
      proposes a bump against one of the newly-pinned references (the
      test is "did the next bump arrive with both SHA and comment
      updated" — nothing action-required here, just observation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)