### PR TITLE
Add j178/prek-action to the GitHub Actions allowlist

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -484,6 +484,9 @@ ilammy/msvc-dev-cmd:
 ilammy/setup-nasm:
   72793074d3c8cdda771dba85f6deafe00623038b:
     tag: v1.5.2
+j178/prek-action:
+  '0bb87d7f00b0c99306c8bcb8b8beba1eb581c037':
+    keep: true
 JamesIves/github-pages-deploy-action:
   d92aa235d04922e8f08b40ce78cc5442fcfbfa2f:
     tag: v4.8.0

--- a/actions.yml
+++ b/actions.yml
@@ -485,8 +485,8 @@ ilammy/setup-nasm:
   72793074d3c8cdda771dba85f6deafe00623038b:
     tag: v1.5.2
 j178/prek-action:
-  '0bb87d7f00b0c99306c8bcb8b8beba1eb581c037':
-    keep: true
+  cbc2f23eb5539cf20d82d1aabd0d0ecbcc56f4e3:
+    tag: v2.0.2
 JamesIves/github-pages-deploy-action:
   d92aa235d04922e8f08b40ce78cc5442fcfbfa2f:
     tag: v4.8.0


### PR DESCRIPTION
Add `j178/prek-action` to the allowlist:

- `j178/prek-action@cbc2f23eb5539cf20d82d1aabd0d0ecbcc56f4e3` (v2.0.2)

Needed by: `apache/airflow-steward`

> [!NOTE]
> Originally proposed at commit `0bb87d7f` (old composite-action era using `curl https://github.com/j178/prek/releases/download/.../prek-installer.sh | sh` with no in-action checksum step). Updated to v2.0.2 — the action was rewritten as a TypeScript JS action that uses `@actions/tool-cache` + `crypto.createHash('sha256')` to verify each downloaded artefact against checksums from the bundled `known-checksums.ts` manifest. `verify-action-build` passes cleanly on this commit.