### PR TITLE
verify-action-build: detect orphan tags that ship package.json

### DIFF
--- a/utils/tests/verify_action_build/test_release_lookup.py
+++ b/utils/tests/verify_action_build/test_release_lookup.py
@@ -22,6 +22,7 @@ from unittest import mock
 from verify_action_build.release_lookup import (
     format_release_time,
     get_release_or_commit_time,
+    is_source_detached,
 )
 
 
@@ -140,3 +141,89 @@ class TestGetReleaseOrCommitTime:
         ):
             result = get_release_or_commit_time("org", "repo", "a" * 40)
         assert result is None
+
+
+class TestIsSourceDetached:
+    """The detector decides whether a tag commit lacks buildable source so
+    the rebuild can fall back to the default-branch source commit the
+    release was cut from.  Each scenario mocks the top-level tree names
+    that would be returned by GitHub's git-tree API for the tag commit.
+    """
+
+    @staticmethod
+    def _patch_tree(names):
+        return mock.patch(
+            "verify_action_build.release_lookup._tree_top_level_names",
+            return_value=set(names),
+        )
+
+    def test_orphan_tag_with_package_json_is_source_detached(self):
+        # benchmark-action/github-action-benchmark@v1.22.0 shape: the
+        # release-tagging workflow ships ``package.json`` (consumers read
+        # it; ``node_modules/`` resolves against it) but excludes the
+        # ``src/`` source.  Pre-fix the ``not has_pkg`` requirement caused
+        # this to be treated as source-bearing → rebuild produced an empty
+        # tree → ``canonicalizeUnit.js`` showed up as "only in original".
+        names = {
+            ".gitignore", "action-types.yml", "action.yml",
+            "dist", "node_modules", "package-lock.json", "package.json",
+        }
+        with self._patch_tree(names):
+            assert is_source_detached("org", "repo", "a" * 40) is True
+
+    def test_orphan_tag_without_package_json_is_source_detached(self):
+        # The original PR #768 shape (``a6b95b7``): orphan tag with only
+        # ``dist/`` and an action manifest.  Must continue to be detected.
+        names = {"action.yml", "dist"}
+        with self._patch_tree(names):
+            assert is_source_detached("org", "repo", "a" * 40) is True
+
+    def test_tree_with_src_directory_is_not_source_detached(self):
+        # The common case: the tag points at the same commit as the
+        # default branch and the source lives under ``src/`` next to the
+        # built ``dist/``.  No fallback needed.
+        names = {
+            "action.yml", "dist", "src", "package.json", "tsconfig.json",
+        }
+        with self._patch_tree(names):
+            assert is_source_detached("org", "repo", "a" * 40) is False
+
+    def test_root_typescript_source_is_not_source_detached(self):
+        # An action that keeps its source at the repo root (``index.ts``
+        # next to ``action.yml``) and emits to ``dist/`` shouldn't be
+        # treated as source-detached even though there's no ``src/``.
+        names = {
+            "action.yml", "dist", "index.ts", "package.json", "tsconfig.json",
+        }
+        with self._patch_tree(names):
+            assert is_source_detached("org", "repo", "a" * 40) is False
+
+    def test_composite_or_docker_action_without_dist_is_not_flagged(self):
+        # Composite / docker actions don't ship a ``dist/`` tree at all.
+        # Without ``dist/`` there's no "rebuilt artifact" to reconcile,
+        # so the source-detached fallback is irrelevant.
+        names = {"action.yml", "Dockerfile", "scripts"}
+        with self._patch_tree(names):
+            assert is_source_detached("org", "repo", "a" * 40) is False
+
+    def test_sub_path_disables_detection(self):
+        # Monorepo sub-actions typically keep build tooling at the repo
+        # root, so a sub_path tree without ``src/`` or ``package.json``
+        # is expected and isn't source-detached.  The detector should
+        # short-circuit on any non-empty ``sub_path`` without consulting
+        # the tree at all.
+        with mock.patch(
+            "verify_action_build.release_lookup._tree_top_level_names"
+        ) as tree:
+            assert (
+                is_source_detached("org", "repo", "a" * 40, sub_path="install/foo")
+                is False
+            )
+            tree.assert_not_called()
+
+    def test_empty_tree_returns_false(self):
+        # An API failure / empty tree shouldn't be classed as
+        # source-detached — the fallback would just look up a non-existent
+        # source commit and produce a confusing report.
+        with self._patch_tree(set()):
+            assert is_source_detached("org", "repo", "a" * 40) is False

--- a/utils/verify_action_build/release_lookup.py
+++ b/utils/verify_action_build/release_lookup.py
@@ -68,12 +68,20 @@ def _tree_top_level_names(org: str, repo: str, commit_hash: str) -> set[str]:
 def is_source_detached(org: str, repo: str, commit_hash: str, sub_path: str = "") -> bool:
     """Return True when the commit tree lacks buildable source.
 
-    A "source-detached" commit is one where the tagged tree contains only
-    distributable artifacts — no ``package.json`` at the build root.  When
-    ``sub_path`` is set (monorepo sub-action), we check that sub-tree; else
-    the repo root.  The heuristic is intentionally narrow: we only flag
-    commits that *also* contain a ``dist/`` directory, so repos that simply
-    don't use a build step (composite/docker actions) aren't false-positived.
+    A "source-detached" commit is one where the tagged tree contains
+    distributable artifacts (a ``dist/`` directory) but no source to
+    rebuild from — no ``src/`` tree and no top-level TypeScript/JS source
+    files.  When ``sub_path`` is set (monorepo sub-action), we check that
+    sub-tree; else the repo root.  The heuristic only flags commits that
+    contain a ``dist/`` directory, so repos that simply don't use a build
+    step (composite/docker actions) aren't false-positived.
+
+    Note: ``package.json`` may or may not be present at a source-detached
+    tag.  Some release-tagging automations (e.g. benchmark-action's at
+    v1.22.0) include ``package.json`` for runtime resolution and consumer
+    metadata while still excluding the source — so we deliberately do
+    not gate on its absence.  The reliable signal is "no place to build
+    from", which is what the source/root-source checks below test for.
     """
     # Monorepo sub-actions typically keep their build tooling at the repo
     # root, so a sub_path without package.json is expected, not source-
@@ -86,9 +94,13 @@ def is_source_detached(org: str, repo: str, commit_hash: str, sub_path: str = ""
         return False
 
     has_dist = "dist" in names
-    has_pkg = "package.json" in names
     has_src_tree = "src" in names
-    return has_dist and not has_pkg and not has_src_tree
+    # Source can also live at the repo root next to ``action.yml`` (an
+    # ``index.ts`` action with no separate ``src/``).  Don't flag those.
+    has_root_ts_source = any(
+        n.endswith((".ts", ".tsx", ".mts", ".cts")) for n in names
+    )
+    return has_dist and not has_src_tree and not has_root_ts_source
 
 
 def _find_tags_for_commit(org: str, repo: str, commit_hash: str) -> list[str]:


### PR DESCRIPTION
## Summary

- `is_source_detached` required `not has_pkg` — the detector only flagged orphan release tags whose tree had **no** `package.json`. But real-world release-tagging workflows commonly **include** `package.json` on the orphan tag (so consumers reading the manifest at runtime, and the action's own `node_modules/`, both resolve) while still excluding the `src/` tree.
- `benchmark-action/github-action-benchmark@v1.22.0` (`a60cea5b…`, surfaced via apache/infrastructure-actions#805) is exactly this shape: tag has `dist/`, `package.json`, `package-lock.json`, `action.yml`, `node_modules/` — and no `src/`. Pre-fix the source-detached fallback never fired, the rebuild ran against a tree with no source, and `canonicalizeUnit.js` showed up as "only in original" in the JS-rebuild diff. After the fix, the fallback resolves the master `release v1.22.0` commit (`c38cce98215c`) and rebuilds from there; all 16 `src/*.js` files are byte-identical.
- Drop the `not has_pkg` requirement. Add a `not has_root_ts_source` guard so root-source actions (`index.ts` next to `action.yml`, no `src/`) aren't false-positived.
- 7 regression tests in `test_release_lookup.py` covering the benchmark-action shape, the original PR #768 shape (no regression), the common `src/`-tree shape, the root-TS-source shape, composite/docker without `dist/`, sub_path, and an empty tree.

## Test plan

- [x] `uv run pytest utils/tests/` — 216/216 pass.
- [x] `prek run --all-files` is clean.
- [x] Re-running `verify-action-build benchmark-action/github-action-benchmark@a60cea5b…`: source-detached fallback fires, rebuilds from `c38cce98215c`, all 16 `src/*.js` files identical.
- [ ] Manual: re-trigger CI on apache/infrastructure-actions#805 once this lands and confirm the previously-failing `JS build verification` check passes.

Note: a single residual finding remains on PR #805 — `scripts/ci_validate_modification.js` is "only in rebuilt" because the publisher's release workflow excludes CI helper scripts from `dist/`, but `tsconfig.build.json`'s `**/*.ts` pattern compiles them. That's a separate concern (lenience for "extra in rebuilt" outputs vs. publisher's curation) — out of scope for this PR.

Generated-by [Claude Code](https://claude.com/claude-code).