### PR TITLE
verify-action-build: skip pin warning for multi-stage FROM references

### DIFF
--- a/utils/tests/verify_action_build/test_security.py
+++ b/utils/tests/verify_action_build/test_security.py
@@ -65,6 +65,18 @@ class TestAnalyzeDockerfile:
             warnings = analyze_dockerfile("org", "repo", "a" * 40)
         assert any("curl" in w.lower() or "evil" in w.lower() for w in warnings)
 
+    def test_multistage_internal_from_no_warnings(self):
+        dockerfile = (
+            "FROM node:20@sha256:abc123 AS builder\n"
+            "RUN npm ci\n"
+            "FROM builder AS runtime\n"
+            "CMD [\"node\", \"index.js\"]\n"
+        )
+        files = {"Dockerfile": dockerfile}
+        with mock.patch("verify_action_build.security.fetch_file_from_github", side_effect=self._mock_fetch(files)):
+            warnings = analyze_dockerfile("org", "repo", "a" * 40)
+        assert warnings == []
+
     def test_no_dockerfile_no_warnings(self):
         with mock.patch("verify_action_build.security.fetch_file_from_github", return_value=None):
             with mock.patch("verify_action_build.security.fetch_action_yml", return_value=None):

--- a/utils/verify_action_build/security.py
+++ b/utils/verify_action_build/security.py
@@ -256,17 +256,24 @@ def analyze_dockerfile(
         lines = content.splitlines()
         from_lines = []
         suspicious_cmds = []
+        stage_names: set[str] = set()
 
         for i, line in enumerate(lines, 1):
             stripped = line.strip()
             if not stripped or stripped.startswith("#"):
                 continue
 
-            from_match = re.match(r"FROM\s+(.+?)(?:\s+AS\s+\S+)?$", stripped, re.IGNORECASE)
+            from_match = re.match(r"FROM\s+(\S+)(?:\s+AS\s+(\S+))?\s*$", stripped, re.IGNORECASE)
             if from_match:
                 image = from_match.group(1).strip()
+                stage_alias = from_match.group(2)
                 from_lines.append((i, image))
-                if "@sha256:" in image:
+                if image in stage_names:
+                    console.print(
+                        f"  [green]✓[/green] [dim]line {i}:[/dim] FROM {image} "
+                        f"[green](multi-stage reference)[/green]"
+                    )
+                elif "@sha256:" in image:
                     console.print(
                         f"  [green]✓[/green] [dim]line {i}:[/dim] FROM {image} "
                         f"[green](digest-pinned)[/green]"
@@ -284,6 +291,8 @@ def analyze_dockerfile(
                         f"[red bold](unpinned or :latest!)[/red bold]"
                     )
                     warnings.append(f"Dockerfile FROM {image} is not pinned")
+                if stage_alias:
+                    stage_names.add(stage_alias)
                 continue
 
             lower = stripped.lower()


### PR DESCRIPTION
## Summary
- `analyze_dockerfile` flagged `FROM <alias>` as unpinned when the alias was defined by an earlier `FROM ... AS <alias>` in the same Dockerfile. Multi-stage internal references don't pull an image, so the warning was noise.
- Track aliases introduced by `FROM <image> AS <alias>` and treat a later `FROM` whose image matches a known alias as a multi-stage reference instead of emitting a pin warning.
- Tightened the FROM regex from `(.+?)` to `(\S+)` so the image token and optional alias parse unambiguously.

## Test plan
- [x] Added `test_multistage_internal_from_no_warnings` covering a two-stage Dockerfile (`FROM node:20@sha256:abc123 AS builder` → `FROM builder AS runtime`)
- [x] `uv run --with pytest pytest tests/verify_action_build/test_security.py` — 16 passed
- [ ] Existing pinned/unpinned/tag-pinned/suspicious-curl cases still exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)