### PR TITLE
verify-action-build: pass cleanly on removal-only PRs

### DIFF
--- a/utils/tests/verify_action_build/test_cli.py
+++ b/utils/tests/verify_action_build/test_cli.py
@@ -44,3 +44,34 @@ class TestMain:
                     with pytest.raises(SystemExit) as exc_info:
                         main()
                     assert exc_info.value.code == 1
+
+    def test_from_pr_with_no_added_refs_passes(self):
+        removal_only_diff = (
+            "diff --git a/actions.yml b/actions.yml\n"
+            "--- a/actions.yml\n"
+            "+++ b/actions.yml\n"
+            "@@ -10,5 +10,0 @@\n"
+            "-some-org/some-action:\n"
+            "-  " + "a" * 40 + ":\n"
+            "-    tag: v1.0.0\n"
+        )
+        with mock.patch("sys.argv", ["verify-action-build", "--from-pr", "999"]):
+            with mock.patch("shutil.which", return_value="/usr/bin/docker"):
+                with mock.patch(
+                    "verify_action_build.cli.GitHubClient"
+                ) as gh_cls:
+                    gh_cls.return_value.get_pr_diff.return_value = removal_only_diff
+                    with pytest.raises(SystemExit) as exc_info:
+                        main()
+                    assert exc_info.value.code == 0
+
+    def test_from_pr_when_diff_fetch_fails_errors(self):
+        with mock.patch("sys.argv", ["verify-action-build", "--from-pr", "999"]):
+            with mock.patch("shutil.which", return_value="/usr/bin/docker"):
+                with mock.patch(
+                    "verify_action_build.cli.GitHubClient"
+                ) as gh_cls:
+                    gh_cls.return_value.get_pr_diff.return_value = None
+                    with pytest.raises(SystemExit) as exc_info:
+                        main()
+                    assert exc_info.value.code == 1

--- a/utils/verify_action_build/cli.py
+++ b/utils/verify_action_build/cli.py
@@ -26,7 +26,7 @@ import sys
 from .console import console
 from .dependabot import check_dependabot_prs
 from .github_client import GitHubClient
-from .pr_extraction import extract_action_refs_from_pr
+from .pr_extraction import extract_action_refs_from_diff
 from .verification import SECURITY_CHECKLIST_URL, verify_single_action
 
 
@@ -122,10 +122,17 @@ def main() -> None:
         gh = GitHubClient(token=args.github_token)
 
     if args.from_pr:
-        action_refs = extract_action_refs_from_pr(args.from_pr, gh=gh)
-        if not action_refs:
-            console.print(f"[red]Error:[/red] could not extract action reference from PR #{args.from_pr}")
+        diff_text = gh.get_pr_diff(args.from_pr)
+        if diff_text is None:
+            console.print(f"[red]Error:[/red] could not fetch diff for PR #{args.from_pr}")
             _exit(1)
+        action_refs = extract_action_refs_from_diff(diff_text)
+        if not action_refs:
+            console.print(
+                f"No added action references in PR #{args.from_pr} — nothing to verify "
+                "(removal-only or non-action changes)."
+            )
+            _exit(0)
         for ref in action_refs:
             console.print(f"  Extracted action reference from PR #{args.from_pr}: [bold]{ref}[/bold]")
         passed = all(


### PR DESCRIPTION
## Summary
- The `--from-pr` branch was failing on removal-only PRs (e.g. #818) because there are no *added* action references to verify — `extract_action_refs_from_diff` correctly returns an empty list, but the CLI treated that as a fatal error.
- Now distinguishes the two empty-result cases: diff-fetch failure still errors out, while a successfully-fetched diff with no added refs passes with a friendly "nothing to verify" message.

## Why
Removal PRs (and any PR that touches `actions.yml` / `approved_patterns.yml` without adding a new pinned SHA) shouldn't fail the verify check — there's literally nothing to verify. PR #818 hit this because it only removes entries.

## Test plan
- [x] `uv run pytest utils/tests/` — 223 passed
- [x] Two new test cases in `test_cli.py`:
  - `test_from_pr_with_no_added_refs_passes` — removal-only diff exits 0
  - `test_from_pr_when_diff_fetch_fails_errors` — None diff exits 1
- [ ] After merge, CI re-run on #818 should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)