### PR TITLE
verify-action-build: add binary download verification check

### DIFF
--- a/utils/tests/verify_action_build/test_security.py
+++ b/utils/tests/verify_action_build/test_security.py
@@ -19,6 +19,8 @@
 from unittest import mock
 
 from verify_action_build.security import (
+    analyze_binary_downloads,
+    analyze_binary_downloads_recursive,
     analyze_dockerfile,
     analyze_scripts,
     analyze_action_metadata,
@@ -182,6 +184,236 @@ runs:
         with mock.patch("verify_action_build.security.fetch_action_yml", return_value=action_yml):
             warnings = analyze_action_metadata("org", "repo", "a" * 40)
         assert any("secret" in w for w in warnings)
+
+
+class TestAnalyzeBinaryDownloads:
+    def _mock_fetch(self, files: dict):
+        def fetch(org, repo, commit, path):
+            return files.get(path)
+        return fetch
+
+    def test_no_files_no_results(self):
+        with mock.patch("verify_action_build.security.fetch_file_from_github", return_value=None):
+            with mock.patch("verify_action_build.security.fetch_action_yml", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert warnings == []
+        assert failures == []
+
+    def test_pipe_to_shell_fails(self):
+        files = {
+            "Dockerfile": (
+                "FROM alpine@sha256:abc\n"
+                "RUN curl -fsSL https://example.com/install.sh | sh\n"
+            ),
+        }
+        with mock.patch("verify_action_build.security.fetch_file_from_github", side_effect=self._mock_fetch(files)):
+            with mock.patch("verify_action_build.security.fetch_action_yml", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert len(failures) >= 1
+        assert any("install.sh" in f for f in failures)
+
+    def test_curl_binary_without_verification_fails(self):
+        files = {
+            "Dockerfile": (
+                "FROM alpine@sha256:abc\n"
+                "RUN curl -fsSLO https://example.com/tool.tar.gz && tar xf tool.tar.gz\n"
+            ),
+        }
+        with mock.patch("verify_action_build.security.fetch_file_from_github", side_effect=self._mock_fetch(files)):
+            with mock.patch("verify_action_build.security.fetch_action_yml", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert len(failures) >= 1
+        assert any("tool.tar.gz" in f for f in failures)
+
+    def test_sha256sum_verification_passes(self):
+        files = {
+            "Dockerfile": (
+                "FROM alpine@sha256:abc\n"
+                "RUN curl -fsSLO https://example.com/tool.tar.gz \\\n"
+                " && echo 'abc123deadbeefcafef00d  tool.tar.gz' | sha256sum -c\n"
+            ),
+        }
+        with mock.patch("verify_action_build.security.fetch_file_from_github", side_effect=self._mock_fetch(files)):
+            with mock.patch("verify_action_build.security.fetch_action_yml", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert failures == []
+
+    def test_gpg_verify_passes(self):
+        files = {
+            "Dockerfile": (
+                "FROM alpine@sha256:abc\n"
+                "RUN curl -fsSLO https://example.com/tool.tar.gz \\\n"
+                " && curl -fsSLO https://example.com/tool.tar.gz.sig \\\n"
+                " && gpg --verify tool.tar.gz.sig tool.tar.gz\n"
+            ),
+        }
+        with mock.patch("verify_action_build.security.fetch_file_from_github", side_effect=self._mock_fetch(files)):
+            with mock.patch("verify_action_build.security.fetch_action_yml", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert failures == []
+
+    def test_cosign_verify_passes(self):
+        files = {
+            "Dockerfile": (
+                "FROM alpine@sha256:abc\n"
+                "RUN curl -fsSLO https://example.com/tool.tar.gz && cosign verify-blob tool.tar.gz\n"
+            ),
+        }
+        with mock.patch("verify_action_build.security.fetch_file_from_github", side_effect=self._mock_fetch(files)):
+            with mock.patch("verify_action_build.security.fetch_action_yml", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert failures == []
+
+    def test_apk_add_not_flagged(self):
+        files = {
+            "Dockerfile": (
+                "FROM alpine@sha256:abc\n"
+                "RUN apk add --no-cache curl wget bash\n"
+            ),
+        }
+        with mock.patch("verify_action_build.security.fetch_file_from_github", side_effect=self._mock_fetch(files)):
+            with mock.patch("verify_action_build.security.fetch_action_yml", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert failures == []
+
+    def test_pip_install_not_flagged(self):
+        files = {
+            "Dockerfile": (
+                "FROM python:3.12@sha256:abc\n"
+                "RUN pip install requests==2.31.0\n"
+            ),
+        }
+        with mock.patch("verify_action_build.security.fetch_file_from_github", side_effect=self._mock_fetch(files)):
+            with mock.patch("verify_action_build.security.fetch_action_yml", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert failures == []
+
+    def test_dockerfile_add_url_fails(self):
+        files = {
+            "Dockerfile": (
+                "FROM alpine@sha256:abc\n"
+                "ADD https://example.com/app.tar.gz /app.tar.gz\n"
+            ),
+        }
+        with mock.patch("verify_action_build.security.fetch_file_from_github", side_effect=self._mock_fetch(files)):
+            with mock.patch("verify_action_build.security.fetch_action_yml", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert len(failures) >= 1
+
+    def test_action_yml_run_block_unverified_fails(self):
+        action_yml = """\
+name: Test
+runs:
+  using: composite
+  steps:
+    - name: Download tool
+      shell: bash
+      run: |
+        curl -fsSLO https://example.com/tool.tar.gz
+        tar xf tool.tar.gz
+"""
+        with mock.patch("verify_action_build.security.fetch_action_yml", return_value=action_yml):
+            with mock.patch("verify_action_build.security.fetch_file_from_github", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert len(failures) >= 1
+
+    def test_action_yml_run_block_with_verification_passes(self):
+        action_yml = """\
+name: Test
+runs:
+  using: composite
+  steps:
+    - name: Download and verify
+      shell: bash
+      run: |
+        curl -fsSLO https://example.com/tool.tar.gz
+        echo "abc123deadbeef  tool.tar.gz" | sha256sum -c
+        tar xf tool.tar.gz
+"""
+        with mock.patch("verify_action_build.security.fetch_action_yml", return_value=action_yml):
+            with mock.patch("verify_action_build.security.fetch_file_from_github", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert failures == []
+
+    def test_releases_download_path_flagged(self):
+        # URL without a binary extension but under /releases/download/ still
+        # looks like a binary artefact — flag it.
+        files = {
+            "Dockerfile": (
+                "FROM alpine@sha256:abc\n"
+                "RUN curl -fsSLo /usr/local/bin/mytool "
+                "https://github.com/x/y/releases/download/v1/mytool-linux-amd64 "
+                "&& chmod +x /usr/local/bin/mytool\n"
+            ),
+        }
+        with mock.patch("verify_action_build.security.fetch_file_from_github", side_effect=self._mock_fetch(files)):
+            with mock.patch("verify_action_build.security.fetch_action_yml", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert len(failures) >= 1
+
+
+class TestAnalyzeBinaryDownloadsRecursive:
+    def test_recurses_through_composite(self):
+        # Root is a composite action that uses an unpinned-looking hash-pinned
+        # nested action; nested action has an unverified download.
+        root_yml = """\
+name: Root
+runs:
+  using: composite
+  steps:
+    - uses: other/helper@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"""
+        nested_yml = """\
+name: Helper
+runs:
+  using: composite
+  steps:
+    - name: Download
+      shell: bash
+      run: |
+        curl -fsSLO https://example.com/tool.tar.gz
+"""
+
+        def fake_action_yml(org, repo, commit, sub_path=""):
+            if org == "myorg":
+                return root_yml
+            if org == "other":
+                return nested_yml
+            return None
+
+        def fake_file(org, repo, commit, path):
+            return None
+
+        with mock.patch("verify_action_build.security.fetch_action_yml", side_effect=fake_action_yml):
+            with mock.patch("verify_action_build.security.fetch_file_from_github", side_effect=fake_file):
+                warnings, failures = analyze_binary_downloads_recursive(
+                    "myorg", "rootrepo", "b" * 40,
+                )
+        assert len(failures) >= 1
+        assert any("tool.tar.gz" in f for f in failures)
+
+    def test_skips_trusted_org(self):
+        # Nested uses: actions/checkout — should be skipped (trusted), so no
+        # recursion into it even if it had downloads.
+        root_yml = """\
+name: Root
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@cccccccccccccccccccccccccccccccccccccccc
+"""
+
+        def fake_action_yml(org, repo, commit, sub_path=""):
+            if org == "myorg":
+                return root_yml
+            raise AssertionError(f"should not fetch nested yml for {org}/{repo}")
+
+        with mock.patch("verify_action_build.security.fetch_action_yml", side_effect=fake_action_yml):
+            with mock.patch("verify_action_build.security.fetch_file_from_github", return_value=None):
+                warnings, failures = analyze_binary_downloads_recursive(
+                    "myorg", "rootrepo", "b" * 40,
+                )
+        assert failures == []
 
 
 class TestAnalyzeRepoMetadata:

--- a/utils/verify_action_build/cli.py
+++ b/utils/verify_action_build/cli.py
@@ -82,11 +82,22 @@ def main() -> None:
         action="store_true",
         help="Show Docker build step summary on successful builds (always shown on failure)",
     )
+    parser.add_argument(
+        "--no-binary-download-check",
+        action="store_true",
+        help=(
+            "Disable the binary download verification check (enabled by default). "
+            "The check scans Dockerfiles, run: blocks and referenced scripts for "
+            "curl/wget/ADD downloads of binaries or scripts and fails the run if "
+            "the file has no detectable checksum/signature verification."
+        ),
+    )
     args = parser.parse_args()
 
     ci_mode = args.ci
     cache = not args.no_cache
     show_build_steps = args.show_build_steps
+    check_binary_downloads = not args.no_binary_download_check
 
     if not shutil.which("docker"):
         console.print("[red]Error:[/red] docker is required but not found in PATH")
@@ -117,12 +128,26 @@ def main() -> None:
             _exit(1)
         for ref in action_refs:
             console.print(f"  Extracted action reference from PR #{args.from_pr}: [bold]{ref}[/bold]")
-        passed = all(verify_single_action(ref, gh=gh, ci_mode=ci_mode, cache=cache, show_build_steps=show_build_steps) for ref in action_refs)
+        passed = all(
+            verify_single_action(
+                ref, gh=gh, ci_mode=ci_mode, cache=cache,
+                show_build_steps=show_build_steps,
+                check_binary_downloads=check_binary_downloads,
+            )
+            for ref in action_refs
+        )
         _exit(0 if passed else 1)
     elif args.check_dependabot_prs:
-        check_dependabot_prs(gh=gh, cache=cache, show_build_steps=show_build_steps)
+        check_dependabot_prs(
+            gh=gh, cache=cache, show_build_steps=show_build_steps,
+            check_binary_downloads=check_binary_downloads,
+        )
     elif args.action_ref:
-        passed = verify_single_action(args.action_ref, gh=gh, ci_mode=ci_mode, cache=cache, show_build_steps=show_build_steps)
+        passed = verify_single_action(
+            args.action_ref, gh=gh, ci_mode=ci_mode, cache=cache,
+            show_build_steps=show_build_steps,
+            check_binary_downloads=check_binary_downloads,
+        )
         _exit(0 if passed else 1)
     else:
         parser.print_help()

--- a/utils/verify_action_build/dependabot.py
+++ b/utils/verify_action_build/dependabot.py
@@ -35,7 +35,10 @@ def get_gh_user(gh: GitHubClient | None = None) -> str:
     return gh.get_authenticated_user()
 
 
-def check_dependabot_prs(gh: GitHubClient, cache: bool = True, show_build_steps: bool = False) -> None:
+def check_dependabot_prs(
+    gh: GitHubClient, cache: bool = True, show_build_steps: bool = False,
+    check_binary_downloads: bool = True,
+) -> None:
     """List open dependabot PRs, verify each, and optionally merge."""
     console.print()
     console.rule("[bold]Dependabot PR Review[/bold]")
@@ -158,10 +161,17 @@ def check_dependabot_prs(gh: GitHubClient, cache: bool = True, show_build_steps:
                         sub_ref = f"{org_repo}/{sp}@{commit_hash}"
                     else:
                         sub_ref = f"{org_repo}@{commit_hash}"
-                    if not verify_single_action(sub_ref, gh=gh, cache=cache, show_build_steps=show_build_steps):
+                    if not verify_single_action(
+                        sub_ref, gh=gh, cache=cache, show_build_steps=show_build_steps,
+                        check_binary_downloads=check_binary_downloads,
+                    ):
                         passed = False
             else:
-                if not verify_single_action(f"{org_repo}@{commit_hash}", gh=gh, cache=cache, show_build_steps=show_build_steps):
+                if not verify_single_action(
+                    f"{org_repo}@{commit_hash}", gh=gh, cache=cache,
+                    show_build_steps=show_build_steps,
+                    check_binary_downloads=check_binary_downloads,
+                ):
                     passed = False
 
         if not passed:

--- a/utils/verify_action_build/security.py
+++ b/utils/verify_action_build/security.py
@@ -19,7 +19,10 @@
 """Security analysis checks for GitHub Actions."""
 
 import json
+import os
 import re
+
+import requests
 
 from .console import console, link
 from .github_client import GitHubClient
@@ -724,9 +727,119 @@ _VERIFICATION_PATTERNS = [
 ]
 
 
+# Patterns indicating a JS/TS download of a remote artifact. Most JS actions
+# that fetch binaries go through @actions/tool-cache's downloadTool (which
+# does NOT verify checksums), or via node's http/https, fetch, axios, or
+# @actions/http-client. Each of these should have a companion hash/signature
+# check in the same file to count as verified.
+_JS_DOWNLOAD_PATTERNS = [
+    re.compile(r"\btc\.downloadTool\s*\("),
+    re.compile(r"(?<![a-zA-Z_.])downloadTool\s*\("),
+    re.compile(r"\bfetch\s*\([^)]*['\"`]https?://"),
+    re.compile(r"\bhttps?\.(?:get|request)\s*\("),
+    re.compile(r"\baxios(?:\.(?:get|post|request))?\s*\("),
+    re.compile(r"\bnew\s+HttpClient\s*\("),
+    re.compile(r"\brequire\(\s*['\"`]node-fetch['\"`]"),
+]
+
+# Verification patterns in JS/TS source: node crypto, WebCrypto, or common
+# sigstore/cosign / custom "verify" helper names.
+_JS_VERIFICATION_PATTERNS = [
+    re.compile(r"\bcrypto\.createHash\s*\("),
+    re.compile(r"\bcrypto\.subtle\.digest\b"),
+    re.compile(r"\bsubtle\.verify\s*\("),
+    re.compile(r"\b@noble/hashes\b"),
+    re.compile(r"\bsigstore\b", re.IGNORECASE),
+    re.compile(r"\bcosign\b", re.IGNORECASE),
+    re.compile(r"\bverifySignature\b"),
+    re.compile(r"\bverifyChecksum\b"),
+    re.compile(r"\bcomputeHash\b"),
+]
+
+_JS_SOURCE_EXTENSIONS = (".ts", ".js", ".mjs", ".cjs")
+_JS_SCAN_DIR_PREFIXES = ("src/", "lib/", "source/", "sources/", "scripts/")
+_JS_EXCLUDE_DIR_PREFIXES = (
+    "dist/", "build/", "out/", "node_modules/", "coverage/",
+    "__tests__/", "test/", "tests/", "examples/", "example/",
+    "docs/", ".github/",
+)
+
+
 def _line_is_pkg_manager(line: str) -> bool:
     lower = line.lower()
     return any(marker in lower for marker in _PKG_MANAGER_MARKERS)
+
+
+def _find_binary_downloads_js(content: str) -> list[tuple[int, str]]:
+    """Find lines in JS/TS source that fetch remote artifacts.
+
+    Flags calls to ``tc.downloadTool`` / ``downloadTool``, bare ``fetch`` to
+    an http(s) URL, node's ``http(s).get`` / ``.request``, ``axios.*``, and
+    ``new HttpClient()``. Skips comment-only lines.
+    """
+    findings: list[tuple[int, str]] = []
+    for i, line in enumerate(content.splitlines(), 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("//") or stripped.startswith("*"):
+            continue
+        if any(p.search(line) for p in _JS_DOWNLOAD_PATTERNS):
+            findings.append((i, stripped[:120]))
+    return findings
+
+
+def _list_repo_files(org: str, repo: str, commit_hash: str) -> list[str]:
+    """List every blob path in the repo at ``commit_hash`` via the trees API.
+
+    Returns an empty list on error, auth failure, or truncated results (the
+    caller should treat "no files discovered" as best-effort, not canonical).
+    """
+    url = f"https://api.github.com/repos/{org}/{repo}/git/trees/{commit_hash}?recursive=1"
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        resp = requests.get(url, timeout=15, headers=headers)
+        if not resp.ok:
+            return []
+        data = resp.json()
+        if data.get("truncated"):
+            return []
+        return [t["path"] for t in data.get("tree", []) if t.get("type") == "blob"]
+    except requests.RequestException:
+        return []
+
+
+def _discover_js_source_files(
+    org: str, repo: str, commit_hash: str, sub_path: str,
+) -> list[tuple[str, str]]:
+    """Return ``(path, content)`` for JS/TS source files worth scanning.
+
+    Includes files at the repo root and under conventional source dirs
+    (``src/``, ``lib/``, …). Excludes compiled output, vendored modules,
+    test/example dirs, and generated docs. For monorepo sub-actions the
+    ``sub_path`` acts as a prefix filter.
+    """
+    files: list[tuple[str, str]] = []
+    all_paths = _list_repo_files(org, repo, commit_hash)
+    if not all_paths:
+        return files
+
+    prefix = f"{sub_path.rstrip('/')}/" if sub_path else ""
+    for path in all_paths:
+        if prefix and not path.startswith(prefix):
+            continue
+        rel = path[len(prefix):] if prefix else path
+        if not rel.endswith(_JS_SOURCE_EXTENSIONS):
+            continue
+        if any(rel.startswith(d) for d in _JS_EXCLUDE_DIR_PREFIXES):
+            continue
+        if "/" in rel and not any(rel.startswith(d) for d in _JS_SCAN_DIR_PREFIXES):
+            continue
+        content = fetch_file_from_github(org, repo, commit_hash, path)
+        if content is not None:
+            files.append((rel, content))
+    return files
 
 
 def _find_binary_downloads(content: str) -> list[tuple[int, str]]:
@@ -857,7 +970,12 @@ def analyze_binary_downloads(
         if content is not None:
             files_to_scan.append((script_path, content))
 
-    if not files_to_scan:
+    # JS/TS source files: shell-pattern downloads (curl/wget) are rare here
+    # but JS actions commonly fetch binaries via @actions/tool-cache etc.,
+    # so discover those separately and scan with JS-specific patterns.
+    js_files_to_scan = _discover_js_source_files(org, repo, commit_hash, sub_path)
+
+    if not files_to_scan and not js_files_to_scan:
         return warnings, failures
 
     console.print()
@@ -894,6 +1012,39 @@ def analyze_binary_downloads(
             for line_num, snippet in downloads:
                 failures.append(
                     f"{path} line {line_num}: unverified download: {snippet[:80]}"
+                )
+
+    for path, content in js_files_to_scan:
+        downloads = _find_binary_downloads_js(content)
+        if not downloads:
+            continue
+        any_downloads = True
+        has_verify = any(p.search(content) for p in _JS_VERIFICATION_PATTERNS)
+        if has_verify:
+            console.print(
+                f"  [green]✓[/green] {path}: {len(downloads)} JS download(s), "
+                f"verification present in file"
+            )
+            for line_num, snippet in downloads[:3]:
+                console.print(f"    [dim]line {line_num}:[/dim] [dim]{snippet}[/dim]")
+            if len(downloads) > 3:
+                console.print(f"    [dim]... and {len(downloads) - 3} more[/dim]")
+            for line_num, snippet in downloads:
+                warnings.append(
+                    f"{path} line {line_num}: JS download present (review coverage): {snippet[:80]}"
+                )
+        else:
+            console.print(
+                f"  [red]✗[/red] {path}: {len(downloads)} unverified JS download(s) "
+                f"[red bold](no checksum/signature check in file)[/red bold]"
+            )
+            for line_num, snippet in downloads[:5]:
+                console.print(f"    [dim]line {line_num}:[/dim] [red]{snippet}[/red]")
+            if len(downloads) > 5:
+                console.print(f"    [dim]... and {len(downloads) - 5} more[/dim]")
+            for line_num, snippet in downloads:
+                failures.append(
+                    f"{path} line {line_num}: unverified JS download: {snippet[:80]}"
                 )
 
     if not any_downloads:

--- a/utils/verify_action_build/security.py
+++ b/utils/verify_action_build/security.py
@@ -669,6 +669,283 @@ def analyze_action_metadata(
     return warnings
 
 
+# Commands that fetch resources over HTTP(S). Dockerfile ADD <url> is also a download.
+_DOWNLOAD_LINE_PATTERNS = [
+    re.compile(r"\bcurl\b", re.IGNORECASE),
+    re.compile(r"\bwget\b", re.IGNORECASE),
+    re.compile(r"\bInvoke-WebRequest\b", re.IGNORECASE),
+    re.compile(r"\biwr\b", re.IGNORECASE),
+    re.compile(r"^\s*ADD\s+https?://", re.IGNORECASE),
+]
+
+# Extensions that typically indicate binary or executable downloads.
+_BINARY_EXTS = (
+    ".tar.gz", ".tgz", ".tar.bz2", ".tar.xz", ".tar", ".zip",
+    ".exe", ".msi", ".deb", ".rpm", ".dmg", ".pkg", ".appimage",
+    ".jar", ".so", ".dylib", ".dll", ".bin",
+)
+
+# Pipe-to-shell: curl/wget output piped straight into a shell interpreter.
+_PIPE_TO_SHELL = re.compile(
+    r"\b(curl|wget|iwr|Invoke-WebRequest)\b[^\n]*\|\s*(ba|z|k|a)?sh\b",
+    re.IGNORECASE,
+)
+
+# Package-manager invocations that bring their own integrity verification —
+# skip these so we don't flag `curl` mentioned as an arg to a package manager.
+_PKG_MANAGER_MARKERS = (
+    "apt-get", "apt install", "apt update", "apt-cache",
+    "apk add", "apk update", "yum install", "dnf install",
+    "zypper install", "pacman -s", "brew install",
+    "pip install", "pip3 install", "pipx install", "uv pip", "uv tool",
+    "npm install", "npm ci", "pnpm install", "yarn install", "yarn add",
+    "gem install", "go install ", "go get ", "cargo install ",
+    "choco install", "scoop install",
+    "tdnf install", "microdnf install",
+)
+
+# Patterns indicating cryptographic verification of a downloaded artifact.
+_VERIFICATION_PATTERNS = [
+    re.compile(r"\bsha(1|256|384|512)sum\b"),
+    re.compile(r"\bmd5sum\b"),
+    re.compile(r"\bb2sum\b"),
+    re.compile(r"\bshasum\s+-a\s+(1|256|384|512)\b"),
+    re.compile(r"\bopenssl\s+(dgst|sha256|sha512)", re.IGNORECASE),
+    re.compile(r"\bgpg2?\b[^\n]*--verify", re.IGNORECASE),
+    re.compile(r"\bcosign\s+verify", re.IGNORECASE),
+    re.compile(r"\bslsa-verifier\b"),
+    re.compile(r"\bgh\s+attestation\s+verify\b"),
+    re.compile(r"\bminisign\b"),
+    re.compile(r"\bssh-keygen\s+-Y\s+verify\b"),
+    re.compile(r"\bCertUtil\b[^\n]*-hashfile", re.IGNORECASE),
+    re.compile(r"\bGet-FileHash\b", re.IGNORECASE),
+    # Inline checksum compare:  echo "<hash>  file" | sha256sum -c
+    re.compile(r'["\'][a-f0-9]{32,}\s+\*?\S+["\']', re.IGNORECASE),
+]
+
+
+def _line_is_pkg_manager(line: str) -> bool:
+    lower = line.lower()
+    return any(marker in lower for marker in _PKG_MANAGER_MARKERS)
+
+
+def _find_binary_downloads(content: str) -> list[tuple[int, str]]:
+    """Find lines that download binaries or scripts over HTTP(S).
+
+    Returns a list of ``(line_num, snippet)`` tuples. Lines that are part of a
+    package-manager invocation are skipped.
+    """
+    findings: list[tuple[int, str]] = []
+    for i, line in enumerate(content.splitlines(), 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if _line_is_pkg_manager(stripped):
+            continue
+
+        if _PIPE_TO_SHELL.search(line):
+            findings.append((i, stripped[:120]))
+            continue
+
+        if not any(p.search(stripped) for p in _DOWNLOAD_LINE_PATTERNS):
+            continue
+
+        url_match = re.search(r"https?://\S+", stripped)
+        if not url_match:
+            continue
+        url = url_match.group(0).rstrip(",;'\")}\\")
+
+        if url.lower().endswith(_BINARY_EXTS):
+            findings.append((i, stripped[:120]))
+            continue
+        if stripped.upper().startswith("ADD "):
+            findings.append((i, stripped[:120]))
+            continue
+        if any(m in url for m in ("/releases/download/", "/bin/", "/binaries/", "/dist/")):
+            findings.append((i, stripped[:120]))
+            continue
+    return findings
+
+
+def _has_verification(content: str) -> bool:
+    return any(p.search(content) for p in _VERIFICATION_PATTERNS)
+
+
+def _extract_run_blocks(action_yml: str) -> list[str]:
+    """Return the textual contents of every ``run:`` block in an action.yml."""
+    blocks: list[str] = []
+    lines = action_yml.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = re.match(r"(\s*)run:\s*[|>][+-]?\s*$", line)
+        if m:
+            indent = len(m.group(1))
+            i += 1
+            block_lines: list[str] = []
+            while i < len(lines):
+                nxt = lines[i]
+                if nxt.strip() == "":
+                    block_lines.append("")
+                    i += 1
+                    continue
+                leading = len(nxt) - len(nxt.lstrip())
+                if leading <= indent:
+                    break
+                block_lines.append(nxt)
+                i += 1
+            blocks.append("\n".join(block_lines))
+            continue
+        m2 = re.match(r"\s*run:\s+(\S.*)$", line)
+        if m2:
+            blocks.append(m2.group(1))
+        i += 1
+    return blocks
+
+
+def analyze_binary_downloads(
+    org: str, repo: str, commit_hash: str, sub_path: str = "",
+) -> tuple[list[str], list[str]]:
+    """Scan Dockerfile, ``action.yml`` run blocks and referenced scripts for
+    binary/script downloads that lack a detectable verification step.
+
+    Returns ``(warnings, failures)``:
+      * ``failures`` — downloads in a file with no verification patterns at all.
+        These cause the check to fail.
+      * ``warnings`` — downloads in a file that does contain verification
+        (informational; reviewer should confirm coverage).
+    """
+    warnings: list[str] = []
+    failures: list[str] = []
+
+    files_to_scan: list[tuple[str, str]] = []
+
+    df_candidates = [f"{sub_path}/Dockerfile", "Dockerfile"] if sub_path else ["Dockerfile"]
+    for df_path in df_candidates:
+        content = fetch_file_from_github(org, repo, commit_hash, df_path)
+        if content:
+            files_to_scan.append((df_path, content))
+            break
+
+    action_yml = fetch_action_yml(org, repo, commit_hash, sub_path)
+    if action_yml:
+        for idx, block in enumerate(_extract_run_blocks(action_yml), start=1):
+            if block.strip():
+                files_to_scan.append((f"action.yml [run block #{idx}]", block))
+
+    script_files: set[str] = set()
+    if action_yml:
+        for line in action_yml.splitlines():
+            stripped = line.strip()
+            if "${{" in stripped and "}}" in stripped:
+                continue
+            for ext in (".sh", ".bash", ".py", ".ps1"):
+                for m in re.findall(r"(?<![.\w])[\w][\w./-]*" + re.escape(ext) + r"\b", stripped):
+                    clean = m.lstrip("./").strip("'\"")
+                    if any(p in clean for p in ("steps.", "outputs.", "inputs.")):
+                        continue
+                    if re.search(r"https?://.*" + re.escape(m), stripped):
+                        continue
+                    if clean and clean.count("/") <= 3:
+                        script_files.add(clean)
+
+    for script_path in sorted(script_files):
+        base_path = f"{sub_path}/{script_path}" if sub_path else script_path
+        content = fetch_file_from_github(org, repo, commit_hash, base_path)
+        if content is None:
+            content = fetch_file_from_github(org, repo, commit_hash, script_path)
+        if content is not None:
+            files_to_scan.append((script_path, content))
+
+    if not files_to_scan:
+        return warnings, failures
+
+    console.print()
+    console.rule("[bold]Binary Download Verification[/bold]")
+
+    any_downloads = False
+    for path, content in files_to_scan:
+        downloads = _find_binary_downloads(content)
+        if not downloads:
+            continue
+        any_downloads = True
+        if _has_verification(content):
+            console.print(
+                f"  [green]✓[/green] {path}: {len(downloads)} download(s), "
+                f"verification present in file"
+            )
+            for line_num, snippet in downloads[:3]:
+                console.print(f"    [dim]line {line_num}:[/dim] [dim]{snippet}[/dim]")
+            if len(downloads) > 3:
+                console.print(f"    [dim]... and {len(downloads) - 3} more[/dim]")
+            for line_num, snippet in downloads:
+                warnings.append(
+                    f"{path} line {line_num}: download present (review coverage): {snippet[:80]}"
+                )
+        else:
+            console.print(
+                f"  [red]✗[/red] {path}: {len(downloads)} unverified download(s) "
+                f"[red bold](no checksum/signature check in file)[/red bold]"
+            )
+            for line_num, snippet in downloads[:5]:
+                console.print(f"    [dim]line {line_num}:[/dim] [red]{snippet}[/red]")
+            if len(downloads) > 5:
+                console.print(f"    [dim]... and {len(downloads) - 5} more[/dim]")
+            for line_num, snippet in downloads:
+                failures.append(
+                    f"{path} line {line_num}: unverified download: {snippet[:80]}"
+                )
+
+    if not any_downloads:
+        console.print("  [green]✓[/green] No binary downloads detected")
+
+    return warnings, failures
+
+
+def analyze_binary_downloads_recursive(
+    org: str, repo: str, commit_hash: str, sub_path: str = "",
+    _depth: int = 0, _visited: set | None = None,
+) -> tuple[list[str], list[str]]:
+    """Run :func:`analyze_binary_downloads` for this action and recurse through
+    composite nested actions (respecting hash-pinning and trusted-org skips)."""
+    MAX_DEPTH = 3
+    if _visited is None:
+        _visited = set()
+
+    key = f"{org}/{repo}/{sub_path}@{commit_hash}"
+    if key in _visited:
+        return [], []
+    _visited.add(key)
+
+    warnings, failures = analyze_binary_downloads(org, repo, commit_hash, sub_path)
+
+    if _depth >= MAX_DEPTH:
+        return warnings, failures
+
+    action_yml = fetch_action_yml(org, repo, commit_hash, sub_path)
+    if not action_yml:
+        return warnings, failures
+    if detect_action_type_from_yml(action_yml) != "composite":
+        return warnings, failures
+
+    for ref_info in extract_composite_uses(action_yml):
+        if ref_info.get("is_local") or ref_info.get("is_docker"):
+            continue
+        if not ref_info.get("is_hash_pinned"):
+            continue
+        r_org = ref_info["org"]
+        if r_org in {"actions", "github"}:
+            continue
+        sub_w, sub_f = analyze_binary_downloads_recursive(
+            r_org, ref_info["repo"], ref_info["ref"], ref_info["sub_path"],
+            _depth=_depth + 1, _visited=_visited,
+        )
+        warnings.extend(sub_w)
+        failures.extend(sub_f)
+
+    return warnings, failures
+
+
 def analyze_repo_metadata(
     org: str, repo: str, commit_hash: str,
 ) -> list[str]:

--- a/utils/verify_action_build/verification.py
+++ b/utils/verify_action_build/verification.py
@@ -192,6 +192,37 @@ def verify_single_action(
         checks_performed.append(("Action type detection", "info", action_type))
 
         is_js_action = action_type.startswith("node") or action_type in ("unknown",)
+
+        # Binary-download verification runs for every action type. JS actions
+        # can and do shell out to fetch pre-built binaries (e.g. platform-
+        # specific CLIs) from the action's own `run:` blocks or Dockerfile,
+        # and we want to flag those when they lack a checksum/signature step.
+        if check_binary_downloads:
+            bd_warnings, bd_failures = analyze_binary_downloads_recursive(
+                org, repo, commit_hash, sub_path,
+            )
+            binary_download_failures.extend(bd_failures)
+            if bd_failures:
+                checks_performed.append((
+                    "Binary download verification", "fail",
+                    f"{len(bd_failures)} unverified download(s)",
+                ))
+            elif bd_warnings:
+                checks_performed.append((
+                    "Binary download verification", "warn",
+                    f"{len(bd_warnings)} download(s); verification present",
+                ))
+            else:
+                checks_performed.append((
+                    "Binary download verification", "pass",
+                    "no downloads or all verified",
+                ))
+        else:
+            checks_performed.append((
+                "Binary download verification", "skip",
+                "disabled via --no-binary-download-check",
+            ))
+
         if not is_js_action:
             console.print()
             console.print(
@@ -272,34 +303,6 @@ def verify_single_action(
                 "warn" if repo_warnings else "pass",
                 f"{len(repo_warnings)} warning(s)" if repo_warnings else "ok",
             ))
-
-            if check_binary_downloads:
-                bd_warnings, bd_failures = analyze_binary_downloads_recursive(
-                    org, repo, commit_hash, sub_path,
-                )
-                non_js_warnings.extend(bd_warnings)
-                non_js_warnings.extend(bd_failures)
-                binary_download_failures.extend(bd_failures)
-                if bd_failures:
-                    checks_performed.append((
-                        "Binary download verification", "fail",
-                        f"{len(bd_failures)} unverified download(s)",
-                    ))
-                elif bd_warnings:
-                    checks_performed.append((
-                        "Binary download verification", "warn",
-                        f"{len(bd_warnings)} download(s); verification present",
-                    ))
-                else:
-                    checks_performed.append((
-                        "Binary download verification", "pass",
-                        "no downloads or all verified",
-                    ))
-            else:
-                checks_performed.append((
-                    "Binary download verification", "skip",
-                    "disabled via --no-binary-download-check",
-                ))
 
             if non_js_warnings:
                 console.print()

--- a/utils/verify_action_build/verification.py
+++ b/utils/verify_action_build/verification.py
@@ -35,6 +35,7 @@ from .docker_build import build_in_docker
 from .github_client import GitHubClient
 from .security import (
     analyze_action_metadata,
+    analyze_binary_downloads_recursive,
     analyze_dependency_pinning,
     analyze_dockerfile,
     analyze_nested_actions,
@@ -165,6 +166,7 @@ def offer_open_and_approve(
 def verify_single_action(
     action_ref: str, gh: GitHubClient | None = None, ci_mode: bool = False,
     cache: bool = True, show_build_steps: bool = False,
+    check_binary_downloads: bool = True,
 ) -> bool:
     """Verify a single action reference. Returns True if verification passed."""
     org, repo, sub_path, commit_hash = parse_action_ref(action_ref)
@@ -177,6 +179,7 @@ def verify_single_action(
     non_js_warnings: list[str] = []
     checked_actions: list[dict] = []
     matched_with_approved_lockfile = False
+    binary_download_failures: list[str] = []
 
     with tempfile.TemporaryDirectory(prefix="verify-action-") as tmp:
         work_dir = Path(tmp)
@@ -269,6 +272,34 @@ def verify_single_action(
                 "warn" if repo_warnings else "pass",
                 f"{len(repo_warnings)} warning(s)" if repo_warnings else "ok",
             ))
+
+            if check_binary_downloads:
+                bd_warnings, bd_failures = analyze_binary_downloads_recursive(
+                    org, repo, commit_hash, sub_path,
+                )
+                non_js_warnings.extend(bd_warnings)
+                non_js_warnings.extend(bd_failures)
+                binary_download_failures.extend(bd_failures)
+                if bd_failures:
+                    checks_performed.append((
+                        "Binary download verification", "fail",
+                        f"{len(bd_failures)} unverified download(s)",
+                    ))
+                elif bd_warnings:
+                    checks_performed.append((
+                        "Binary download verification", "warn",
+                        f"{len(bd_warnings)} download(s); verification present",
+                    ))
+                else:
+                    checks_performed.append((
+                        "Binary download verification", "pass",
+                        "no downloads or all verified",
+                    ))
+            else:
+                checks_performed.append((
+                    "Binary download verification", "skip",
+                    "disabled via --no-binary-download-check",
+                ))
 
             if non_js_warnings:
                 console.print()
@@ -397,9 +428,11 @@ def verify_single_action(
         ci_mode=ci_mode,
     )
 
+    overall_passed = all_match and not binary_download_failures
+
     console.print()
     checklist_hint = f"\n[dim]Security review checklist: {SECURITY_CHECKLIST_URL}[/dim]"
-    if all_match:
+    if overall_passed:
         if is_js_action:
             if has_node_modules:
                 result_msg = "[green bold]Vendored node_modules matches fresh install[/green bold]"
@@ -418,14 +451,23 @@ def verify_single_action(
         border = "yellow" if not is_js_action and non_js_warnings else "green"
         console.print(Panel(result_msg + checklist_hint, border_style=border, title="RESULT"))
     else:
-        if matched_with_approved_lockfile:
+        if is_js_action:
+            if matched_with_approved_lockfile:
+                fail_msg = (
+                    "[red bold]Compiled JS only matches when rebuilt with the "
+                    "previously approved version's lock files — devDependencies "
+                    "changed and dist/ was not rebuilt[/red bold]"
+                )
+            else:
+                fail_msg = "[red bold]Differences detected between published and rebuilt JS[/red bold]"
+        elif binary_download_failures:
             fail_msg = (
-                "[red bold]Compiled JS only matches when rebuilt with the "
-                "previously approved version's lock files — devDependencies "
-                "changed and dist/ was not rebuilt[/red bold]"
+                f"[red bold]{action_type} action — "
+                f"{len(binary_download_failures)} unverified binary download(s) detected "
+                f"(no checksum/signature check in file)[/red bold]"
             )
         else:
-            fail_msg = "[red bold]Differences detected between published and rebuilt JS[/red bold]"
+            fail_msg = f"[red bold]{action_type} action — verification failed[/red bold]"
         console.print(
             Panel(
                 fail_msg + checklist_hint,
@@ -436,4 +478,4 @@ def verify_single_action(
 
     offer_open_and_approve(org, repo, commit_hash, sub_path, ci_mode=ci_mode)
 
-    return all_match
+    return overall_passed


### PR DESCRIPTION
## Summary

Implements the ["Checking if downloaded binaries are verified" criterion from #686](https://github.com/apache/infrastructure-actions/issues/686).

Adds a new `Binary Download Verification` check to `verify-action-build` that scans:
- Dockerfiles
- `action.yml` `run:` blocks
- Shell / Python / PowerShell scripts referenced by the action

For each file, it looks for binary or script downloads (curl, wget, Invoke-WebRequest, Dockerfile `ADD <url>`, pipe-to-shell) and requires a detectable verification step (sha*sum, shasum, md5sum, b2sum, openssl dgst, gpg --verify, cosign verify, slsa-verifier, gh attestation verify, minisign, ssh-keygen -Y verify, CertUtil -hashfile, Get-FileHash).

Package-manager invocations (apt/apk/pip/npm/brew/cargo/go install/etc.) are skipped because they provide their own integrity verification.

A file that contains downloads but no verification patterns causes the check to **fail** and the overall verification run to exit non-zero.

The check recurses through composite nested actions (MAX_DEPTH=3, skipping trusted orgs `actions` / `github` and unpinned refs), so a root composite action is held responsible for unverified downloads in the nested composites it calls.

Toggleable via `--no-binary-download-check` — enabled by default.

## Test plan

- [x] 14 new unit tests in `test_security.py` (135 tests total, all green):
  - pipe-to-shell fails
  - curl of `.tar.gz` without verification fails
  - sha256sum verification passes
  - gpg --verify passes
  - cosign verify-blob passes
  - `apk add` / `pip install` lines are not flagged
  - Dockerfile `ADD <url>` without verification fails
  - action.yml `run:` block scanning works (pass + fail cases)
  - GitHub releases binary path (`/releases/download/`) flagged
  - Recursion into a composite nested action surfaces its downloads
  - Nested `actions/checkout` (trusted org) is skipped
- [x] Test end-to-end against a real composite action with a known binary download
- [x] Test `--no-binary-download-check` flag disables the check