### PR TITLE
Allow erlef/setup-beam v1.24.0

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -376,6 +376,9 @@ erisu/license-checker-action:
     expires_at: 2026-07-05
   04511f4c052b5773f11e1c65b42cda88235c62ae:
     tag: v2.1.0
+erlef/setup-beam:
+  fc68ffb90438ef2936bbb3251622353b3dcb2f93:
+    tag: v1.24.0
 geekyeggo/delete-artifact:
   '*':
     keep: true


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview
closes https://issues.apache.org/jira/browse/INFRA-27826

Allow `apache/fluss-rust` (incubating) to use `erlef/setup-beam` for CI of its Elixir bindings. `erlef/setup-beam` is the de-facto standard setup action for BEAM-language projects (Erlang, Elixir, Gleam) and is maintained by the Erlang Ecosystem Foundation — a vendor-neutral organization supporting the Erlang/Elixir ecosystem. It is the direct equivalent of `actions/setup-python` or `actions/setup-node` for the BEAM VM.

Context:
- INFRA ticket: https://issues.apache.org/jira/browse/INFRA-27826
- Consumer PR: https://github.com/apache/fluss-rust/pull/497

**Name of action:** `erlef/setup-beam`

**URL of action:** https://github.com/erlef/setup-beam

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** `fc68ffb90438ef2936bbb3251622353b3dcb2f93` (v1.24.0)

## Permissions

The action installs Erlang/OTP and Elixir (or other BEAM toolchains) onto the runner. It requires no elevated repository permissions and does not access credentials. Calling workflows in apache/fluss-rust will keep `permissions:` minimal (default `contents: read`).

## Related Actions

No existing allowlisted action covers BEAM/Elixir toolchain setup. The closest analogues are `actions/setup-python`, `actions/setup-node`, and `astral-sh/setup-uv`, which handle other language ecosystems.

## Checklist

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license (MIT)
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured (ubuntu.yml, macos.yml, windows.yml)
- [x] Compiled JavaScript in `dist/` matches a clean rebuild (verified with `uv run utils/verify-action-build.py erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93` — all compiled JS matches, no binary downloads, action type node24) 
                        