### PR TITLE
Stop running transitive-failures check on pull_request

### DIFF
--- a/.github/workflows/check-for-transitive-failures.yml
+++ b/.github/workflows/check-for-transitive-failures.yml
@@ -21,10 +21,13 @@ name: Check for transitive failures in current latest actions
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - .github/actions/for-dependabot-triggered-reviews/action.yml
+  schedule:
+    # Run daily to detect when a transitive dependency has fallen out
+    # of the allowlist even without changes to the action file.
+    - cron: "30 5 * * *"
   push:
+    branches:
+      - main
     paths:
       - .github/actions/for-dependabot-triggered-reviews/action.yml
 


### PR DESCRIPTION
## Summary

The `check-for-transitive-failures` workflow consumes `.github/actions/for-dependabot-triggered-reviews/action.yml` via `uses:`, so GitHub resolves every nested action SHA during workflow preparation — before `if: false` is ever evaluated. When Dependabot opens a PR bumping one of those SHAs (e.g. #720), the new SHA is not yet in the repo allowlist — that PR's *entire purpose* is to trigger the allowlist review — so the job fails with `The action ... is not allowed`. Chicken-and-egg.

This drops the `pull_request` trigger and relies on:

- **`push` on `main`** (scoped, so it only fires *after* the allowlist regeneration workflow has landed the new SHA)
- **a daily `schedule`** — matching the design intent described in `action.yml`'s header comment: *"GHA will periodically 'run' this action, which will fail when any of the listed actions have a transitive action dependency that is not allowlisted"*

Tradeoff: we lose pre-merge verification that a bumped SHA is already in the allowlist. That check was already redundant with the human allowlist review, and a post-merge failure on `main` is recoverable via revert or a follow-up allowlist fix.

## Test plan

- [ ] Verify this PR itself does **not** trigger `check-for-transitive-failures` (it modifies a workflow file, not `for-dependabot-triggered-reviews/action.yml`).
- [ ] After merge, confirm the post-merge `push` run on `main` succeeds.
- [ ] Rebase #720 (or let Dependabot recreate it) and confirm `check-for-transitive-failures` no longer runs on the Dependabot PR.
- [ ] Confirm the scheduled run fires at `30 5 * * *` UTC the next day.

Generated-by: Claude Opus 4.6 (1M context)