### PR TITLE
verify-action-build: skip binary-download check for pure data fetches

### DIFF
--- a/utils/tests/verify_action_build/test_security.py
+++ b/utils/tests/verify_action_build/test_security.py
@@ -27,6 +27,10 @@ from verify_action_build.security import (
     analyze_action_metadata,
     analyze_repo_metadata,
 )
+from verify_action_build.security import (
+    _file_is_pure_data_fetch,
+    _find_binary_downloads_js,
+)
 
 
 class TestAnalyzeDockerfile:
@@ -753,3 +757,109 @@ class TestAnalyzeLockFiles:
         )
         result = _load_lock_file_exemptions(yml)
         assert result[("some", "multiecosystem-repo")] == {"python", "dart"}
+
+
+class TestPureDataFetchExemption:
+    """The binary-download check should not flag JS files that fetch HTTP
+    responses purely as data (regex-parsed, JSON.parse'd, etc.) when nothing
+    in the file persists or executes the response."""
+
+    # The exact pattern that triggered the false positive on PR #752
+    # (dependabot/fetch-metadata): badge fetch + regex match + parseInt.
+    DEPENDABOT_BADGE_FETCH = """\
+import * as https from 'https'
+
+export async function getCompatibility (name, oldVersion, newVersion, ecosystem) {
+  const svg = await new Promise((resolve) => {
+    https.get(`https://dependabot-badges.githubapp.com/badges/compatibility_score?dependency-name=${name}&package-manager=${ecosystem}&previous-version=${oldVersion}&new-version=${newVersion}`, res => {
+      let data = ''
+      res.on('data', chunk => { data += chunk.toString('utf8') })
+      res.on('end', () => { resolve(data) })
+    }).on('error', () => { resolve('') })
+  })
+
+  const scoreChunk = svg.match(/<title>compatibility: (?<score>\\d+)%<\\/title>/m)
+  return scoreChunk?.groups ? parseInt(scoreChunk.groups.score) : 0
+}
+"""
+
+    LUAROCKS_BINARY_DOWNLOAD = """\
+import * as tc from "@actions/tool-cache"
+
+const sourceTar = await tc.downloadTool(`https://luarocks.org/releases/luarocks-${v}.tar.gz`)
+await tc.extractTar(sourceTar, dest)
+"""
+
+    def test_pure_data_fetch_exempted(self):
+        # https.get + .match + parseInt, no extract/write/exec → exempted.
+        assert _file_is_pure_data_fetch(self.DEPENDABOT_BADGE_FETCH) is True
+        assert _find_binary_downloads_js(self.DEPENDABOT_BADGE_FETCH) == []
+
+    def test_real_binary_download_still_flagged(self):
+        # tc.downloadTool followed by tc.extractTar → not exempt.
+        assert _file_is_pure_data_fetch(self.LUAROCKS_BINARY_DOWNLOAD) is False
+        findings = _find_binary_downloads_js(self.LUAROCKS_BINARY_DOWNLOAD)
+        assert len(findings) == 1
+        assert "downloadTool" in findings[0][1]
+
+    def test_data_fetch_with_extract_in_same_file_not_exempt(self):
+        # File mixes a metadata fetch and a real binary extraction. The
+        # heuristic is intentionally conservative: any binary-handling
+        # marker in the file disables the exemption for everything in it.
+        mixed = """\
+import * as https from 'https'
+import * as tc from "@actions/tool-cache"
+
+const meta = await new Promise((r) => https.get('https://x/y.json', res => {/*...*/}))
+const parsed = JSON.parse(meta)
+
+const archive = await tc.downloadTool('https://x/foo.tar.gz')
+await tc.extractTar(archive, dest)
+"""
+        assert _file_is_pure_data_fetch(mixed) is False
+        findings = _find_binary_downloads_js(mixed)
+        # Both downloads remain flagged.
+        assert len(findings) == 2
+
+    def test_no_data_parse_marker_not_exempt(self):
+        # A fetch that doesn't visibly parse the response shouldn't be
+        # exempted by accident — we can't tell if it's binary or data.
+        opaque = """\
+import * as https from 'https'
+
+https.get('https://x/y', res => { /* opaque */ })
+"""
+        assert _file_is_pure_data_fetch(opaque) is False
+        assert len(_find_binary_downloads_js(opaque)) == 1
+
+    def test_chmod_plus_x_in_string_disables_exemption(self):
+        # chmod +x on a downloaded path is a strong "this is an executable"
+        # signal even with parse markers also present.
+        mixed = """\
+const r = await fetch('https://x/y')
+const txt = await r.text()
+const score = parseInt(txt)
+exec.exec('chmod +x ./downloaded')
+"""
+        assert _file_is_pure_data_fetch(mixed) is False
+
+    def test_json_parse_alone_exempts(self):
+        json_fetch = """\
+import * as https from 'https'
+
+const data = await new Promise((r) => https.get('https://api.x/v1/info', res => { r(res) }))
+const parsed = JSON.parse(data)
+return parsed.version
+"""
+        assert _file_is_pure_data_fetch(json_fetch) is True
+        assert _find_binary_downloads_js(json_fetch) == []
+
+    def test_split_alone_exempts(self):
+        # .split is a common data-parse operation.
+        split_fetch = """\
+const data = await fetch('https://x/y').then(r => r.text())
+const lines = data.split('\\n')
+return lines[0]
+"""
+        assert _file_is_pure_data_fetch(split_fetch) is True
+        assert _find_binary_downloads_js(split_fetch) == []

--- a/utils/verify_action_build/security.py
+++ b/utils/verify_action_build/security.py
@@ -1056,6 +1056,43 @@ _JS_DOWNLOAD_PATTERNS = [
     re.compile(r"\brequire\(\s*['\"`]node-fetch['\"`]"),
 ]
 
+# Markers indicating the response of an HTTP call is consumed as *data* —
+# parsed for a value rather than written to disk and executed/extracted.
+# A "data fetch" with these markers and no binary-handling markers (see
+# below) anywhere in the file is exempt from the unverified-download check,
+# since there is no binary or executable to verify in the first place.
+_JS_DATA_PARSE_PATTERNS = [
+    re.compile(r"\.match\s*\("),
+    re.compile(r"\.matchAll\s*\("),
+    re.compile(r"\.replace\s*\("),
+    re.compile(r"\.test\s*\("),
+    re.compile(r"\bJSON\.parse\s*\("),
+    re.compile(r"\bparseInt\s*\("),
+    re.compile(r"\bparseFloat\s*\("),
+    re.compile(r"\bNumber\s*\("),
+    re.compile(r"\.split\s*\("),
+    re.compile(r"\.includes\s*\("),
+    re.compile(r"\.startsWith\s*\("),
+    re.compile(r"\.endsWith\s*\("),
+    re.compile(r"\.toLowerCase\s*\(\)"),
+    re.compile(r"\.toUpperCase\s*\(\)"),
+]
+
+# Markers indicating the response is treated as a binary or executable —
+# extracted, written to disk, made executable, or executed.  If any of these
+# appear anywhere in the file the download stays subject to the verification
+# requirement, regardless of any data-parse markers also present.
+_JS_BINARY_HANDLE_PATTERNS = [
+    re.compile(r"\btc\.extract(?:Tar|Zip|7z|Xar)\s*\("),
+    re.compile(r"\btc\.cache(?:File|Dir)\s*\("),
+    re.compile(r"\bfs\.(?:writeFile|writeFileSync|createWriteStream|copyFile|copyFileSync|rename|renameSync)\b"),
+    re.compile(r"\bexec\.exec(?:Async)?\s*\("),
+    re.compile(r"\bchild_process\b"),
+    re.compile(r"\bspawn(?:Sync)?\s*\("),
+    re.compile(r"\bchmod(?:Sync)?\s*\("),
+    re.compile(r"['\"`]chmod\s+\+x"),
+]
+
 # Verification patterns in JS/TS source: node crypto, WebCrypto, or common
 # sigstore/cosign / custom "verify" helper names.
 _JS_VERIFICATION_PATTERNS = [
@@ -1084,13 +1121,40 @@ def _line_is_pkg_manager(line: str) -> bool:
     return any(marker in lower for marker in _PKG_MANAGER_MARKERS)
 
 
+def _file_is_pure_data_fetch(content: str) -> bool:
+    """Return True if the file fetches HTTP responses purely as data.
+
+    Heuristic: the file has at least one data-parse marker (regex .match,
+    JSON.parse, parseInt, etc.) AND no binary-handling marker (tc.extractTar,
+    fs.writeFile, exec.exec, chmod +x, etc.).  When both hold, the response
+    is being consumed as a string/number rather than persisted or executed,
+    so there is no binary to verify in the first place.
+
+    This is intentionally a per-file heuristic rather than per-finding: a
+    file that mixes a real binary download with a metadata fetch should
+    keep the strict check, since we cannot reliably scope which usage
+    follows which call without a real AST.
+    """
+    has_parse = any(p.search(content) for p in _JS_DATA_PARSE_PATTERNS)
+    if not has_parse:
+        return False
+    has_binary_handle = any(p.search(content) for p in _JS_BINARY_HANDLE_PATTERNS)
+    return not has_binary_handle
+
+
 def _find_binary_downloads_js(content: str) -> list[tuple[int, str]]:
     """Find lines in JS/TS source that fetch remote artifacts.
 
     Flags calls to ``tc.downloadTool`` / ``downloadTool``, bare ``fetch`` to
     an http(s) URL, node's ``http(s).get`` / ``.request``, ``axios.*``, and
     ``new HttpClient()``. Skips comment-only lines.
+
+    Files that look like pure data fetches (response parsed as a value, not
+    persisted or executed) return no findings — see ``_file_is_pure_data_fetch``
+    for the heuristic.
     """
+    if _file_is_pure_data_fetch(content):
+        return []
     findings: list[tuple[int, str]] = []
     for i, line in enumerate(content.splitlines(), 1):
         stripped = line.strip()


### PR DESCRIPTION
## Summary

The binary-download check currently flags every `tc.downloadTool` / `fetch` / `https.get` in JS source that doesn't sit alongside a hash/signature pattern. That over-flags actions that fetch HTTP responses **as data** — a metadata badge regex'd for an integer, an API JSON parsed for a version number — where there is no binary or executable to verify in the first place.

Add a per-file heuristic that exempts pure data fetches from the check.

## The false-positive that motivated this

PR #752 (`dependabot/fetch-metadata` 3.0.0 → 3.1.0) was flagged on `src/dependabot/verified_commits.ts:99`:

```ts
const svg = await new Promise<string>((resolve) => {
  https.get(`https://dependabot-badges.githubapp.com/badges/compatibility_score?...`, res => { ... })
})
const scoreChunk = svg.match(/<title>compatibility: (?<score>\d+)%<\/title>/m)
return scoreChunk?.groups ? parseInt(scoreChunk.groups.score) : 0
```

This is a computed-on-demand SVG badge — no possible "expected hash" exists, and a regex-extracted integer doesn't cross a security boundary. Adding a checksum upstream would be cargo-cult.

## The heuristic

A file's download calls are exempted iff **both** hold:

1. The file contains at least one **data-parse marker**: `.match` / `.matchAll` / `.replace` / `.test` / `.split` / `.includes` / `.startsWith` / `.endsWith` / `.toLowerCase()` / `.toUpperCase()` / `JSON.parse` / `parseInt` / `parseFloat` / `Number(...)`.
2. The file contains **no binary-handling markers**: `tc.extractTar` / `tc.extractZip` / `tc.extract7z` / `tc.extractXar`, `tc.cacheFile` / `tc.cacheDir`, `fs.writeFile` family, `exec.exec` / `child_process` / `spawn`, `chmod` calls, `'chmod +x'` strings.

Per-file scope (not per-finding): a file that mixes a metadata fetch with a real archive download keeps the strict check on **every** download in it. Per-finding scoping would need a real AST to track which response gets passed to which use, and the conservative blanket rule is preferable to a flaky one.

## Verified behaviour

| Action | Before | After |
|---|---|---|
| `dependabot/fetch-metadata@v3.1.0` (the false positive) | ✗ 1 unverified JS download | ✓ no downloads or all verified |
| `leafo/gh-actions-luarocks@v6.1.0` (real `tc.downloadTool` + `tc.extractTar`) | ✗ 1 unverified JS download | ✗ 1 unverified JS download (still flagged — correct) |

## Test plan

- [x] 7 new unit tests in `test_security.py::TestPureDataFetchExemption` covering: pure-data-fetch exempted, real-binary still flagged, mixed-file not exempt, no-data-parse-marker not exempt, `chmod +x` string disables exemption, `JSON.parse` alone exempts, `.split` alone exempts.
- [x] Full suite: 146 tests pass.
- [x] Live smoke against `dependabot/fetch-metadata@25dd0e34` — `Binary download verification: ✓` (was ✗).
- [x] Live smoke against `leafo/gh-actions-luarocks@35d062de` — still ✗ (the real flag we want).

Generated-by: Claude Opus 4.7 (1M context)