### PR TITLE
ci: add CODEOWNERS for default reviewer requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 # PRs to the right area experts, and ultimately merging, is welcome
 # but voluntary.  Additional reviewers (e.g. PMC members for actions
 # touching their area) should still be pulled in ad hoc.
-*            @dfoulks1 @potiuk @pkarwasz
+*            @dfoulks1 @potiuk @ppkarwasz
 
 # Area-specific owners — reviewed in addition to the defaults above.
 /pelican/    @dave2wave

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Default reviewers — requested automatically on every PR so they don't
+# have to be added by hand each time.  Being listed here does not
+# obligate anyone to review or to route PRs; it is a convenience so
+# that people who have shown up consistently get pinged.  Helping route
+# PRs to the right area experts, and ultimately merging, is welcome
+# but voluntary.  Additional reviewers (e.g. PMC members for actions
+# touching their area) should still be pulled in ad hoc.
+*            @dfoulks1 @raboof @potiuk
+
+# Area-specific owners — reviewed in addition to the defaults above.
+/pelican/    @dave2wave

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 # PRs to the right area experts, and ultimately merging, is welcome
 # but voluntary.  Additional reviewers (e.g. PMC members for actions
 # touching their area) should still be pulled in ad hoc.
-*            @dfoulks1 @raboof @potiuk
+*            @dfoulks1 @potiuk
 
 # Area-specific owners — reviewed in addition to the defaults above.
 /pelican/    @dave2wave

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 # PRs to the right area experts, and ultimately merging, is welcome
 # but voluntary.  Additional reviewers (e.g. PMC members for actions
 # touching their area) should still be pulled in ad hoc.
-*            @dfoulks1 @potiuk
+*            @dfoulks1 @potiuk @ppkarwasz
 
 # Area-specific owners — reviewed in addition to the defaults above.
 /pelican/    @dave2wave

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 # PRs to the right area experts, and ultimately merging, is welcome
 # but voluntary.  Additional reviewers (e.g. PMC members for actions
 # touching their area) should still be pulled in ad hoc.
-*            @dfoulks1 @potiuk @ppkarwasz
+*            @dfoulks1 @potiuk @pkarwasz
 
 # Area-specific owners — reviewed in addition to the defaults above.
 /pelican/    @dave2wave


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` so that `@dave2wave`, `@raboof` and `@potiuk` are automatically requested as reviewers on every PR, rather than being added by hand each time. Additional reviewers (area experts or PMC members affected by a particular change) can still be added ad hoc on top of the defaults.

## Test plan

- [ ] After merge, the next PR opened against `main` should auto-request all three as reviewers.
- [ ] Existing branch-protection rules continue to work (this PR does not change them).