### PR TITLE
pin apache/infrastructure-actions/pelican to 93dfe4693bc118397840e7e4ae447e57a3eea7ee

### DIFF
--- a/pelican/README.md
+++ b/pelican/README.md
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: apache/infrastructure-actions/pelican@main
+      - uses: apache/infrastructure-actions/pelican@93dfe4693bc118397840e7e4ae447e57a3eea7ee # main
         with:
           destination: master
           gfm: 'true'
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: apache/infrastructure-actions/pelican@main
+      - uses: apache/infrastructure-actions/pelican@93dfe4693bc118397840e7e4ae447e57a3eea7ee # main
         with:
           publish: 'false'
 ```

--- a/pelican/migration/build-pelican.yml
+++ b/pelican/migration/build-pelican.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           # This must equal the push/branches list above, and be appropriate for the destination below
           ref: 'SOURCE_BRANCH'
-      - uses: apache/infrastructure-actions/pelican@main
+      - uses: apache/infrastructure-actions/pelican@93dfe4693bc118397840e7e4ae447e57a3eea7ee # main
         with:
           # This must be appropriate for the branch being built
           destination: 'DESTINATION_BRANCH'

--- a/pelican/migration/build-pelican.yml.ezt
+++ b/pelican/migration/build-pelican.yml.ezt
@@ -32,7 +32,7 @@ jobs:
         with:
           # This must equal the push/branches list above, and be appropriate for the destination below
           ref: '[whoami]'
-      - uses: apache/infrastructure-actions/pelican@main
+      - uses: apache/infrastructure-actions/pelican@93dfe4693bc118397840e7e4ae447e57a3eea7ee # main
         with:
           # This must be appropriate for the branch being built
           destination: '[target]'


### PR DESCRIPTION
Requested by ASF Infra to pin to [93dfe4693bc118397840e7e4ae447e57a3eea7ee](https://github.com/apache/infrastructure-actions/commit/93dfe4693bc118397840e7e4ae447e57a3eea7ee)
Devlist thread https://lists.apache.org/thread/zd9cpkhwt0xh2sq958gwc62cw4f86yc7

We should pin to hash commit in the examples in this repo too