### PR TITLE
Add rubygems/release-gem to allowlist

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -781,6 +781,12 @@ release-drafter/release-drafter:
 ruby/setup-ruby:
   '*':
     keep: true
+rubygems/configure-rubygems-credentials:
+  bc6dd217f8a4f919d6835fcfefd470ef821f5c44:
+    tag: v1.0.0
+rubygems/release-gem:
+  6317d8d1f7e28c24d28f6eff169ea854948bd9f7:
+    tag: v1.2.0
 runs-on/action:
   cd2b598b0515d39d78c38a02d529db87d2196d1e:
     tag: v2.0.3


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

Add `rubygems/release-gem` to the allowlist. This is the official trusted publishing action maintained by the RubyGems team, see [Releasing gems with a trusted publisher](https://guides.rubygems.org/trusted-publishing/#releasing-gems-with-a-trusted-publisher).

At Apache Thrift we [want to switch to trusted publishing](https://github.com/apache/thrift/pull/3383) to remediate supply chain risk, but I believe the workflow will be blocked until the action is allowlisted. See https://github.com/apache/thrift/blob/master/.github/workflows/release_ruby.yml

**Name of action:**

rubygems/release-gem

**URL of action:**

https://github.com/rubygems/release-gem

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**

`6317d8d1f7e28c24d28f6eff169ea854948bd9f7`

## Permissions

`id-token: write`

## Related Actions

* `rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1`
   https://github.com/rubygems/release-gem/blob/v1/action.yml#L58C13-L58C93

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
- [x] Compiled JavaScript in `dist/` matches a clean rebuild (verify with `uv run utils/verify-action-build.py org/repo@hash`)
