### PR TITLE
pytest: enable colored output in CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Run tests
         run: |
           pipx install uv
-          uv run pytest
+          uv run pytest --color=yes
         env:
           GH_TOKEN: ${{ github.token }}
+          FORCE_COLOR: "1"
+          PY_COLORS: "1"


### PR DESCRIPTION
## Summary
- Pass `--color=yes` to pytest and export `FORCE_COLOR=1` / `PY_COLORS=1` in the pytest workflow so test output renders ANSI colors in the GitHub Actions log viewer.
- Covers both pytest's own output and Rich-based output from code under test (e.g. `verify-action-build`).

## Test plan
- [ ] Confirm CI pytest job output shows colored pass/fail markers and colorized tracebacks/Rich output.

Generated-by: Claude Opus 4.7 (1M context)