### PR TITLE
expire scacap/action-surefire-report at 2026-08-01

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -850,7 +850,7 @@ sbt/setup-sbt:
     tag: v1.1.23
 scacap/action-surefire-report:
   '*':
-    keep: true
+    expires_at: 2026-08-01
   5609ce4db72c09db044803b344a8968fd1f315da:
     tag: v1.9.1
     expires_at: 2026-07-17
@@ -858,6 +858,7 @@ scacap/action-surefire-report:
     tag: v1.10.0
     expires_at: 2026-07-31
   3dacff26879cd2a7f2160d101254032a3707fe6f:
+    expires_at: 2026-08-01
     tag: v1.12.0
 scalacenter/sbt-dependency-submission:
   f43202114d7522a4b233e052f82c2eea8d658134:


### PR DESCRIPTION
as recommended at https://github.com/ScaCap/action-surefire-report