### PR TITLE
verify-action-build: recognize sibling verification steps

### DIFF
--- a/utils/tests/verify_action_build/test_security.py
+++ b/utils/tests/verify_action_build/test_security.py
@@ -340,6 +340,68 @@ runs:
                 warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
         assert failures == []
 
+    def test_action_yml_sibling_ampel_verify_step_passes(self):
+        # Mirrors the sbt/setup-sbt pattern: download in one run block,
+        # signature verification in a sibling `uses:` step that calls
+        # carabiner-dev/actions/ampel/verify.
+        action_yml = """\
+name: Test
+runs:
+  using: composite
+  steps:
+    - name: Download tool
+      shell: bash
+      run: |
+        curl -sL https://example.com/tool.zip > /tmp/tool.zip
+        curl -sL https://example.com/tool.zip.asc > /tmp/tool.zip.asc
+    - name: Verify signature
+      uses: carabiner-dev/actions/ampel/verify@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      with:
+        subject: /tmp/tool.zip
+"""
+        with mock.patch("verify_action_build.security.fetch_action_yml", return_value=action_yml):
+            with mock.patch("verify_action_build.security.fetch_file_from_github", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert failures == []
+
+    def test_action_yml_sibling_slsa_verifier_step_passes(self):
+        action_yml = """\
+name: Test
+runs:
+  using: composite
+  steps:
+    - name: Download tool
+      shell: bash
+      run: |
+        curl -fsSLO https://example.com/tool.tar.gz
+    - name: Verify provenance
+      uses: slsa-framework/slsa-verifier-action@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+"""
+        with mock.patch("verify_action_build.security.fetch_action_yml", return_value=action_yml):
+            with mock.patch("verify_action_build.security.fetch_file_from_github", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert failures == []
+
+    def test_action_yml_sibling_unrelated_uses_step_still_fails(self):
+        # A `uses:` step that is NOT a known verification action must not
+        # excuse an unverified download.
+        action_yml = """\
+name: Test
+runs:
+  using: composite
+  steps:
+    - name: Download tool
+      shell: bash
+      run: |
+        curl -fsSLO https://example.com/tool.tar.gz
+    - name: Cache
+      uses: actions/cache@cccccccccccccccccccccccccccccccccccccccc
+"""
+        with mock.patch("verify_action_build.security.fetch_action_yml", return_value=action_yml):
+            with mock.patch("verify_action_build.security.fetch_file_from_github", return_value=None):
+                warnings, failures = analyze_binary_downloads("org", "repo", "a" * 40)
+        assert len(failures) >= 1
+
     def test_releases_download_path_flagged(self):
         # URL without a binary extension but under /releases/download/ still
         # looks like a binary artefact — flag it.

--- a/utils/tests/verify_action_build/test_security.py
+++ b/utils/tests/verify_action_build/test_security.py
@@ -482,6 +482,33 @@ runs:
                 )
         assert failures == []
 
+    def test_skips_trusted_verifier_ref(self):
+        # Mirrors sbt/setup-sbt → carabiner-dev/actions/ampel/verify →
+        # install/ampel: descending into the verifier surfaces a bootstrap
+        # installer that can't verify itself. The walker treats the verifier
+        # ref as a trust leaf and stops there.
+        root_yml = """\
+name: Root
+runs:
+  using: composite
+  steps:
+    - uses: carabiner-dev/actions/ampel/verify@dddddddddddddddddddddddddddddddddddddddd
+"""
+
+        def fake_action_yml(org, repo, commit, sub_path=""):
+            if org == "myorg":
+                return root_yml
+            raise AssertionError(
+                f"should not fetch nested yml for {org}/{repo}/{sub_path}"
+            )
+
+        with mock.patch("verify_action_build.security.fetch_action_yml", side_effect=fake_action_yml):
+            with mock.patch("verify_action_build.security.fetch_file_from_github", return_value=None):
+                warnings, failures = analyze_binary_downloads_recursive(
+                    "myorg", "rootrepo", "b" * 40,
+                )
+        assert failures == []
+
 
 class TestAnalyzeRepoMetadata:
     def test_mit_license_detected(self):

--- a/utils/verify_action_build/security.py
+++ b/utils/verify_action_build/security.py
@@ -41,6 +41,24 @@ from .approved_actions import find_approved_versions
 # Orgs we trust to the point of not descending into their nested action graph.
 TRUSTED_ORGS = {"actions", "github"}
 
+# Verifier-action references that are treated as trust leaves. When a parent
+# action.yml `uses:` one of these, the walker yields the visit as a stub and
+# does not descend into the verifier's own action graph.
+#
+# Why: a verification action is itself the root of the artifact-trust chain
+# from its caller's perspective. Descending in would surface its bootstrap
+# installer (e.g. carabiner-dev/actions/install/ampel), which downloads the
+# verifier binary without an inline checksum/signature — a chicken-and-egg
+# problem the installer cannot solve. We accept the verifier ref's
+# hash-pinned commit as the trust anchor instead.
+#
+# Each entry is (org, repo, sub_path). Keep in sync with
+# `_VERIFICATION_USES_PATTERNS` below — same identities, different layer.
+TRUSTED_VERIFIER_REFS: set[tuple[str, str, str]] = {
+    ("carabiner-dev", "actions", "ampel/verify"),
+    ("slsa-framework", "slsa-verifier-action", ""),
+}
+
 # Exemptions file for the lock-file-presence check.  Path matches the
 # convention used by approved_actions.ACTIONS_YML.
 LOCK_FILE_EXEMPTIONS_YML = (
@@ -161,7 +179,7 @@ def walk_actions(
             )
             return
 
-        trusted = o in TRUSTED_ORGS
+        trusted = o in TRUSTED_ORGS or (o, r, s) in TRUSTED_VERIFIER_REFS
         if depth > 0 and trusted:
             yield VisitedAction(
                 org=o, repo=r, commit_hash=c, sub_path=s, depth=depth,

--- a/utils/verify_action_build/security.py
+++ b/utils/verify_action_build/security.py
@@ -1040,6 +1040,20 @@ _VERIFICATION_PATTERNS = [
     re.compile(r'["\'][a-f0-9]{32,}\s+\*?\S+["\']', re.IGNORECASE),
 ]
 
+# `uses:` references to external composite/JS actions that perform
+# cryptographic verification of a downloaded artifact. When a step in an
+# action.yml invokes one of these, downloads in sibling run blocks (or in
+# scripts referenced from the same action.yml) are considered verified —
+# the verification just happens in a separate step rather than inline.
+_VERIFICATION_USES_PATTERNS = [
+    # carabiner-dev Ampel: policy-driven signature/attestation verification.
+    re.compile(r"\buses:\s*[\"']?carabiner-dev/actions/ampel/verify\b", re.IGNORECASE),
+    # SLSA provenance verifier.
+    re.compile(r"\buses:\s*[\"']?slsa-framework/slsa-verifier-action\b", re.IGNORECASE),
+    # GitHub-native attestation verification.
+    re.compile(r"\buses:\s*[\"']?actions/attest-verify\b", re.IGNORECASE),
+]
+
 
 # Patterns indicating a JS/TS download of a remote artifact. Most JS actions
 # that fetch binaries go through @actions/tool-cache's downloadTool (which
@@ -1267,6 +1281,10 @@ def _has_verification(content: str) -> bool:
     return any(p.search(content) for p in _VERIFICATION_PATTERNS)
 
 
+def _action_yml_uses_external_verification(action_yml: str) -> bool:
+    return any(p.search(action_yml) for p in _VERIFICATION_USES_PATTERNS)
+
+
 def _extract_run_blocks(action_yml: str) -> list[str]:
     """Return the textual contents of every ``run:`` block in an action.yml."""
     blocks: list[str] = []
@@ -1315,6 +1333,11 @@ def analyze_binary_downloads(
     failures: list[str] = []
 
     files_to_scan: list[tuple[str, str]] = []
+    # Paths whose verification context is the surrounding action.yml — i.e.
+    # run blocks of the action.yml itself and scripts it invokes. A sibling
+    # `uses:` step (e.g. carabiner-dev/actions/ampel/verify) or a sibling
+    # run block with shell verification covers all of these.
+    action_yml_paths: set[str] = set()
 
     df_candidates = [f"{sub_path}/Dockerfile", "Dockerfile"] if sub_path else ["Dockerfile"]
     for df_path in df_candidates:
@@ -1324,10 +1347,16 @@ def analyze_binary_downloads(
             break
 
     action_yml = fetch_action_yml(org, repo, commit_hash, sub_path)
+    action_yml_provides_verify = bool(action_yml) and (
+        _has_verification(action_yml)
+        or _action_yml_uses_external_verification(action_yml)
+    )
     if action_yml:
         for idx, block in enumerate(_extract_run_blocks(action_yml), start=1):
             if block.strip():
-                files_to_scan.append((f"action.yml [run block #{idx}]", block))
+                path = f"action.yml [run block #{idx}]"
+                files_to_scan.append((path, block))
+                action_yml_paths.add(path)
 
     script_files: set[str] = set()
     if action_yml:
@@ -1352,6 +1381,7 @@ def analyze_binary_downloads(
             content = fetch_file_from_github(org, repo, commit_hash, script_path)
         if content is not None:
             files_to_scan.append((script_path, content))
+            action_yml_paths.add(script_path)
 
     # JS/TS source files: shell-pattern downloads (curl/wget) are rare here
     # but JS actions commonly fetch binaries via @actions/tool-cache etc.,
@@ -1370,10 +1400,17 @@ def analyze_binary_downloads(
         if not downloads:
             continue
         any_downloads = True
-        if _has_verification(content):
+        verified_via_action_yml = (
+            path in action_yml_paths and action_yml_provides_verify
+        )
+        if _has_verification(content) or verified_via_action_yml:
+            note = (
+                "verification present in file"
+                if not verified_via_action_yml or _has_verification(content)
+                else "verification present in sibling step of action.yml"
+            )
             console.print(
-                f"  [green]✓[/green] {path}: {len(downloads)} download(s), "
-                f"verification present in file"
+                f"  [green]✓[/green] {path}: {len(downloads)} download(s), {note}"
             )
             for line_num, snippet in downloads[:3]:
                 console.print(f"    [dim]line {line_num}:[/dim] [dim]{snippet}[/dim]")


### PR DESCRIPTION
## Summary
Two complementary changes that together let `sbt/setup-sbt@v1.1.23` pass binary-download verification:

1. **Recognize sibling verification steps** — within a single composite `action.yml`, treat verification as an action-wide property: a sibling step that does shell-level verification (`sha256sum`, `gpg --verify`, …) **or** invokes a known verifier (`carabiner-dev/actions/ampel/verify`, `slsa-framework/slsa-verifier-action`, `actions/attest-verify`) covers downloads in any of the action's run blocks or referenced scripts.

2. **Treat verifier-action refs as trust leaves** — when the recursive walker encounters a hash-pinned ref to a known verifier action, it stops there (same handling as `TRUSTED_ORGS`). Otherwise the walker would surface the verifier's own bootstrap installer (e.g. `carabiner-dev/actions/install/ampel`), which can't verify the verifier binary it installs (chicken-and-egg). The trust anchor is the hash-pinned commit of the verifier ref.

Fixes the false-positive flagged on #799 for `sbt/setup-sbt@v1.1.23` (the action downloads `.zip`+`.zip.asc` in one step and verifies the signature in a sibling Ampel step).

## Test plan
- [x] All 203 existing `verify_action_build` tests pass.
- [x] 4 new tests added: Ampel sibling step passes, SLSA verifier sibling passes, unrelated `uses:` step still fails, recursive walker stops at a verifier ref.
- [x] End-to-end verified against `sbt/setup-sbt@v1.1.23` via `uv run utils/verify-action-build.py`: Binary download verification now reports ✓ instead of ✗.