### PR TITLE
support benchmark-action/github-action-benchmark

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -124,6 +124,9 @@ bazel-contrib/setup-bazel:
     expires_at: 2026-06-20
   c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86:
     tag: 0.19.0
+benchmark-action/github-action-benchmark:
+  52576c92bccf6ac60c8223ec7eb2565637cae9ba:
+    tag: v1.22.1
 betahuhn/repo-file-sync-action:
   8b92be3375cf1d1b0cd579af488a9255572e4619:
     tag: v1.21.1


### PR DESCRIPTION
## **Why this action is needed for your project**

Groovy wants to create a graphical summary of its jmh tests. We generate a lot of performance stats. It all lives within GitHub action artifacts. It is tedious to determine the overall result of what the performance tests show.

There also seems to be at least one other project that was trying to use this (> 6 months ago):
https://github.com/apache/casbin-ucon/blob/master/.github/workflows/PerformancePush.yml#L24

Result for them:
https://apache.github.io/casbin-ucon/benchmark-monitoring/

## **Any alternatives you've considered**

We looked at what some other projects do for benchmarking
* Apache Arrow runs its perf infrastructure on Conbench, a custom continuous-benchmarking server the project built and self-hosts. Results live at conbench.ursa.dev, not on GitHub Pages.
* Apache Lucene uses luceneutil (Mike McCandless's long-running suite, ~15 years of nightly results) published at benchmarks.mikemccandless.com — entirely outside GitHub. The repo issue #1750 ("objective performance test for Lucene") is still open, which suggests they haven't standardised on a CI-driven dashboard at all.
* Apache Hadoop has built-in benchmarking tools (NNBench, MRBench, TestDFSIO) documented on the project site but, as far as I can see, no automated dashboard wired into GitHub Actions.

These seemed like overkill or not applicable for us.

## **Any security concerns you've identified**

The action writes into the gh-pages section of the repo. We don't use that for anything else.
We do need to give it `write` permissions to allow it to do its work.

Claude's security assessment of the plugin:
* **No external code is fetched at runtime** — only `git` to GitHub and Octokit calls to `api.github.com`.
* **No `eval`/`Function`/dynamic require**; all parsing is `JSON.parse` or regex.
* **Permissions required:** `contents: write` (for `gh-pages` auto-push) and `issues: write` (commit comments)
* **Maintainer concentration is the residual risk** — single active maintainer, unsigned release commits. A SHA pin mitigates this until you upgrade.

1. Pin verification
- Workflow pin: `a60cea5bc7b49e15c1f58f411161f99e0df48372`
- `git/refs/tags/v1.22.0` resolves to the **same SHA**. Pin is genuine.
- Release commit author/committer: `Chris Trzesniewski` (GitHub: `ktrz`). Commit signature: **unsigned** (`verification.verified=false`). Not unusual for actions, but means trust is anchored to repo-write access, not a maintainer key.

2. Project trust surface

| Signal                    | Value                                                                                |
| ------------------------- | ------------------------------------------------------------------------------------ |
| Owner                     | `benchmark-action` org (project was donated by original author `rhysd`, 297 commits) |
| Active release maintainer | `ktrz` (68 commits) — sole signer of the last 6 releases                             |
| Other contributors        | small long-tail; mostly Dependabot                                                   |
| Stars / Forks             | 1.2k / 181                                                                           |
| Open issues               | 125                                                                                  |
| Published advisories      | None                                                                                 |
| License                   | MIT                                                                                  |
| Last release / push       | v1.22.0 on 2026-03-31 / repo pushed 2026-04-23                                       |

