### PR TITLE
Add `jbangdev/setup-jbang` action with tag v0.1.1

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -508,6 +508,9 @@ jarvusinnovations/background-action:
 jasonetco/create-an-issue:
   1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5:
     tag: v2
+jbangdev/setup-jbang:
+  2b1b465a7b75f4222b81426f23a01e013aa7b95c:
+    tag: v0.1.1
 JetBrains/qodana-action:
   89eb4357efd2b52e639f3216e63edaf33b82622b:
     tag: v2025.3.2


### PR DESCRIPTION
## **Why this action is needed for your project**
A new CI / PR checks system introduced in KIE (https://github.com/apache/incubator-kie-drools/commit/eaed2789c5df6acc6366d61b820695aebc364252) needs to run some scripts in order to produce efficient build partitioning for Maven builds. JBang was selected because it doesn't require any additional tooling for developers to install.

## **Any alternatives you've considered**
Installing JBang manually but I would just be duplicating what the action already does. See manual installation instructions [here](https://www.jbang.dev/documentation/jbang/latest/installation.html#universal-all-platforms). And the action's code [here](https://github.com/jbangdev/setup-jbang/blob/v0.1.1/action.yml).

## **Any security concerns you've identified**
None. `jbagdev` is the official organization of the JBang project in GitHub.