### PR TITLE
verify-action-build: fix RESULT panel cause on binary-download failure

### DIFF
--- a/utils/tests/verify_action_build/test_verification.py
+++ b/utils/tests/verify_action_build/test_verification.py
@@ -254,3 +254,108 @@ class TestVerifySingleActionLockFileRetry:
         assert len(js_rows) == 1
         assert js_rows[0][1] == "fail"
         assert "approved lock files" in js_rows[0][2]
+
+
+class TestVerifySingleActionResultMessage:
+    """The RESULT panel text must describe the actual failure cause."""
+
+    def _patch_stack(
+        self,
+        *,
+        approved: list[dict],
+        diff_js_side_effect,
+        binary_download_result,
+        action_type: str = "node20",
+    ):
+        patches = {
+            "parse_action_ref": mock.patch(
+                "verify_action_build.verification.parse_action_ref",
+                return_value=("org", "repo", "", "c" * 40),
+            ),
+            "find_approved_versions": mock.patch(
+                "verify_action_build.verification.find_approved_versions",
+                return_value=approved,
+            ),
+            "build_in_docker": mock.patch(
+                "verify_action_build.verification.build_in_docker",
+                return_value=_build_in_docker_result(action_type=action_type),
+            ),
+            "diff_js_files": mock.patch(
+                "verify_action_build.verification.diff_js_files",
+                side_effect=diff_js_side_effect,
+            ),
+            "show_approved_versions": mock.patch(
+                "verify_action_build.verification.show_approved_versions",
+                return_value=None,
+            ),
+            "show_commits_between": mock.patch(
+                "verify_action_build.verification.show_commits_between",
+            ),
+            "diff_approved_vs_new": mock.patch(
+                "verify_action_build.verification.diff_approved_vs_new",
+            ),
+            "analyze_binary_downloads_recursive": mock.patch(
+                "verify_action_build.verification.analyze_binary_downloads_recursive",
+                return_value=binary_download_result,
+            ),
+            "Panel": mock.patch("verify_action_build.verification.Panel"),
+        }
+        started = {name: p.start() for name, p in patches.items()}
+        started["_patchers"] = list(patches.values())
+        return started
+
+    def _stop(self, started):
+        for p in reversed(started["_patchers"]):
+            p.stop()
+
+    def _result_panel_message(self, panel_mock) -> str:
+        result_calls = [
+            c for c in panel_mock.call_args_list
+            if c.kwargs.get("title") == "RESULT"
+        ]
+        assert len(result_calls) == 1, (
+            f"expected exactly one RESULT panel, got {len(result_calls)}"
+        )
+        return result_calls[0].args[0]
+
+    def test_js_action_with_unverified_download_reports_binary_cause(self):
+        """Regression for the misleading RESULT panel seen on PR #724:
+
+        A JS action that rebuilds cleanly but fails the binary-download
+        check must surface the binary-download reason in the RESULT
+        panel, not the default JS-mismatch message.
+        """
+        started = self._patch_stack(
+            approved=[],
+            diff_js_side_effect=[True],
+            binary_download_result=(
+                [],
+                ["Dockerfile line 3: unverified download: curl -fsSL ..."],
+            ),
+        )
+        try:
+            result = verify_single_action("org/repo@" + "c" * 40, ci_mode=True)
+        finally:
+            self._stop(started)
+
+        assert result is False
+        msg = self._result_panel_message(started["Panel"])
+        assert "unverified binary download" in msg
+        assert "Differences detected between published and rebuilt JS" not in msg
+
+    def test_js_action_with_js_mismatch_reports_js_cause(self):
+        """JS mismatch without binary-download failures still reports the
+        JS-mismatch message (the original behaviour)."""
+        started = self._patch_stack(
+            approved=[],
+            diff_js_side_effect=[False],
+            binary_download_result=([], []),
+        )
+        try:
+            result = verify_single_action("org/repo@" + "c" * 40, ci_mode=True)
+        finally:
+            self._stop(started)
+
+        assert result is False
+        msg = self._result_panel_message(started["Panel"])
+        assert "Differences detected between published and rebuilt JS" in msg

--- a/utils/verify_action_build/verification.py
+++ b/utils/verify_action_build/verification.py
@@ -454,7 +454,11 @@ def verify_single_action(
         border = "yellow" if not is_js_action and non_js_warnings else "green"
         console.print(Panel(result_msg + checklist_hint, border_style=border, title="RESULT"))
     else:
-        if is_js_action:
+        # Pick the failure message based on the actual cause, not the action
+        # type. The binary-download check runs for every action type, so a
+        # JS action can fail this path with all_match=True when its only
+        # issue is an unverified download.
+        if not all_match:
             if matched_with_approved_lockfile:
                 fail_msg = (
                     "[red bold]Compiled JS only matches when rebuilt with the "


### PR DESCRIPTION
## Summary

Observed on [PR #724's verify run](https://github.com/apache/infrastructure-actions/actions/runs/24634855262/job/72028382958?pr=724): the summary table correctly showed `JS build verification: ✓ compiled JS matches rebuild` and `Binary download verification: ✗ 1 unverified download(s)` — but the RESULT panel still said "Differences detected between published and rebuilt JS", which was not the cause of failure.

## Root cause

In `verify_single_action`, the failure branch chose its message based on `is_js_action` first and hardcoded the JS-mismatch string for every JS action. Since #743, the binary-download check runs for *every* action type (including JS actions), so `overall_passed = all_match and not binary_download_failures` can go false via the second term alone — but the RESULT text would still blame JS.

## Fix

Dispatch on the actual failure condition:
- `all_match == False` → JS-mismatch message (with or without the lock-file-retry variant).
- Otherwise, `binary_download_failures` → binary-download message.
- Fallback → generic "verification failed".

## Test plan

- [x] New `TestVerifySingleActionResultMessage` class in `test_verification.py`:
  - `test_js_action_with_unverified_download_reports_binary_cause` — the regression case; **fails without the fix**, passes with it
  - `test_js_action_with_js_mismatch_reports_js_cause` — guards the original JS-mismatch path stays intact
- [x] Full `tests/verify_action_build/` suite green: 137 passed (was 135 before the 2 new tests)
- [x] Re-run verify on PR #724 after merge to confirm the RESULT panel reads correctly

## Related

- #743 — introduced the binary-download check
- PR #724 — run that surfaced the incorrect message