### PR TITLE
Allow use of `dependabot/fetch-metadata`

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -98,6 +98,8 @@ jobs:
         if: false
       - uses: dawidd6/action-send-mail@d38f3f7cd391cdebfe0d38efc3998b935e951c4f  # v16
         if: false
+      - uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36  # v3.0.0
+        if: false
       - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
         if: false
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0

--- a/actions.yml
+++ b/actions.yml
@@ -268,6 +268,9 @@ dawidd6/action-send-mail:
 delaguardo/setup-graalvm:
   '*':
     keep: true
+dependabot/fetch-metadata:
+  ffa630c65fa7e0ecfa0625b5ceda64399aea1b36:
+    tag: v3.0.0
 dlang-community/setup-dlang:
   '*':
     keep: true


### PR DESCRIPTION
## Overview

The `dependabot/fetch-metadata` action retrieves metadata from a Dependabot PR. Most notably:
* It verifies that all commits in the PR are authored by Dependabot. This prevents malicious users from opening PRs that merge a Dependabot-managed branch from a fork into the base repo, which could otherwise trigger events that bypass a `github.actor == 'dependabot[bot]'` check.
* It parses the PR description and the latest commit.
* It exports metadata about the updated dependencies.

**Name of action:** `dependabot/fetch-metadata`
**URL of action:** https://github.com/dependabot/fetch-metadata
**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** `ffa630c65fa7e0ecfa0625b5ceda64399aea1b36` (v3.0.0)

This is a continuation of #339.

## Permissions

The action requires only read permission on `contents` and `pull_requests`. It also has an **optional** feature that retrieves the security alert associated with a PR, which requires a token with the `security_events` scope.

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
