### PR TITLE
verify-action-build: extract all action refs from multi-action PRs

### DIFF
--- a/utils/tests/verify_action_build/test_pr_extraction.py
+++ b/utils/tests/verify_action_build/test_pr_extraction.py
@@ -122,3 +122,119 @@ class TestExtractActionRefsFromDiff:
         refs = extract_action_refs_from_diff(diff)
         assert len(refs) == 1
         assert "abc123def456789012345678901234567890abcd" in refs[0]
+
+    def test_hash_added_under_existing_key_via_context_line(self):
+        # The most common shape of a real PR diff: the org/repo key is
+        # already in main and shows up in the hunk as a context line
+        # (leading single space, no ``+``); only the new hash entry below
+        # it is an actual addition.  Pre-fix this dropped the hash because
+        # the extractor only considered ``+`` lines for the key.
+        diff = """\
+ actions/checkout:
+   def456789012345678901234567890abcd123456:
+     tag: v4.1.0
++  abc123def456789012345678901234567890abcd:
++    tag: v4.2.0
+"""
+        refs = extract_action_refs_from_diff(diff)
+        assert refs == [
+            "actions/checkout@abc123def456789012345678901234567890abcd"
+        ]
+
+    def test_hash_added_under_existing_key_via_hunk_header(self):
+        # When git's diff context window doesn't reach back to the key, the
+        # key only appears in the hunk header's function-context tail
+        # (``@@ ... @@ docker/build-push-action:``).  We must seed the key
+        # from there or the extractor sees only a bare ``+  <hash>:`` and
+        # has no way to attribute it.
+        diff = """\
+@@ -10,3 +10,6 @@ docker/build-push-action:
+     expires_at: 2026-07-07
+   bcafcacb16a39f128d818304e6c9c0c18556b85f:
+     tag: v7.1.0
++  ca052bb54ab0790a636c9b5f226502c73d547a25:
++    tag: v5.4.0
++    expires_at: 2026-07-28
+"""
+        refs = extract_action_refs_from_diff(diff)
+        assert refs == [
+            "docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25"
+        ]
+
+    def test_pr_803_shape_three_actions(self):
+        # Reproduces the apache/infrastructure-actions#803 shape: one fully
+        # new key plus two hash additions under pre-existing keys.  All
+        # three refs should be extracted.  Pre-fix only the wholly-new key
+        # was found.
+        diff = """\
+diff --git a/actions.yml b/actions.yml
+--- a/actions.yml
++++ b/actions.yml
+@@ -286,6 +286,9 @@ dependabot/fetch-metadata:
+ dlang-community/setup-dlang:
+   '*':
+     keep: true
++docker/bake-action:
++  aefd381cbaa93c62a1e8b02194ae420cc36269d2:
++    tag: v4.7.0
+ docker/build-push-action:
+   10e90e3645eae34f1e60eeb005ba3a3d33f178e8:
+     tag: v6.19.2
+@@ -295,6 +298,9 @@ docker/build-push-action:
+     expires_at: 2026-07-07
+   bcafcacb16a39f128d818304e6c9c0c18556b85f:
+     tag: v7.1.0
++  ca052bb54ab0790a636c9b5f226502c73d547a25:
++    tag: v5.4.0
++    expires_at: 2026-07-28
+ docker/login-action:
+   c94ce9fb468520275223c153574b00df6fe4bcc9:
+     tag: v3.7.0
+@@ -322,6 +328,9 @@ docker/setup-qemu-action:
+     expires_at: 2026-06-14
+   ce360397dd3f832beb865e1373c09c0e9f86d70a:
+     tag: v4.0.0
++  c7c53464625b32c7a7e944ae62b3e17d2b600130:
++    tag: v3.7.0
++    expires_at: 2026-07-28
+ docker://jekyll/jekyll:
+"""
+        refs = extract_action_refs_from_diff(diff)
+        assert refs == [
+            "docker/bake-action@aefd381cbaa93c62a1e8b02194ae420cc36269d2",
+            "docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25",
+            "docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130",
+        ]
+
+    def test_removed_key_does_not_leak_context(self):
+        # A removed key should never seed actions_yml_key — otherwise a
+        # subsequent ``+  <hash>:`` (perhaps from an unrelated edit further
+        # down the file) would be wrongly attributed to the removed key.
+        diff = """\
+-actions/checkout:
+-  abc123def456789012345678901234567890abcd:
+-    tag: v4.0.0
++  def456789012345678901234567890abcd123456:
++    tag: v9.9.9
+"""
+        # The bare hash is unattributable, so the extractor should yield
+        # nothing — never the removed-key + new-hash combination.
+        refs = extract_action_refs_from_diff(diff)
+        assert refs == []
+
+    def test_hunk_boundary_resets_key(self):
+        # If a hunk ends inside one action's block and the next hunk has
+        # no header context, the key from the previous hunk must not leak
+        # — it would silently reattribute additions to the wrong action.
+        diff = """\
+@@ -1,3 +1,4 @@ actions/checkout:
+   abc123def456789012345678901234567890abcd:
+     tag: v4
+@@ -50,2 +52,3 @@
++  def456789012345678901234567890abcd123456:
++    tag: v1.0.0
+"""
+        # Second hunk has no enclosing key context, so the bare ``+  <hash>:``
+        # line is unattributable and dropped.  No ref returned.
+        refs = extract_action_refs_from_diff(diff)
+        assert refs == []

--- a/utils/verify_action_build/pr_extraction.py
+++ b/utils/verify_action_build/pr_extraction.py
@@ -45,44 +45,81 @@ def extract_action_refs_from_diff(diff_text: str) -> list[str]:
     """Extract action refs from a unified diff string.
 
     This is the pure-logic core of PR extraction, separated for testability.
+
+    The actions.yml format is a map of ``org/repo:`` keys to nested commit-hash
+    entries.  A PR may add a wholly new key (``+org/repo:`` followed by ``+
+    <hash>:``) or a new hash under an *existing* key — in which case the key
+    only appears as a context line (`` org/repo:``) or in the hunk header
+    (``@@ -N,N +N,N @@ org/repo:``).  Both forms must be handled, otherwise
+    multi-action PRs that add hashes under several pre-existing keys (e.g.
+    apache/infrastructure-actions#803) silently drop all but the first
+    fully-new key.
     """
     seen: set[str] = set()
     refs: list[str] = []
 
     actions_yml_key: str | None = None
 
+    # actions.yml top-level key, with the diff marker (+/space) included so
+    # both added (``+org/repo:``) and context (`` org/repo:``) lines match.
+    # Note we deliberately *exclude* removed lines (``-org/repo:``): a removal
+    # block shouldn't leave a stale key context for any subsequent hash.
+    yml_key_re = re.compile(r"^[+ ]([a-zA-Z0-9_.-]+/[a-zA-Z0-9_./-]+):\s*$")
+    # Same key shape, but appearing as the function-context tail of a hunk
+    # header — git includes the closest enclosing block name there.
+    hunk_key_re = re.compile(
+        r"^@@ [-+,\d ]+ @@\s*([a-zA-Z0-9_.-]+/[a-zA-Z0-9_./-]+):\s*$"
+    )
+
     for line in diff_text.splitlines():
-        # Workflow files: uses: org/repo@hash
+        # Reset key context at hunk boundaries so a hash addition can't pick
+        # up a stale key from an earlier hunk.  Hunk headers may carry the
+        # enclosing actions.yml key as their tail context — if so, seed it.
+        if line.startswith("@@"):
+            hunk_match = hunk_key_re.match(line)
+            actions_yml_key = (
+                hunk_match.group(1).rstrip("/") if hunk_match else None
+            )
+            continue
+        if line.startswith(("---", "+++", "diff ")):
+            actions_yml_key = None
+            continue
+
+        # Workflow files: uses: org/repo@hash (added lines only).
         match = re.search(r"^\+.*uses?:\s+([^@\s]+)@([0-9a-f]{40})", line)
         if match:
-            action_path = match.group(1)
-            commit_hash = match.group(2)
-            ref = f"{action_path}@{commit_hash}"
+            ref = f"{match.group(1)}@{match.group(2)}"
             if ref not in seen:
                 seen.add(ref)
                 refs.append(ref)
             continue
 
-        # actions.yml: org/repo: as top-level key
-        key_match = re.match(r"^\+([a-zA-Z0-9_.-]+/[a-zA-Z0-9_./-]+):\s*$", line)
+        # actions.yml top-level key on either an added or context line.
+        key_match = yml_key_re.match(line)
         if key_match:
             actions_yml_key = key_match.group(1).rstrip("/")
             continue
 
-        # Match indented hash under the current key
         if actions_yml_key:
-            hash_match = re.match(r"^\+\s+['\"]?([0-9a-f]{40})['\"]?:\s*$", line)
+            # Hash entries: only attribute *added* hashes — context-line
+            # hashes belong to entries that were already in main.
+            hash_match = re.match(
+                r"^\+\s+['\"]?([0-9a-f]{40})['\"]?:\s*$", line
+            )
             if hash_match:
-                commit_hash = hash_match.group(1)
-                ref = f"{actions_yml_key}@{commit_hash}"
+                ref = f"{actions_yml_key}@{hash_match.group(1)}"
                 if ref not in seen:
                     seen.add(ref)
                     refs.append(ref)
                 continue
 
-            if re.match(r"^\+\s{4,}", line):
+            # Indented properties under the current key (``tag:``,
+            # ``expires_at:``, etc.) — keep the key context active.  Accepted
+            # on either added or context lines for the same reason as above.
+            if re.match(r"^[+ ]\s{2,}", line):
                 continue
 
+            # Anything else means we've left the current key's block.
             actions_yml_key = None
 
     return refs


### PR DESCRIPTION
## Summary

- `extract_action_refs_from_diff` only seeded the actions.yml key context from `+` lines, so hash additions under pre-existing keys (where the key shows up only as a context line or in the hunk header's tail) were silently dropped — apache/infrastructure-actions#803 has 3 new entries, but pre-fix `--from-pr 803` only returned the one wholly-new key `docker/bake-action`.
- Read the key from `+`/context lines and from `@@ ... @@ <key>:` hunk-header tails. Reset the key on hunk boundaries so stale context can't bleed across unrelated edits. Removed lines (`-`) deliberately don't seed — a deletion block must not leave a context for any later hash.
- 5 new tests: hash-under-existing-key (context line + hunk header), the PR 803 fixture (3 refs), and two negative cases.

## Test plan

- [x] `uv run pytest utils/tests/` — 209/209 pass.
- [x] Real PR 803 diff fed through the extractor returns all 3 refs (was 1 pre-fix):
  - `docker/bake-action@aefd381c…`
  - `docker/build-push-action@ca052bb5…`
  - `docker/setup-qemu-action@c7c53464…`

Generated-by [Claude Code](https://claude.com/claude-code).