### PR TITLE
verify-action-build: support Deno-based actions (deno task bundle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ uv run utils/verify-action-build.py dorny/test-reporter@dc3a92680fcc15842eef52e8
 The script will:
 1. Clone the action at the specified commit inside an isolated Docker container
 2. Save the original `dist/` files as published in the repository
-3. Rebuild the action from source (`npm ci && npm run build`)
+3. Rebuild the action from source, picking the right toolchain automatically — Node.js (`npm ci && npm run build`, `yarn`, or `pnpm`), Dart (`dart compile js` when a `pubspec.yaml` is present), or Deno (`deno task bundle` when a `deno.json`/`deno.jsonc` is present)
 4. Reformat both versions of the JavaScript for readable comparison
 5. Show a colored diff of any differences
 

--- a/utils/tests/verify_action_build/test_docker_build.py
+++ b/utils/tests/verify_action_build/test_docker_build.py
@@ -99,6 +99,23 @@ class TestReadDockerfileTemplate:
         assert "/rebuilt-dist" in content
         assert "/original-dist" in content
 
+    def test_dart_support_present(self):
+        # Sanity check that the Dart branch wasn't accidentally removed.
+        content = _read_dockerfile_template()
+        assert "pubspec.yaml" in content
+        assert "apt-get install -y --no-install-recommends dart" in content
+        assert "dart pub get" in content
+
+    def test_deno_support_present(self):
+        content = _read_dockerfile_template()
+        # Install branch runs the official installer into /usr/local.
+        assert "deno.json" in content
+        assert "deno.jsonc" in content
+        assert "deno.land/install.sh" in content
+        assert "DENO_INSTALL=/usr/local" in content
+        # Build step invokes the conventional bundle task.
+        assert "deno task bundle" in content
+
 
 class TestPrintDockerBuildSteps:
     def test_parses_build_output(self):

--- a/utils/verify_action_build/dockerfiles/build_action.Dockerfile
+++ b/utils/verify_action_build/dockerfiles/build_action.Dockerfile
@@ -56,6 +56,22 @@ RUN if [ -f pubspec.yaml ]; then \
       echo "dart-pub-get: ran" >> /build-info.log; \
     fi
 
+# Deno-based actions (e.g. Kesin11/actions-timeline) emit the compiled JS
+# in their `dist/` folder via `deno task bundle`, typically driving
+# `@deno/dnt` or `esbuild`.  A pure-Deno action has no `package.json`, so
+# the npm build loop below would be a no-op; install the official deno
+# binary when `deno.json`/`deno.jsonc` is present so the build step can
+# invoke the task unchanged.
+RUN if [ -f deno.json ] || [ -f deno.jsonc ]; then \
+      apt-get update && \
+      apt-get install -y --no-install-recommends ca-certificates curl unzip && \
+      rm -rf /var/lib/apt/lists/* && \
+      curl -fsSL https://deno.land/install.sh \
+        | DENO_INSTALL=/usr/local sh -s -- --yes >/dev/null && \
+      /usr/local/bin/deno --version | head -1 >> /build-info.log && \
+      echo "deno: installed (deno.json(c) detected)" >> /build-info.log; \
+    fi
+
 # Detect action type from action.yml or action.yaml.
 # For monorepo sub-actions (SUB_PATH set), check <sub_path>/action.yml first,
 # falling back to the root action.yml.
@@ -211,7 +227,13 @@ RUN OUT_DIR=$(cat /out-dir.txt); \
     RUN_CMD=$(cat /run-cmd); \
     has_output() { [ -d "$OUT_DIR" ] && find "$OUT_DIR" \( -name '*.js' -o -name '*.cjs' -o -name '*.mjs' \) -print -quit | grep -q .; }; \
     BUILD_DONE=false; \
-    if [ -x build ] && ./build dist 2>/dev/null; then \
+    if [ "$BUILD_DONE" = "false" ] && { [ -f deno.json ] || [ -f deno.jsonc ]; }; then \
+      if deno task bundle 2>/dev/null; then \
+        echo "build-step: deno task bundle" >> /build-info.log; \
+        if has_output; then BUILD_DONE=true; fi; \
+      fi; \
+    fi && \
+    if [ "$BUILD_DONE" = "false" ] && [ -x build ] && ./build dist 2>/dev/null; then \
       echo "build-step: ./build dist" >> /build-info.log; \
       if has_output; then BUILD_DONE=true; fi; \
     fi && \


### PR DESCRIPTION
## Summary

Adds Deno support to `verify-action-build`, so Deno-based actions like [`Kesin11/actions-timeline`](https://github.com/Kesin11/actions-timeline) (PR #736) rebuild correctly and no longer trip the "JS build verification: ✗ DIFFERENCES DETECTED" check just because the container didn't know how to invoke their build.

Mirrors the pattern that landed for Dart in [9f87136](https://github.com/apache/infrastructure-actions/commit/9f87136646f64ae2cfc65bbfbd7b3905dd349407):

- **Install:** when `deno.json` or `deno.jsonc` is detected at the repo root, install the official `deno` binary into `/usr/local` via `deno.land/install.sh`.
- **Build:** before the existing root-level `./build` / npm-run / ncc-fallback loop, try `deno task bundle` (the Deno convention used by `@deno/dnt`, `esbuild`, etc.).
- **Skip:** leaves the rest of the build flow untouched; Node-only actions behave exactly as before.

## Root cause for PR #736

`Kesin11/actions-timeline`'s `dist/main.js` + `dist/post.js` are emitted by `deno task bundle` → `@deno/dnt`. The node:slim base had no `deno`, no `package.json`, so the npm loop did nothing, the rebuild was empty, and the diff showed "only in original" for both files. With this patch the rebuild succeeds and matches.

## Test plan

- [x] Unit: `TestReadDockerfileTemplate.test_deno_support_present` / `.test_dart_support_present` assert the key markers (`deno.json`, `deno.land/install.sh`, `deno task bundle`; `pubspec.yaml`, `dart pub get`) remain in the template. 137/137 tests pass.
- [x] End-to-end: `uv run utils/verify-action-build.py --from-pr 736 --ci --no-cache` now exits 0 with `JS build verification: ✓ compiled JS matches rebuild`.
- [ ] After merge: re-run the `verify_dependabot_action.yml` workflow on PR #736 and confirm it turns green.

## Related

- #736 — the Kesin11/actions-timeline bump that prompted this
- 9f87136 — Dart support (same pattern)