### PR TITLE
Remove matlab-actions/run-tests v3.1.0 from approved actions

### DIFF
--- a/.github/actions/for-dependabot-triggered-reviews/action.yml
+++ b/.github/actions/for-dependabot-triggered-reviews/action.yml
@@ -169,8 +169,6 @@ runs:
       if: false
     - uses: manusa/actions-setup-minikube@96202dee4ae1c2f46a62fe197273aaf22b83f42d  # v2.16.1
       if: false
-    - uses: matlab-actions/run-tests@353aee49b0edf62278c118a51b484d90bf6da1b7  # v3.1.0
-      if: false
     - uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f  # v3.0.1
       if: false
     - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29  # v2.2.1

--- a/actions.yml
+++ b/actions.yml
@@ -630,8 +630,6 @@ matlab-actions/run-tests:
   4be3345d41da8b1bf8cc5cb01a5e19c4611cb15d:
     tag: v3.0.0
     expires_at: 2026-07-05
-  353aee49b0edf62278c118a51b484d90bf6da1b7:
-    tag: v3.1.0
 matlab-actions/setup-matlab:
   aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4:
     tag: v2.7.0

--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -223,7 +223,6 @@
 - manusa/actions-setup-minikube@96202dee4ae1c2f46a62fe197273aaf22b83f42d
 - matlab-actions/run-tests@4a3d2e8bdc811f72defb8122e46a009312acc198
 - matlab-actions/run-tests@4be3345d41da8b1bf8cc5cb01a5e19c4611cb15d
-- matlab-actions/run-tests@353aee49b0edf62278c118a51b484d90bf6da1b7
 - matlab-actions/setup-matlab@aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4
 - matlab-actions/setup-matlab@c6998d116f15c400d5e16e05318e3450abdcf053
 - matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f


### PR DESCRIPTION
Drop the 353aee49b0edf62278c118a51b484d90bf6da1b7 (v3.1.0) entry from actions.yml, approved_patterns.yml and the dependabot-review composite action. Earlier v2.3.1 and v3.0.0 hashes remain approved.

Generated-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>