### PR TITLE
allowlist: remove browser-actions/setup-geckodriver and /setup-firefox

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -136,14 +136,6 @@ biomejs/setup-biome:
 BobAnkh/auto-generate-changelog:
   '*':
     keep: true
-browser-actions/setup-firefox:
-  5914774dda97099441f02628f8d46411fcfbd208:
-    tag: v1.7.0
-    expires_at: 2026-06-12
-  fcf821c621167805dd63a29662bd7cb5676c81a8:
-    tag: v1.7.1
-browser-actions/setup-geckodriver:
-  5ef1526ed36211ab6cb531ec1cfb11f924ca2dee:
 bufbuild/buf-breaking-action:
   '*':
     keep: true


### PR DESCRIPTION
As Tapestry was the only one using them, and they
moved away from it.

https://github.com/apache/infrastructure-actions/pull/813 https://github.com/apache/tapestry-5/pull/58