### PR TITLE
verify-action-build: support .cjs and .mjs compiled bundles

### DIFF
--- a/utils/tests/verify_action_build/test_diff_js.py
+++ b/utils/tests/verify_action_build/test_diff_js.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from verify_action_build.diff_js import beautify_js
+from verify_action_build.diff_js import _collect_compiled_js, beautify_js
 
 
 class TestBeautifyJs:
@@ -47,3 +47,32 @@ class TestBeautifyJs:
         result1 = beautify_js(code)
         result2 = beautify_js(code)
         assert result1 == result2
+
+
+class TestCollectCompiledJs:
+    def test_picks_up_js_cjs_mjs(self, tmp_path):
+        (tmp_path / "dist").mkdir()
+        (tmp_path / "dist" / "index.js").write_text("// js\n")
+        (tmp_path / "dist" / "index.cjs").write_text("// cjs\n")
+        (tmp_path / "dist" / "index.mjs").write_text("// mjs\n")
+        (tmp_path / "dist" / "index.cjs.map").write_text("{}\n")
+        (tmp_path / "dist" / "readme.md").write_text("ignored\n")
+
+        found = _collect_compiled_js(tmp_path)
+
+        from pathlib import Path
+        assert found == {
+            Path("dist/index.js"),
+            Path("dist/index.cjs"),
+            Path("dist/index.mjs"),
+        }
+
+    def test_empty_dir_returns_empty(self, tmp_path):
+        assert _collect_compiled_js(tmp_path) == set()
+
+    def test_nested_dirs(self, tmp_path):
+        (tmp_path / "dist" / "sub" / "main").mkdir(parents=True)
+        (tmp_path / "dist" / "sub" / "main" / "index.cjs").write_text("// cjs\n")
+
+        from pathlib import Path
+        assert _collect_compiled_js(tmp_path) == {Path("dist/sub/main/index.cjs")}

--- a/utils/verify_action_build/diff_js.py
+++ b/utils/verify_action_build/diff_js.py
@@ -25,6 +25,22 @@ import jsbeautifier
 from .console import console, link
 from .diff_display import show_colored_diff
 
+# Extensions emitted by action build toolchains. `.js` is the common case
+# (webpack/ncc/tsc); `.cjs` is what esbuild/rollup write when the source
+# package is ESM (type: module) and the action needs a CommonJS bundle for
+# the node runner (e.g. JustinBeckwith/linkinator-action);
+# `.mjs` is the inverse — an ESM bundle for node20+ runners.
+COMPILED_JS_EXTENSIONS = ("*.js", "*.cjs", "*.mjs")
+
+
+def _collect_compiled_js(base: Path) -> set[Path]:
+    """Return relative paths of compiled JS files under base."""
+    found: set[Path] = set()
+    for pattern in COMPILED_JS_EXTENSIONS:
+        for f in base.rglob(pattern):
+            found.add(f.relative_to(base))
+    return found
+
 
 def beautify_js(content: str) -> str:
     """Reformat JavaScript for readable diffing."""
@@ -46,13 +62,8 @@ def diff_js_files(
     # Files vendored by @vercel/ncc that are not built from the action's source.
     ignored_files = {"sourcemap-register.js"}
 
-    original_files = set()
-    rebuilt_files = set()
-
-    for f in original_dir.rglob("*.js"):
-        original_files.add(f.relative_to(original_dir))
-    for f in rebuilt_dir.rglob("*.js"):
-        rebuilt_files.add(f.relative_to(rebuilt_dir))
+    original_files = _collect_compiled_js(original_dir)
+    rebuilt_files = _collect_compiled_js(rebuilt_dir)
 
     all_files = sorted(original_files | rebuilt_files)
 

--- a/utils/verify_action_build/dockerfiles/build_action.Dockerfile
+++ b/utils/verify_action_build/dockerfiles/build_action.Dockerfile
@@ -83,9 +83,15 @@ RUN if [ -d "node_modules" ]; then \
       mkdir /original-node-modules; \
     fi
 
-# Delete compiled JS from output dir before rebuild to ensure a clean build
+# Delete compiled JS from output dir before rebuild to ensure a clean build.
+# Covers .js, .cjs and .mjs — actions bundled with esbuild/rollup may emit
+# dist/index.cjs (e.g. JustinBeckwith/linkinator-action) or dist/index.mjs.
 RUN OUT_DIR=$(cat /out-dir.txt); \
-    if [ -d "$OUT_DIR" ]; then find "$OUT_DIR" -name '*.js' -print -delete > /deleted-js.log 2>&1; else echo "no $OUT_DIR/ directory" > /deleted-js.log; fi
+    if [ -d "$OUT_DIR" ]; then \
+      find "$OUT_DIR" \( -name '*.js' -o -name '*.cjs' -o -name '*.mjs' \) -print -delete > /deleted-js.log 2>&1; \
+    else \
+      echo "no $OUT_DIR/ directory" > /deleted-js.log; \
+    fi
 
 # If an approved (previous) commit hash is provided, restore the dev-dependency
 # lock files from that commit so the rebuild uses the same toolchain (e.g. same
@@ -179,7 +185,7 @@ RUN BUILD_DIR=$(cat /build-dir.txt); \
 RUN OUT_DIR=$(cat /out-dir.txt); \
     BUILD_DIR=$(cat /build-dir.txt); \
     RUN_CMD=$(cat /run-cmd); \
-    has_output() { [ -d "$OUT_DIR" ] && find "$OUT_DIR" -name '*.js' -print -quit | grep -q .; }; \
+    has_output() { [ -d "$OUT_DIR" ] && find "$OUT_DIR" \( -name '*.js' -o -name '*.cjs' -o -name '*.mjs' \) -print -quit | grep -q .; }; \
     BUILD_DONE=false; \
     if [ -x build ] && ./build dist 2>/dev/null; then \
       echo "build-step: ./build dist" >> /build-info.log; \


### PR DESCRIPTION
## Summary
Motivated by Dependabot PR #720 bumping `JustinBeckwith/linkinator-action` to v2.4.2. That action declares `main: dist/index.cjs` in action.yml and its `npm run build` invokes esbuild with `--format=cjs --outfile=dist/index.cjs`. Our `verify-action-build` pipeline only recognized `*.js`, so for any `.cjs`/`.mjs` bundle it:
- did **not** delete the published file before rebuild (a broken rebuild silently leaves the original in place), and
- reported *"No compiled JavaScript found"* from `diff_js_files`, skipping the original-vs-rebuilt comparison entirely.

### Changes
- `utils/verify_action_build/dockerfiles/build_action.Dockerfile`
  - Pre-rebuild delete step now matches `*.js`, `*.cjs`, `*.mjs`.
  - `has_output()` probe that decides whether to try the next build step now recognizes all three extensions.
- `utils/verify_action_build/diff_js.py`
  - New `_collect_compiled_js(base)` helper scans `*.js`, `*.cjs`, `*.mjs`.
  - `diff_js_files` uses the helper.
- `utils/tests/verify_action_build/test_diff_js.py`
  - 3 new tests: mixed extensions, empty dir, nested output (`dist/sub/main/index.cjs` — the gradle/actions-style monorepo shape).

### How `dist/index.cjs` is rebuilt
linkinator-action's `package.json` has `\"type\": \"module\"` and:
```json
\"build\": \"esbuild src/index.js --bundle --platform=node --format=cjs --outfile=dist/index.cjs --sourcemap\"
```
So when the Dockerfile runs `npm run build` inside the build dir, esbuild emits `dist/index.cjs` (+ `dist/index.cjs.map`). With the old `find ... -name '*.js'` guard the rebuild step's `has_output` returned false after esbuild succeeded, causing the Dockerfile to fall through to the `npx ncc build --source-map` fallback — which either failed or produced `dist/index.js`, something the action never ships. With this change the esbuild output is recognized as the final build artifact and compared directly against the committed `dist/index.cjs`.

## Test plan
- [x] `uv run --with pytest pytest tests/verify_action_build` — 120 passed (includes 3 new)
- [ ] Run `verify-action-build` end-to-end against `JustinBeckwith/linkinator-action@7b6b0bc` (PR #720 target) once CI has access to Docker, and confirm the pre-rebuild delete log lists `dist/index.cjs` and the diff step reports the rebuild matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)