### PR TITLE
verify-action-build: match TS generics on @actions/http-client *Json calls

### DIFF
--- a/utils/tests/verify_action_build/test_security.py
+++ b/utils/tests/verify_action_build/test_security.py
@@ -864,10 +864,12 @@ return lines[0]
         assert _file_is_pure_data_fetch(split_fetch) is True
         assert _find_binary_downloads_js(split_fetch) == []
 
-    # The exact pattern that triggered the false positive on PR #789
+    # The exact pattern that triggered the false positive on PR #789 / #795
     # (rubygems/configure-rubygems-credentials, transitively pulled in by
     # rubygems/release-gem): @actions/http-client postJson against an OIDC
     # token-exchange endpoint. The response is a credential, not a binary.
+    # The ``<IdToken>`` generic mirrors the v2.0.0 source verbatim — earlier
+    # versions of this fixture omitted it and quietly hid a regex hole.
     RUBYGEMS_OIDC_EXCHANGE = """\
 import * as core from '@actions/core'
 import {HttpClient} from '@actions/http-client'
@@ -877,8 +879,12 @@ export async function exchangeToken(audience, server) {
   const webIdentityToken = await core.getIDToken(audience)
   const http = new HttpClient('rubygems-oidc-action')
   const url = `${server}/api/v1/oidc/trusted_publisher/exchange_token`
-  const res = await http.postJson(url, {jwt: webIdentityToken}, {})
-  return res.result
+  const res = await http.postJson<IdToken>(
+    url,
+    {jwt: webIdentityToken},
+    {'content-type': 'application/json', accept: 'application/json'}
+  )
+  return IdTokenSchema.parse(res.result)
 }
 """
 

--- a/utils/verify_action_build/security.py
+++ b/utils/verify_action_build/security.py
@@ -1080,7 +1080,10 @@ _JS_DATA_PARSE_PATTERNS = [
     # delJson/requestJson) auto-parse the response body as JSON. Reaching for
     # these is an explicit "treat the response as structured data" signal
     # — typical of OIDC/RPC token-exchange calls, not binary downloads.
-    re.compile(r"\.(?:get|post|put|patch|del|request)Json\s*\("),
+    # The optional ``<...>`` admits TypeScript generic type parameters
+    # (``http.postJson<IdToken>(...)``); without it the regex misses the
+    # exact call shape rubygems/configure-rubygems-credentials uses.
+    re.compile(r"\.(?:get|post|put|patch|del|request)Json(?:\s*<[^>]*>)?\s*\("),
 ]
 
 # Markers indicating the response is treated as a binary or executable —


### PR DESCRIPTION
## Summary

- The earlier fix (commit 920d616) added `*Json` to the data-parse markers but the regex required `(` directly after `Json`, so it silently missed the real `http.postJson<IdToken>(...)` call in rubygems/configure-rubygems-credentials v2.0.0 — PR #795 still flagged both `src/oidc/assumeRole.ts` and `src/oidc/trustedPublisher.ts` as unverified downloads.
- Allow an optional `<...>` generic between `Json` and `(`.
- Rewrite the `RUBYGEMS_OIDC_EXCHANGE` test fixture so it mirrors the v2.0.0 source verbatim (with the `<IdToken>` generic and `IdTokenSchema.parse(res.result)`) — closing the regression-test hole that let this slip through the first time.

## Test plan

- [x] `uv run pytest utils/tests/verify_action_build/test_security.py -k 'PureDataFetch or postJson or getJson'` — 10/10 pass.
- [x] Spot-checked against the real source at PR #795's SHA: `_file_is_pure_data_fetch` is `True` and `_find_binary_downloads_js` is `[]` for both flagged files.
- [ ] Re-run the "Handle Dependabot update" check on PR #795 once this lands on main — expect no unverified-download findings.

Generated-by [Claude Code](https://claude.com/claude-code).