### PR TITLE
ci: auto-insert Apache license headers via insert-license pre-commit hook

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 #
 ---
 name: "CodeQL"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 #
 ---
 name: Pre-commit Checks

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 #
 name: pytest
 

--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 #
 name: rat
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 ---
 default_stages: [pre-commit]
 default_language_version:
@@ -29,3 +31,92 @@ repos:
         additional_dependencies: ['rich>=12.4.4', 'ruamel.yaml']
         require_serial: true
         files: ^actions\.yml$
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: ad1b27d73581aa16cca06fc4a0761fc563ffe8e8  # frozen: v1.5.6
+    hooks:
+      # Files in stash/ (except stash/pyproject.toml) carry the short-form
+      # Apache 2.0 license ("Copyright (c) The stash contributors / Licensed
+      # under the Apache License, Version 2.0") which RAT accepts. Adding the
+      # full ASF contributor header on top would just duplicate, so they are
+      # excluded across every ecosystem-specific hook below.
+      - id: insert-license
+        name: Add Apache license header to Python files
+        files: \.py$
+        exclude: ^stash/(?!pyproject\.toml).*$
+        args:
+          - --comment-style
+          - "#|#|#"
+          - --license-filepath
+          - license-templates/LICENSE.txt
+          - --fuzzy-match-generates-todo
+      - id: insert-license
+        name: Add Apache license header to YAML files
+        files: \.ya?ml$
+        # approved_patterns.yml is regenerated from actions.yml by gateway/.
+        # stash-action-test.yml uses the short-form Apache 2.0 license to
+        # match the rest of the stash sub-project.
+        exclude: |
+          (?x)
+          ^approved_patterns\.yml$|
+          ^stash/(?!pyproject\.toml).*$|
+          ^\.github/workflows/stash-action-test\.yml$
+        args:
+          - --comment-style
+          - "#|#|#"
+          - --license-filepath
+          - license-templates/LICENSE.txt
+          - --fuzzy-match-generates-todo
+      - id: insert-license
+        name: Add Apache license header to TOML files
+        files: \.toml$
+        args:
+          - --comment-style
+          - "#|#|#"
+          - --license-filepath
+          - license-templates/LICENSE.txt
+          - --fuzzy-match-generates-todo
+      - id: insert-license
+        name: Add Apache license header to shell scripts
+        files: \.(sh|bash)$
+        args:
+          - --comment-style
+          - "#|#|#"
+          - --license-filepath
+          - license-templates/LICENSE.txt
+          - --fuzzy-match-generates-todo
+      - id: insert-license
+        name: Add Apache license header to Dockerfiles
+        files: (^|/)Dockerfile$|\.Dockerfile$
+        args:
+          - --comment-style
+          - "#|#|#"
+          - --license-filepath
+          - license-templates/LICENSE.txt
+          - --fuzzy-match-generates-todo
+      - id: insert-license
+        name: Add Apache license header to ezt templates
+        files: \.ezt$
+        args:
+          - --comment-style
+          - "#|#|#"
+          - --license-filepath
+          - license-templates/LICENSE.txt
+          - --fuzzy-match-generates-todo
+      - id: insert-license
+        name: Add Apache license header to Markdown files
+        files: \.md$
+        # CLAUDE.md / AGENTS.md are agentic-tooling docs that follow the
+        # short-license convention used in apache/airflow; keeping them
+        # exempted here matches that convention until we add the short
+        # template too. stash/README.md uses the short-form Apache license.
+        exclude: |
+          (?x)
+          ^(?:.*/)?AGENTS\.md$|
+          ^(?:.*/)?CLAUDE\.md$|
+          ^stash/.*\.md$
+        args:
+          - --comment-style
+          - "<!--|  |-->"
+          - --license-filepath
+          - license-templates/LICENSE.txt
+          - --fuzzy-match-generates-todo

--- a/allowlist-check/action.yml
+++ b/allowlist-check/action.yml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 
 name: "ASF Allowlist Check"
 description: >

--- a/allowlist-check/check_asf_allowlist.py
+++ b/allowlist-check/check_asf_allowlist.py
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 
 """Check that all GitHub Actions uses: refs are on the ASF allowlist.
 

--- a/allowlist-check/insert_actions.py
+++ b/allowlist-check/insert_actions.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 """Insert action entries into actions.yml in alphabetical order.
 
 Usage:

--- a/allowlist-check/test_check_asf_allowlist.py
+++ b/allowlist-check/test_check_asf_allowlist.py
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 
 import os
 import shutil

--- a/license-templates/LICENSE.txt
+++ b/license-templates/LICENSE.txt
@@ -1,0 +1,16 @@
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.

--- a/pelican/plugin_paths.py
+++ b/pelican/plugin_paths.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*- #
-# vim: encoding=utf-8
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -10,7 +9,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#   https://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/pelican/plugins/asfcopy.py
+++ b/pelican/plugins/asfcopy.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python -B
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -18,6 +19,7 @@
 #
 #
 # asfcopy.py -- Pelican plugin that copies trees during finalization
+#
 #
 
 import sys

--- a/pelican/plugins/asfdata.py
+++ b/pelican/plugins/asfdata.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python -B
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -18,6 +19,7 @@
 #
 #
 # asfdata.py -- Pelican plugin that processes a yaml specification of data into a setting directory
+#
 #
 
 import os.path

--- a/pelican/plugins/asfindex.py
+++ b/pelican/plugins/asfindex.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python -B
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -18,6 +19,7 @@
 #
 #
 # asfindex.py - Pelican plugin that generates indexes
+#
 #
 
 import sys

--- a/pelican/plugins/asfreader.py
+++ b/pelican/plugins/asfreader.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python -B
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -18,6 +19,7 @@
 #
 #
 # asfreader.py -- Pelican plugin that processes ezt template Markdown through ezt and  then GitHub Flavored Markdown.
+#
 #
 
 import sys

--- a/pelican/plugins/asfrun.py
+++ b/pelican/plugins/asfrun.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python -B
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -18,6 +19,7 @@
 #
 #
 # asfrun.py - Pelican plugin that runs shell scripts during initialization or finalization
+#
 #
 
 import os

--- a/pelican/plugins/consensual_youtube.py
+++ b/pelican/plugins/consensual_youtube.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python -B
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -30,6 +31,7 @@
 # The preview image will be taken from `img/{youtube_id}.jpg` in your content
 # folder. If no preview image is found there, it will be fetched from youtube
 # at site generation time.
+#
 from os import path
 
 from urllib import request

--- a/pelican/plugins/spu.py
+++ b/pelican/plugins/spu.py
@@ -1,19 +1,23 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 
 """
 This is a collection of simple in-page callable tools for pelican.

--- a/scripts/sort_yml.py
+++ b/scripts/sort_yml.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -23,6 +24,7 @@
 #     "ruamel.yaml",
 # ]
 # ///
+#
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap

--- a/utils/verify_action_build/dockerfiles/build_action.Dockerfile
+++ b/utils/verify_action_build/dockerfiles/build_action.Dockerfile
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -18,6 +19,7 @@
 # Dockerfile for rebuilding a GitHub Action's compiled JavaScript
 # in an isolated container.  Used by verify-action-build to compare
 # published dist/ output against a from-scratch rebuild.
+#
 
 ARG NODE_VERSION=20
 FROM node:${NODE_VERSION}-slim


### PR DESCRIPTION
## Summary

Adds the [`Lucas-C/pre-commit-hooks` `insert-license`](https://github.com/Lucas-C/pre-commit-hooks) hook to `.pre-commit-config.yaml`, configured for every file type that is actually present in the repo, plus a shared license template at `scripts/license-templates/LICENSE.txt`. Modelled after [apache/airflow's setup](https://github.com/apache/airflow/blob/main/.pre-commit-config.yaml), but tuned to match infrastructure-actions's existing canonical header style (wrapped `#`-comment, 2-space-indented HTML comment for Markdown).

After merge, running `pre-commit run --all-files` (or `prek run --all-files`) is a no-op — the only files that ever get touched are the ones a contributor forgot to put a header on.

## Why

PR #770 added `lock_file_exemptions.yml` without an ASF license header. The `rat` workflow correctly failed, but only after the PR was already opened and reviewed by @dave2wave — costing a review round-trip. With this hook installed locally (`pre-commit install`), the contributor would have been told to add the header before pushing.

## File-type coverage

Hooks added — only for file types that exist in the repo today:

| Hook | Pattern | Comment style |
|---|---|---|
| Python | `\.py$` | `#\|#\|#` (wrapped `#`) |
| YAML | `\.ya?ml$` | `#\|#\|#` |
| TOML | `\.toml$` | `#\|#\|#` |
| Shell | `\.(sh\|bash)$` | `#\|#\|#` |
| Dockerfile | `(^\|/)Dockerfile$\|\.Dockerfile$` | `#\|#\|#` |
| ezt templates | `\.ezt$` | `#\|#\|#` |
| Markdown | `\.md$` | `<!--\|  \|-->` (2-space HTML comment) |

`.json` files are not covered (JSON has no comment syntax). `.lock`, `.txt`, and binary files are not covered. `LICENSE` and `NOTICE` at the repo root carry no header per ASF convention.

## Exclusions (narrowly scoped)

| Path | Reason |
|---|---|
| `approved_patterns.yml` | Auto-generated from `actions.yml` by `gateway/`. |
| `stash/*` (except `stash/pyproject.toml`) | The stash sub-project uses the short-form `Copyright (c) The stash contributors / Licensed under Apache 2.0` header, which RAT already accepts. Adding the full ASF contributor header on top would just duplicate. |
| `.github/workflows/stash-action-test.yml` | Same short-form. |
| `AGENTS.md` / `CLAUDE.md` | Agentic-tooling docs following the short-license convention used in apache/airflow. |

## Drive-by changes outside `stash/`

To make the hook a no-op on existing files (so it only ever flags genuine misses going forward), the following one-off normalisation was needed:

- **17 files** had the unwrapped header style (`# Licensed…` on line 1, no surrounding `#` lines) — re-wrapped to match the canonical style used by the other 68 already-headered files. No content changes; just two `#` lines added per file.
- **`pelican/plugins/spu.py`** and **`pelican/plugin_paths.py`** had legacy near-identical license blocks (slightly different paragraph wrap, `https://` vs `http://` URL). The hook didn't fuzzy-match them and added a fresh canonical block above; the legacy block was removed so each file ends up with exactly one canonical header.

These are mechanical changes and reviewed cleanly diff-by-diff if you want to spot-check.

## Test plan

- [x] `prek run --all-files` is clean on the final tree (no further modifications).
- [x] `rat` check should pass (every covered file has the canonical header).
- [ ] After merge, `pre-commit install` (or `prek install`) wires the hooks so a missing header on a new file is caught at commit time, not at PR review.

Generated-by: Claude Opus 4.7 (1M context)