### PR TITLE
Allow dart-lang/setup-dart publish reusable workflow v1

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -265,6 +265,9 @@ DavidAnson/markdownlint-cli2-action:
     expires_at: 2026-06-20
   ce4853d43830c74c1753b39f3cf40f71c2031eb9:
     tag: v23.0.0
+dart-lang/setup-dart/.github/workflows/publish.yml:
+  65eb853c7ba17dde3be364c3d2858773e7144260:
+    tag: v1
 dawidd6/action-download-artifact:
   '*':
     keep: true

--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -101,6 +101,7 @@
 - damccorm/tag-ur-it@6fa72bbf1a2ea157b533d7e7abeafdb5855dbea5
 - DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101
 - DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9
+- dart-lang/setup-dart/.github/workflows/publish.yml@65eb853c7ba17dde3be364c3d2858773e7144260
 - dawidd6/action-download-artifact@*
 - dawidd6/action-send-mail@6d98ae34d733f9a723a9e04e94f2f24ba05e1402
 - dawidd6/action-send-mail@d38f3f7cd391cdebfe0d38efc3998b935e951c4f


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

Allow `apache/fory` to use the reusable pub.dev publishing workflow from `dart-lang/setup-dart` for the Dart release workflow.

**Name of action:** `dart-lang/setup-dart/.github/workflows/publish.yml`

**URL of action:** https://github.com/dart-lang/setup-dart

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** `65eb853c7ba17dde3be364c3d2858773e7144260`

## Permissions

The reusable workflow declares `id-token: write` for pub.dev trusted publishing via OIDC. The calling workflow in `apache/fory` will also keep repository permissions minimal.

## Related Actions

This is a reusable workflow entrypoint from the already maintained `dart-lang/setup-dart` repository. The goal is to use the upstream pub.dev publishing workflow instead of carrying custom publish logic in `apache/fory`.

## Checklist

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
- [ ] Compiled JavaScript in `dist/` matches a clean rebuild (not applicable for a reusable workflow entrypoint)
