### PR TITLE
allowlist: add carabiner-dev install/{ampel,bnd} transitive deps

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -166,6 +166,14 @@ bytedeco/javacpp-presets:
 carabiner-dev/actions/ampel/verify:
   e0e3b8149dafed833431095bc148d50e7eade4e8:
     tag: v1.2.0
+carabiner-dev/actions/install/ampel:
+  2a11d59a135c5e291f305f249a92ad7903e3ee0f:
+    # transitive dep of carabiner-dev/actions/ampel/verify @ v1.2.0
+    tag: v1.1.7
+carabiner-dev/actions/install/bnd:
+  2a11d59a135c5e291f305f249a92ad7903e3ee0f:
+    # transitive dep of carabiner-dev/actions/ampel/verify @ v1.2.0
+    tag: v1.1.7
 carloscastrojumo/github-cherry-pick-action:
   503773289f4a459069c832dc628826685b75b4b3:
     tag: v1.0.10


### PR DESCRIPTION
## Summary
- Add `carabiner-dev/actions/install/ampel@v1.1.7` and `install/bnd@v1.1.7` to the allowlist. Both are transitive deps that `carabiner-dev/actions/ampel/verify@v1.2.0` calls.
- Fixes the recurring `check-for-transitive-failures` failures (e.g. [run 25643163039](https://github.com/apache/infrastructure-actions/actions/runs/25643163039/job/75266996915)): GitHub Actions rejects the transitive `install/*` refs because they aren't on the org allowlist.

## Test plan
- [ ] After merge, `update_actions.yml` regenerates `approved_patterns.yml` + the composite action.yml from `actions.yml`.
- [ ] ASF Infra's allowlist sync picks up the new SHAs; the next hourly `check-for-transitive-failures` run passes.