### PR TITLE
Add lhotari/sandboxed-trivy-action v1.0.2 to approved actions

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -591,6 +591,8 @@ leafo/gh-actions-luarocks:
 lhotari/sandboxed-trivy-action:
   555963036b2012b44c1071508a236e569db28ebb:
     tag: v1.0.1
+  f01374b6cc3bf7264ab238293e94f6db7ada6dd0:
+    tag: v1.0.2
 lycheeverse/lychee-action:
   8646ba30535128ac92d33dfc9133794bfdd9b411:
     tag: v2.8.0


### PR DESCRIPTION
## Summary

Adds lhotari/sandboxed-trivy-action hash for [v1.0.2](https://github.com/lhotari/sandboxed-trivy-action/releases/tag/v1.0.2).
Action name with hash: `lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0`

v1.0.2 contains a change by @rmoff to add Trivy scanning to [Apache Iceberg's Kafka Connect CI](https://github.com/apache/iceberg/pull/15430).