### PR TITLE
verify-action-build: support Dart-based actions (setup-dart)

### DIFF
--- a/utils/verify_action_build/dockerfiles/build_action.Dockerfile
+++ b/utils/verify_action_build/dockerfiles/build_action.Dockerfile
@@ -32,6 +32,30 @@ ARG COMMIT_HASH
 
 RUN git clone "$REPO_URL" . && git checkout "$COMMIT_HASH"
 
+# Dart-based actions (e.g. dart-lang/setup-dart) compile Dart sources with
+# `dart compile js` in their npm build script and then bundle via a bare
+# `ncc build` invocation in their dist script. Neither is available in the
+# node:slim base, so detect `pubspec.yaml` at the repo root and install
+# both the Dart SDK (from Google's apt repo) and `@vercel/ncc` globally so
+# the action's own `npm run` scripts can execute unmodified.
+ENV PATH="/usr/lib/dart/bin:${PATH}"
+RUN if [ -f pubspec.yaml ]; then \
+      apt-get update && \
+      apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+      curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub \
+        | gpg --dearmor -o /usr/share/keyrings/dart.gpg && \
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/dart.gpg] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main" \
+        > /etc/apt/sources.list.d/dart_stable.list && \
+      apt-get update && \
+      apt-get install -y --no-install-recommends dart && \
+      rm -rf /var/lib/apt/lists/* && \
+      npm install -g @vercel/ncc && \
+      dart pub get && \
+      echo "dart-sdk: installed (pubspec.yaml detected)" >> /build-info.log && \
+      echo "global-ncc: installed (pubspec.yaml detected)" >> /build-info.log && \
+      echo "dart-pub-get: ran" >> /build-info.log; \
+    fi
+
 # Detect action type from action.yml or action.yaml.
 # For monorepo sub-actions (SUB_PATH set), check <sub_path>/action.yml first,
 # falling back to the root action.yml.
@@ -193,7 +217,7 @@ RUN OUT_DIR=$(cat /out-dir.txt); \
     fi && \
     if [ "$BUILD_DONE" = "false" ]; then \
       cd "$BUILD_DIR" && \
-      for step in build package start; do \
+      for step in all build package start; do \
         if $RUN_CMD run "$step" 2>/dev/null; then \
           echo "build-step: $RUN_CMD run $step (in $BUILD_DIR)" >> /build-info.log; \
           cd /action && \


### PR DESCRIPTION
## Summary

Teach `verify-action-build` to rebuild actions whose source is written in Dart (e.g. `dart-lang/setup-dart`).

When a `pubspec.yaml` exists at the repo root, the Dockerfile now:

- Installs the Dart SDK from Google's apt repo.
- Installs `@vercel/ncc` globally (setup-dart's `dist` script invokes bare `ncc build` rather than `npx ncc`, so it has to be on `PATH`).
- Runs `dart pub get` so pubspec dependencies (`path`, `pub_semver`, …) are resolved before `dart compile js`.

Also adds `all` to the list of candidate npm scripts — setup-dart's `all` script chains `build` + `dist` as one step, and other actions use the same convention.

## Why this was broken

Without these tools the Dockerfile's `npm run build`/`package`/`start` loop failed silently (`2>/dev/null`) and fell through to the `npx ncc build --source-map` fallback. That produced `dist/index.mjs` but omitted `dist/main.cjs` (the dart2js output) and `dist/sig.txt` (generated by `dart tool/sig.dart`), so every rebuild of a Dart action diffed against the published one.

## Verification

Against [PR #739](https://github.com/apache/infrastructure-actions/pull/739) (allowing `dart-lang/setup-dart@e51d8e571e22`):

Before:
```
JS build verification   ✗   DIFFERENCES DETECTED
```

After:
```
JS build verification   ✓   compiled JS matches rebuild
```

## Test plan

- [x] `uv run utils/verify-action-build.py --from-pr 739 --ci` passes against `dart-lang/setup-dart@e51d8e571e22`
- [ ] Rerun against an existing JS-only action (e.g. one from the approved allowlist) to confirm behaviour is unchanged for non-Dart actions
- [ ] CI green on this branch