### PR TITLE
verify-action-build: show release date + weekday in summary

### DIFF
--- a/utils/tests/verify_action_build/test_release_lookup.py
+++ b/utils/tests/verify_action_build/test_release_lookup.py
@@ -1,0 +1,142 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+from datetime import datetime, timezone
+from unittest import mock
+
+from verify_action_build.release_lookup import (
+    format_release_time,
+    get_release_or_commit_time,
+)
+
+
+class TestFormatReleaseTime:
+    def test_includes_full_weekday_name(self):
+        # 2026-04-23 was a Thursday.
+        ts = datetime(2026, 4, 23, 14, 32, 0, tzinfo=timezone.utc)
+        assert format_release_time(ts) == "Thursday 2026-04-23 14:32 UTC"
+
+    def test_each_weekday(self):
+        # Spot-check every weekday in a single calendar week.
+        # 2026-04-20 was a Monday.
+        for offset, name in enumerate(
+            ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+        ):
+            ts = datetime(2026, 4, 20 + offset, 9, 0, tzinfo=timezone.utc)
+            assert format_release_time(ts).startswith(name)
+
+    def test_no_relative_phrase_in_output(self):
+        # The whole point: never embed "X days ago" since it'd rot if the
+        # output is re-read later.
+        ts = datetime(2026, 4, 23, 14, 32, 0, tzinfo=timezone.utc)
+        out = format_release_time(ts)
+        assert "ago" not in out
+        assert "in the future" not in out
+
+    def test_naive_timestamp_treated_as_utc(self):
+        # A datetime without tzinfo is assumed UTC rather than crashing.
+        ts = datetime(2026, 4, 23, 14, 32, 0)
+        out = format_release_time(ts)
+        assert "2026-04-23 14:32 UTC" in out
+        assert out.startswith("Thursday")
+
+    def test_non_utc_timezone_converted(self):
+        # +02:00 input should be displayed as the equivalent UTC.
+        from datetime import timedelta as _td
+        tz = timezone(_td(hours=2))
+        ts = datetime(2026, 4, 23, 16, 32, 0, tzinfo=tz)  # 14:32 UTC
+        out = format_release_time(ts)
+        assert out == "Thursday 2026-04-23 14:32 UTC"
+
+
+class TestGetReleaseOrCommitTime:
+    def test_returns_release_published_at_when_tag_has_release(self):
+        with mock.patch(
+            "verify_action_build.release_lookup._find_tags_for_commit",
+            return_value=["v1.2.3", "v1"],
+        ), mock.patch(
+            "verify_action_build.release_lookup._release_published_at",
+            side_effect=lambda o, r, t: (
+                datetime(2026, 4, 23, 14, 32, tzinfo=timezone.utc)
+                if t == "v1.2.3" else None
+            ),
+        ):
+            result = get_release_or_commit_time("org", "repo", "a" * 40)
+        assert result is not None
+        ts, tag, source = result
+        assert tag == "v1.2.3"
+        assert source == "release"
+        assert ts.year == 2026 and ts.month == 4 and ts.day == 23
+
+    def test_falls_back_to_second_tag_when_first_has_no_release(self):
+        with mock.patch(
+            "verify_action_build.release_lookup._find_tags_for_commit",
+            return_value=["v1-rolling", "v1.0.0"],
+        ), mock.patch(
+            "verify_action_build.release_lookup._release_published_at",
+            side_effect=lambda o, r, t: (
+                datetime(2026, 1, 1, tzinfo=timezone.utc) if t == "v1.0.0" else None
+            ),
+        ):
+            result = get_release_or_commit_time("org", "repo", "a" * 40)
+        assert result is not None
+        ts, tag, source = result
+        assert tag == "v1.0.0"
+        assert source == "release"
+
+    def test_falls_back_to_commit_date_when_no_release(self):
+        with mock.patch(
+            "verify_action_build.release_lookup._find_tags_for_commit",
+            return_value=["v9.9.9"],
+        ), mock.patch(
+            "verify_action_build.release_lookup._release_published_at",
+            return_value=None,
+        ), mock.patch(
+            "verify_action_build.release_lookup._commit_committer_date",
+            return_value=datetime(2026, 3, 1, tzinfo=timezone.utc),
+        ):
+            result = get_release_or_commit_time("org", "repo", "a" * 40)
+        assert result is not None
+        ts, tag, source = result
+        assert tag == "v9.9.9"
+        assert source == "commit"
+
+    def test_falls_back_to_commit_date_when_no_tags(self):
+        with mock.patch(
+            "verify_action_build.release_lookup._find_tags_for_commit",
+            return_value=[],
+        ), mock.patch(
+            "verify_action_build.release_lookup._commit_committer_date",
+            return_value=datetime(2026, 2, 14, tzinfo=timezone.utc),
+        ):
+            result = get_release_or_commit_time("org", "repo", "a" * 40)
+        assert result is not None
+        ts, tag, source = result
+        assert tag is None
+        assert source == "commit"
+
+    def test_returns_none_when_everything_fails(self):
+        with mock.patch(
+            "verify_action_build.release_lookup._find_tags_for_commit",
+            return_value=[],
+        ), mock.patch(
+            "verify_action_build.release_lookup._commit_committer_date",
+            return_value=None,
+        ):
+            result = get_release_or_commit_time("org", "repo", "a" * 40)
+        assert result is None

--- a/utils/verify_action_build/release_lookup.py
+++ b/utils/verify_action_build/release_lookup.py
@@ -238,3 +238,61 @@ def resolve_source_commit(
             return sha, tag_name
 
     return None
+
+
+def _commit_committer_date(org: str, repo: str, commit_hash: str) -> datetime | None:
+    """Return the committer date of ``commit_hash`` as a tz-aware datetime."""
+    data = _gh_api(f"repos/{org}/{repo}/commits/{commit_hash}")
+    if not isinstance(data, dict):
+        return None
+    ts = (
+        data.get("commit", {}).get("committer", {}).get("date")
+        or data.get("commit", {}).get("author", {}).get("date")
+    )
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def get_release_or_commit_time(
+    org: str, repo: str, commit_hash: str,
+) -> tuple[datetime, str | None, str] | None:
+    """Return when this commit was released, with the tag name if known.
+
+    Resolution order:
+      1. Find every tag pointing at ``commit_hash``; for each (most-specific
+         first) try to fetch its GitHub Release and use ``published_at``.
+      2. If no release exists, fall back to the commit's committer date.
+
+    Returns ``(timestamp, tag_name, source)`` where ``source`` is either
+    ``"release"`` or ``"commit"``, or ``None`` if neither lookup succeeds.
+    ``tag_name`` is ``None`` when the commit isn't pointed at by any tag.
+    """
+    tags = _find_tags_for_commit(org, repo, commit_hash)
+    for tag in tags:
+        ts = _release_published_at(org, repo, tag)
+        if ts is not None:
+            return ts, tag, "release"
+
+    ts = _commit_committer_date(org, repo, commit_hash)
+    if ts is None:
+        return None
+    # Even if we have no GitHub Release, we may have a tag name to display.
+    return ts, (tags[0] if tags else None), "commit"
+
+
+def format_release_time(ts: datetime) -> str:
+    """Format ``ts`` for the verification summary as 'Weekday YYYY-MM-DD HH:MM UTC'.
+
+    Leads with the day of the week so the reader can eyeball how many days
+    ago this was relative to today — without baking a "N days ago" string
+    that silently rots when the same output is re-read later (a CI log,
+    a PR-comment quote, a saved transcript). The absolute timestamp is
+    self-validating; the weekday makes the recency obvious.
+    """
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(timezone.utc).strftime("%A %Y-%m-%d %H:%M UTC")

--- a/utils/verify_action_build/verification.py
+++ b/utils/verify_action_build/verification.py
@@ -33,7 +33,12 @@ from .diff_node_modules import diff_node_modules
 from .diff_source import diff_approved_vs_new
 from .docker_build import build_in_docker
 from .github_client import GitHubClient
-from .release_lookup import is_source_detached, resolve_source_commit
+from .release_lookup import (
+    format_release_time,
+    get_release_or_commit_time,
+    is_source_detached,
+    resolve_source_commit,
+)
 from .security import (
     analyze_action_metadata,
     analyze_binary_downloads_recursive,
@@ -240,6 +245,18 @@ def verify_single_action(
                 "info" if source_commit_hash else "warn",
                 source_detached_detail,
             ))
+
+        # Show when this commit was released so a reviewer can spot fresh-off-
+        # the-press tags that haven't soaked in the wild yet, or stale tags
+        # being bumped to.
+        release_info = get_release_or_commit_time(org, repo, commit_hash)
+        if release_info is not None:
+            ts, tag, source = release_info
+            label = "Released" if source == "release" else "Commit date"
+            detail = format_release_time(ts)
+            if tag:
+                detail = f"{tag} — {detail}"
+            checks_performed.append((label, "info", detail))
 
         is_js_action = action_type.startswith("node") or action_type in ("unknown",)
 


### PR DESCRIPTION
## Summary

Adds a **Released** (or **Commit date** fallback) info row to the verify-action-build summary so a reviewer can see, at a glance, when the action's tag was actually published.

Example output (real run on `mozilla-actions/sccache-action@v0.0.10`):

```
│ Action type detection │ ℹ │ node24                                            │
│ Released              │ ℹ │ v0.0.10 — Wednesday 2026-04-22 22:27 UTC          │
│ Lock file presence    │ ✓ │ all detected manifests have lock files (or are…)  │
```

## Resolution order

`get_release_or_commit_time(org, repo, commit_hash)`:

1. Find every tag pointing at the commit (most-specific first — `v3.0.2` beats `v3`).
2. For each, query the GitHub Releases API for `published_at`.
3. If no release exists, fall back to the commit's **committer date** (still useful when an action is tagged but the maintainer skipped creating a Release).
4. Returns `None` if neither lookup succeeds — the row is omitted rather than showing "unknown".

## Why weekday, not "N days ago"

`format_release_time(ts)` deliberately does **not** include a "5 days ago"-style relative tense. The verification output gets re-read in places where the relative phrase would silently rot:

- CI logs read days or weeks after the run
- PR comments quoting the output
- Saved transcripts / artifacts

Instead, the format is `Weekday YYYY-MM-DD HH:MM UTC`. The weekday is invariant for that date, and gives the reader an instant feel for recency relative to today's weekday — without baking a stale relative into the output.

## Test plan

- [x] 10 new unit tests in `test_release_lookup.py` covering format (each weekday, naive-tz handling, non-UTC timezone conversion, no-relative-phrase invariant) and resolver (release path, fallback to second tag, fallback to commit date, fallback when no tags, returns `None` when everything fails).
- [x] Full suite passes (149 tests).
- [x] Smoke test on `mozilla-actions/sccache-action@v0.0.10` shows `v0.0.10 — Wednesday 2026-04-22 22:27 UTC`.
- [x] Smoke test on `Kesin11/actions-timeline@v2.2.5` shows `v2.2.5 — Wednesday 2025-10-01 01:44 UTC`.

Generated-by: Claude Opus 4.7 (1M context)