### PR TITLE
Allow dart-lang/setup-dart v1.7.1

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -259,6 +259,9 @@ crazy-max/ghaction-import-gpg:
     tag: v7.0.0
 damccorm/tag-ur-it:
   6fa72bbf1a2ea157b533d7e7abeafdb5855dbea5:
+dart-lang/setup-dart:
+  e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c:
+    tag: v1.7.1
 DavidAnson/markdownlint-cli2-action:
   07035fd053f7be764496c0f8d8f9f41f98305101:
     tag: v22.0.0

--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -99,6 +99,7 @@
 - crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
 - crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd
 - damccorm/tag-ur-it@6fa72bbf1a2ea157b533d7e7abeafdb5855dbea5
+- dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
 - DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101
 - DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9
 - dawidd6/action-download-artifact@*


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

Allow `apache/fory` to use the direct `dart-lang/setup-dart` action in its Dart release workflow for pub.dev trusted publishing.

**Name of action:** `dart-lang/setup-dart`

**URL of action:** https://github.com/dart-lang/setup-dart

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** `e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c`

## Permissions

The action itself installs the Dart SDK. The calling workflow in `apache/fory` keeps repository permissions minimal and uses `id-token: write` for pub.dev trusted publishing via OIDC.

## Related Actions

`apache/fory` already has a separate allowlist request for the reusable publish workflow path from the same repository. This request is for the direct action ref because the release workflow was rewritten to use explicit publish steps instead of the reusable workflow wrapper.

## Checklist

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
- [ ] Compiled JavaScript in `dist/` matches a clean rebuild

Verification note: `uv run utils/verify-action-build.py dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c` was attempted locally, but the check could not complete because the local Docker CLI rejected `docker build --progress=plain` (`unknown flag: --progress`).
