### PR TITLE
ci: verify manual allowlist PRs via verify-action-build

### DIFF
--- a/.github/workflows/verify_manual_action.yml
+++ b/.github/workflows/verify_manual_action.yml
@@ -1,0 +1,60 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Runs verify-action-build on PRs that manually add a new action to the
+# allow list (touching actions.yml or approved_patterns.yml).  Complements
+# verify_dependabot_action.yml, which covers dependabot-authored PRs.
+#
+# The job exits with the verify script's exit code — success/failure is
+# surfaced through the status check on the PR.
+name: Verify Manual Allowlist PR
+
+on:
+  pull_request:
+    paths:
+      - actions.yml
+      - approved_patterns.yml
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  verify:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - run: pipx install uv
+
+      - name: Verify action build
+        run: |
+          # Disable workflow command processing so that strings like
+          # "##[add-matcher]" or "::error::" in action diffs are not
+          # interpreted as GitHub Actions commands.
+          stop_token="$(uuidgen)"
+          echo "::stop-commands::${stop_token}"
+          uv run utils/verify-action-build.py --ci --from-pr "${{ github.event.pull_request.number }}"
+          rc=$?
+          echo "::${stop_token}::"
+          exit $rc
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,15 @@ When creating a PR via `gh pr create --web`, GitHub will present a template choo
 template that matches the type of change. When opening a PR URL directly, you can append
 `&template=action_approval.md` or `&template=code_change.md` to pre-fill the appropriate template.
 
+## Documentation
+
+When you add, change, or remove a user-visible feature, workflow, script, or flag, update the
+corresponding reference documentation in the same PR. At minimum this means the relevant section of
+`README.md`; check other `*.md` files in the area you touched for stale references as well. A PR
+that introduces a new workflow in `.github/workflows/`, a new utility under `utils/`, or a new CLI
+flag is not complete until the docs describe it — reviewers should not have to ask "is this
+documented?".
+
 ## License headers
 
 All files must include the Apache License 2.0 header where the file format supports it. Use the

--- a/README.md
+++ b/README.md
@@ -246,7 +246,12 @@ The `--no-gh` mode supports all the same features as the default `gh`-based mode
 
 #### Automated Verification in CI
 
-Dependabot PRs that modify `.github/actions/for-dependabot-triggered-reviews/action.yml` are automatically verified by the `verify_dependabot_action.yml` workflow. It extracts the action reference from the PR, rebuilds the compiled JavaScript in Docker, and compares it against the published version. The workflow reports success or failure but does **not** auto-approve or merge — a human reviewer must still approve.
+Two workflows in `.github/workflows/` run `verify-action-build` on PRs that touch the allow list, so the verification status is visible on every PR as a required-candidate status check:
+
+- **`verify_dependabot_action.yml`** — triggers on Dependabot PRs that modify `.github/actions/for-dependabot-triggered-reviews/action.yml`. Extracts the action reference from the PR, rebuilds the compiled JavaScript in Docker, and compares it against the published version.
+- **`verify_manual_action.yml`** — triggers on human-authored PRs that modify `actions.yml` or `approved_patterns.yml` (i.e. manual allow-list additions / version bumps). Dependabot-authored PRs are skipped, since they are already covered by the workflow above.
+
+Both workflows use a regular `pull_request` trigger with read-only permissions and no PR comments — pass/fail is surfaced through the status check. Neither workflow auto-approves or merges; a human reviewer must still approve.
 
 The script exits with code **1** (failure) when something is unexpectedly broken — for example, the action cannot be compiled, the rebuilt JavaScript is invalid, or required tools are missing. In all other cases it exits with code **0** and produces reviewable diffs: a large diff does not by itself cause an error (e.g. major version bumps will naturally have big diffs). It is always up to a human reviewer to inspect the output, assess the changes, and decide whether the update is safe to approve.
 


### PR DESCRIPTION
## Summary

Adds a workflow that runs `verify-action-build` on PRs which manually add a new action to the allow list — i.e. those touching `actions.yml` or `approved_patterns.yml` and not authored by dependabot. Example PR this would have caught: #739.

Mirrors the existing `verify_dependabot_action.yml` pattern:
- `pull_request` trigger (not `pull_request_target` — avoids the privilege-escalation risk).
- Read-only permissions (`contents: read`, `pull-requests: read`).
- The `verify-action-build --ci --from-pr $N` script exits with rc, and that becomes the status check on the PR.
- `::stop-commands::` wrapper to neutralize any workflow-command strings that might appear in action diffs.
- `persist-credentials: false` on checkout.

Skipped for dependabot-authored PRs (already covered by `verify_dependabot_action.yml`).

## Test plan

- [ ] On this PR (no `actions.yml` change) — the workflow should **not** run.
- [ ] Simulate by opening a dummy PR that edits `actions.yml` — the workflow should run and pass/fail according to the verify result.
- [ ] Dependabot PRs that also touch `actions.yml` / `approved_patterns.yml` — should be skipped by the `if:` guard (the dependabot workflow handles them).