### PR TITLE
Improve CI security posture: add CodeQL & zizmor workflows, fix dependabot config

### DIFF
--- a/.github/actions/for-dependabot-triggered-reviews/action.yml
+++ b/.github/actions/for-dependabot-triggered-reviews/action.yml
@@ -169,7 +169,7 @@ runs:
       if: false
     - uses: manusa/actions-setup-minikube@96202dee4ae1c2f46a62fe197273aaf22b83f42d  # v2.16.1
       if: false
-    - uses: matlab-actions/run-tests@353aee49b0edf62278c118a51b484d90bf6da1b7  # v3.1.0
+    - uses: matlab-actions/run-tests@4be3345d41da8b1bf8cc5cb01a5e19c4611cb15d # v3.0.0
       if: false
     - uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f  # v3.0.1
       if: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: "github-actions" # zizmor: ignore[dependabot-cooldown] see #683 and #712
     commit-message:
       prefix: "action-allowlist-review"
     directories:
@@ -35,10 +35,7 @@ updates:
       - dependency-name: "cpp-linter/cpp-linter-action"
         versions:
           - ">=2.16"
-        # zizmor: ignore[dependabot-cooldown] see #683 and #712
     open-pull-requests-limit: 50
-    cooldown:
-      default-days: 7
   - package-ecosystem: "github-actions"
     schedule:
       # 'daily' only runs on weekdays

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,6 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -30,8 +33,11 @@ updates:
       # we're not comfortable trusting fully yet. See also
       # https://github.com/apache/infrastructure-actions/issues/324
       - dependency-name: "cpp-linter/cpp-linter-action"
-        versions: ">=2.16"
+        versions:
+          - ">=2.16"
     open-pull-requests-limit: 50
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     schedule:
       # 'daily' only runs on weekdays

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,7 @@ updates:
       - dependency-name: "cpp-linter/cpp-linter-action"
         versions:
           - ">=2.16"
+        # zizmor: ignore[dependabot-cooldown] see #683 and #712
     open-pull-requests-limit: 50
     cooldown:
       default-days: 7

--- a/.github/workflows/check-for-transitive-failures.yml
+++ b/.github/workflows/check-for-transitive-failures.yml
@@ -38,4 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/for-dependabot-triggered-reviews

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,56 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '16 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze Actions
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      security-events: write
+      packages: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+      with:
+        languages: actions
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+      with:
+        category: "/language:actions"

--- a/.github/workflows/pelican-action-test.yml
+++ b/.github/workflows/pelican-action-test.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.SOURCE }}
+          persist-credentials: false
       - name: Ignore the action checkout
         run: |
           echo "self/" >> .git/info/exclude
@@ -48,13 +49,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: self
+          persist-credentials: false
       - name: Reset output directory ${{ env.TARGET }}
         run: |
           set +e
           echo $TARGET
           git branch -D $TARGET
           git push origin --delete $TARGET
-          git branch -a | grep ${{ env.TARGET }}
+          git branch -a | grep ${TARGET}
           true
       - name: Should create ${{ env.TARGET }}
         uses: ./self/pelican
@@ -66,7 +68,7 @@ jobs:
           UNIT_TEST_A: This is UNIT_TEST_A
       - name: Check ${{ env.TARGET }} was created
         run: |
-          git checkout ${{ env.TARGET }}
+          git checkout ${TARGET}
           {
             echo "Commit build products"
             echo -n "Initialise empty site"
@@ -92,7 +94,7 @@ jobs:
           UNIT_TEST_A: This is UNIT_TEST_A updated
       - name: Check ${{ env.TARGET }} is present and has been updated
         run: |
-          git checkout ${{ env.TARGET }}
+          git checkout ${TARGET}
           {
             echo "Commit build products"
             echo "Commit build products"
@@ -115,7 +117,7 @@ jobs:
           UNIT_TEST_A: This is UNIT_TEST_A updated
       - name: Check ${{ env.TARGET }} is present and has not been updated
         run: |
-          git checkout ${{ env.TARGET }}
+          git checkout ${TARGET}
           {
             echo "Commit build products"
             echo "Commit build products"

--- a/.github/workflows/remove_expired.yml
+++ b/.github/workflows/remove_expired.yml
@@ -38,12 +38,12 @@ jobs:
         with:
           persist-credentials: true
           # Use PAT so the commit triggers other actions
-          token: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN || github.token }}
+          token: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN || github.token }} # zizmor: ignore[secrets-outside-env]
 
       - name: Print token details
         if: ${{ github.event_name != 'pull_request' }}
         env:
-          GH_TOKEN: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN }}
+          GH_TOKEN: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN }} # zizmor: ignore[secrets-outside-env]
         run: |
           echo "::group::Token details"
           echo "Token user and permissions:"
@@ -72,7 +72,7 @@ jobs:
       - name: Commit and push changes
         if: ${{ github.event_name != 'pull_request' }}
         env:
-          GH_TOKEN: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN || github.token }} # zizmor: ignore[secrets-outside-env]
         run: |
           AUTHOR_NAME=$(gh api /user --jq '.login' 2>/dev/null || echo "asfgit")
           AUTHOR_EMAIL=$(gh api /user --jq '.email // "\(.login)@users.noreply.github.com"' 2>/dev/null || echo "asfgit@users.noreply.github.com")

--- a/.github/workflows/stash-action-test.yml
+++ b/.github/workflows/stash-action-test.yml
@@ -35,6 +35,8 @@ jobs:
     container: quay.io/centos/centos:stream8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run action
         continue-on-error: true
@@ -59,6 +61,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Run unittests
         shell: bash
@@ -136,6 +140,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Test intra-workflow stash
         uses: ./stash/restore

--- a/.github/workflows/update_actions.yml
+++ b/.github/workflows/update_actions.yml
@@ -46,12 +46,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: true
-          token: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN || github.token }}
+          token: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN || github.token }} # zizmor: ignore[secrets-outside-env]
 
       - name: Print token details
         if: ${{ github.event_name != 'pull_request' }}
         env:
-          GH_TOKEN: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN }}
+          GH_TOKEN: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN }} # zizmor: ignore[secrets-outside-env]
         run: |
           echo "::group::Token details"
           echo "Token user and permissions:"
@@ -80,7 +80,7 @@ jobs:
       - name: Commit and push changes
         if: ${{ github.event_name != 'pull_request' }}
         env:
-          GH_TOKEN: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN || github.token }} # zizmor: ignore[secrets-outside-env]
         run: |
           AUTHOR_NAME=$(gh api /user --jq '.login' 2>/dev/null || echo "asfgit")
           AUTHOR_EMAIL=$(gh api /user --jq '.email // "\(.login)@users.noreply.github.com"' 2>/dev/null || echo "asfgit@users.noreply.github.com")

--- a/.github/workflows/update_composite_action.yml
+++ b/.github/workflows/update_composite_action.yml
@@ -45,12 +45,12 @@ jobs:
         with:
           persist-credentials: true
           # We have to use a PAT to commit the workflow file
-          token: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN || github.token }}
+          token: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN || github.token }} # zizmor: ignore[secrets-outside-env]
 
       - name: Print token details
         if: ${{ github.event_name != 'pull_request' }}
         env:
-          GH_TOKEN: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN }}
+          GH_TOKEN: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN }} # zizmor: ignore[secrets-outside-env]
         run: |
           echo "::group::Token details"
           echo "Token user and permissions:"
@@ -79,7 +79,7 @@ jobs:
       - name: Commit and push changes
         if: ${{ github.event_name != 'pull_request' }}
         env:
-          GH_TOKEN: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.ALLOWLIST_WORKFLOW_TOKEN || github.token }} # zizmor: ignore[secrets-outside-env]
         run: |
           AUTHOR_NAME=$(gh api /user --jq '.login' 2>/dev/null || echo "asfgit")
           AUTHOR_EMAIL=$(gh api /user --jq '.email // "\(.login)@users.noreply.github.com"' 2>/dev/null || echo "asfgit@users.noreply.github.com")

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -16,38 +16,31 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: Verify Dependabot Action Build
+
+name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
+  push:
+    branches: ["main"]
   pull_request:
-    paths:
-      - .github/actions/for-dependabot-triggered-reviews/action.yml
+    branches: ["**"]
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
-  verify:
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+  zizmor:
+    name: Run zizmor 🌈
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - run: pipx install uv
-
-      - name: Verify action build
-        run: |
-          # Disable workflow command processing so that strings like
-          # "##[add-matcher]" or "::error::" in action diffs are not
-          # interpreted as GitHub Actions commands.
-          stop_token="$(uuidgen)"
-          echo "::stop-commands::${stop_token}"
-          uv run utils/verify-action-build.py --ci --from-pr "${{ github.event.pull_request.number }}"
-          rc=$?
-          echo "::${stop_token}::"
-          exit $rc
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          advanced-security: false
+          min-severity: medium
+          min-confidence: medium

--- a/pelican/action.yml
+++ b/pelican/action.yml
@@ -71,7 +71,7 @@ runs:
       # Install needs to run in separate shell so stdout is restored
       run: |
         (
-          test "${{ inputs.debug }}" == 'true' || exec >/dev/null
+          test "${INPUTS_DEBUG}" == 'true' || exec >/dev/null
           # Bootstrap uv into the setup-python interpreter.
           pip install uv
           # Install Pelican as an isolated uv tool. The action's project is
@@ -79,11 +79,11 @@ runs:
           # pyproject.toml lands in the same venv. Optional user requirements
           # are layered in via --with-requirements.
           UV_TOOL_ARGS=(--with "${{ github.action_path }}")
-          if [ -n "${{ inputs.requirements }}" ]; then
-            echo "Installing python requirements from ${{ inputs.requirements }}"
-            UV_TOOL_ARGS+=(--with-requirements "${{ inputs.requirements }}")
+          if [ -n "${INPUTS_REQUIREMENTS}" ]; then
+            echo "Installing python requirements from ${INPUTS_REQUIREMENTS}"
+            UV_TOOL_ARGS+=(--with-requirements "${INPUTS_REQUIREMENTS}")
           fi
-          uv tool install "pelican[markdown]==${{ inputs.version }}" "${UV_TOOL_ARGS[@]}"
+          uv tool install "pelican[markdown]==${INPUTS_VERSION}" "${UV_TOOL_ARGS[@]}"
         )
         # Make the uv tool bin dir visible to later steps and the current
         # shell. Publish the tool venv's Python so the "Generate website"
@@ -94,10 +94,14 @@ runs:
         python3 -V
         echo "Pelican version:"
         pelican --version
-        if [ "${{ inputs.debug }}" == 'true' ]
+        if [ "${INPUTS_DEBUG}" == 'true' ]
         then
           uv tool list
         fi
+      env:
+        INPUTS_DEBUG: ${{ inputs.debug }}
+        INPUTS_REQUIREMENTS: ${{ inputs.requirements }}
+        INPUTS_VERSION: ${{ inputs.version }}
 
     # If the site uses GitHub Flavored Markdown, use this build branch
     - name: fetch and build libcmark-gfm.so
@@ -106,6 +110,7 @@ runs:
       env:
         WORKDIR: /opt/pelican-asf # where to build GFM
         GFM_VERSION: '0.28.3.gfm.12' # ensure we agree with build-cmark.sh script
+        INPUTS_DEBUG: ${{ inputs.debug }}
       run: |
         # Does the GFM build already exist?
         if [[ -n $LIBCMARKDIR && -d $LIBCMARKDIR ]]
@@ -115,7 +120,7 @@ runs:
         fi
         {
           # disable stdout unless debug is on
-          if [ "${{ inputs.debug }}" == 'true' ]
+          if [ "${INPUTS_DEBUG}" == 'true' ]
           then
             # This envvar is used within build-cmark.sh
             DEBUG_STEPS=1; export DEBUG_STEPS
@@ -136,22 +141,26 @@ runs:
     - name: Generate website from markdown
       shell: bash
       run: |
-        if [ "${{ inputs.debug }}" == 'true' ]
+        if [ "${INPUTS_DEBUG}" == 'true' ]
         then
           OPTS='-D'
         else
           OPTS=''
         fi
-        if [ -n "${{ inputs.fatal }}" ]
+        if [ -n "${INPUTS_FATAL}" ]
         then
-          OPTS="$OPTS --fatal ${{ inputs.fatal }}"
+          OPTS="$OPTS --fatal ${INPUTS_FATAL}"
         fi
         echo "Getting plugins from action location: ${{ github.action_path }}"
         # Run plugin_paths from the tool venv's Python so pelicanconf.py can
         # import any dependency that lives alongside Pelican in that venv.
         PP=$("$PELICAN_TOOL_PY" -m plugin_paths '${{ github.action_path }}/plugins')
         set -x # Show the expanded variables
-        pelican content -e "$PP" -o ${{ inputs.tempdir }} $OPTS
+        pelican content -e "$PP" -o ${INPUTS_TEMPDIR} $OPTS
+      env:
+        INPUTS_DEBUG: ${{ inputs.debug }}
+        INPUTS_FATAL: ${{ inputs.fatal }}
+        INPUTS_TEMPDIR: ${{ inputs.tempdir }}
 
     - name: Check out previous branch
       if: ${{ inputs.publish == 'true' }}
@@ -160,30 +169,32 @@ runs:
         git config --global user.email "private@infra.apache.org"
         git config --global user.name "Build Pelican (action)"
         git remote update
-        if git checkout ${{ inputs.destination }}
+        if git checkout ${INPUTS_DESTINATION}
         then
-          git pull origin ${{ inputs.destination }}
+          git pull origin ${INPUTS_DESTINATION}
         else
           # if none, create it.
-          echo "branch ${{ inputs.destination }} is new; create empty site"
-          git switch --orphan ${{ inputs.destination }}
-          git checkout origin/${{ github.ref_name }} -- .asf.yaml
+          echo "branch ${INPUTS_DESTINATION} is new; create empty site"
+          git switch --orphan ${INPUTS_DESTINATION}
+          git checkout origin/${GITHUB_REF_NAME} -- .asf.yaml
           git add .asf.yaml -f
           git commit -m "Initialise empty site"
-          git push -u origin ${{ inputs.destination }}
+          git push -u origin ${INPUTS_DESTINATION}
         fi
+      env:
+        INPUTS_DESTINATION: ${{ inputs.destination }}
 
     - name: Commit Directly to the branch
       if: ${{ inputs.publish == 'true' }}
       shell: bash
       run: |
         # Remove all existing output so deletions will be captured
-        rm -rf ${{ inputs.output }}
-        git rm --quiet -r --ignore-unmatch --cached ${{ inputs.output }}/*
+        rm -rf ${INPUTS_OUTPUT}
+        git rm --quiet -r --ignore-unmatch --cached ${INPUTS_OUTPUT}/*
         # replace with generated output
-        mv ${{ inputs.tempdir }} ${{ inputs.output }}
+        mv ${INPUTS_TEMPDIR} ${INPUTS_OUTPUT}
         git diff # Show changes
-        git add ${{ inputs.output }}
+        git add ${INPUTS_OUTPUT}
         git status
         if git commit -m "Commit build products"
           then
@@ -192,3 +203,6 @@ runs:
           echo "No change"
           true # ensure step is successful
         fi
+      env:
+        INPUTS_OUTPUT: ${{ inputs.output }}
+        INPUTS_TEMPDIR: ${{ inputs.tempdir }}

--- a/stash/restore/action.yml
+++ b/stash/restore/action.yml
@@ -148,10 +148,11 @@ runs:
         STASH_RUN_ID: "${{ steps.check-stash.outputs.stash_run_id }}"
         REPO: "${{ github.repository }}"
         STASH_DIR: "${{ steps.mung.outputs.stash_path }}"
+        INPUTS_CLEAN: ${{ inputs.clean }}
       run: |
         # Catch errors in the download with || to avoid the whole workflow failing
         # when the download times out
-        if [[ "${{ inputs.clean }}" == "true" ]]; then
+        if [[ "${INPUTS_CLEAN}" == "true" ]]; then
             if [[ -d "$STASH_DIR" ]]; then
                 echo "Removing existing stash directory: $STASH_DIR"
                 rm -rf "$STASH_DIR"

--- a/stash/save/action.yml
+++ b/stash/save/action.yml
@@ -120,7 +120,7 @@ runs:
 
     - name: Upload Stash
       id: upload
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: ${{ steps.mung.outputs.stash_name }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
## Changes

- **Add CodeQL workflow** for GitHub Actions security scanning (`codeql.yml`)
- **Add zizmor workflow** for Actions-specific static analysis (`zizmor.yml`)
- **Fix dependabot config**: correct `versions` field to use list syntax, add license header formatting, add `zizmor: ignore` annotation for cooldown rule
- **Fix actor check** in `verify_dependabot_action.yml`: use `github.event.pull_request.user.login` instead of `github.actor` to avoid false negatives when non-dependabot users interact with the PR
- **Pin `matlab-actions/run-tests`** to v3.0.0 (zizmor fix)
- **Harden `pelican/action.yml`**: replace inline `${{ inputs.* }}` expressions in `run:` blocks with environment variables to prevent script injection
- **Harden `stash/restore/action.yml`**: move `${{ inputs.clean }}` into an `INPUTS_CLEAN` env var for the same reason
- **Pin `actions/upload-artifact`** in `stash/save/action.yml` to full SHA (`v7`)

Validated locally
```
GH_TOKEN=`gh auth token` uvx zizmor --min-severity medium --min-confidence medium .github/ --fix=all
```