### PR TITLE
Allow reqsign 1Password load-secrets refs

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -30,6 +30,14 @@
     expires_at: 2026-06-17
   92467eb28f72e8255933372f1e0707c567ce2259:
     tag: v4.0.0
+1password/load-secrets-action:
+  92467eb28f72e8255933372f1e0707c567ce2259:
+    keep: true
+    tag: v4.0.0
+1password/load-secrets-action/configure:
+  92467eb28f72e8255933372f1e0707c567ce2259:
+    keep: true
+    tag: v4.0.0
 actions-cool/check-user-permission:
   '*':
     keep: true

--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -22,6 +22,8 @@
 - 1Password/load-secrets-action@8d0d610af187e78a2772c2d18d627f4c52d3fbfb
 - 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf
 - 1Password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259
+- 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259
+- 1password/load-secrets-action/configure@92467eb28f72e8255933372f1e0707c567ce2259
 - actions-cool/check-user-permission@*
 - actions-cool/issues-helper@*
 - actions-cool/maintain-one-comment@*


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

Allow the exact lower-case 1Password load-secrets refs currently used by Apache reqsign workflows. The canonical `1Password/load-secrets-action` v4.0.0 root action is already approved, but the ASF checker is case-sensitive and reqsign uses lower-case refs, including the `configure` subaction path.

**Name of action:** `1password/load-secrets-action` and `1password/load-secrets-action/configure`

**URL of action:** https://github.com/1Password/load-secrets-action

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** `92467eb28f72e8255933372f1e0707c567ce2259`

## Permissions

Same upstream action and commit already approved under the canonical `1Password/load-secrets-action` root entry. This PR only adds exact allowlist patterns for reqsign's case-sensitive refs.

## Related Actions

`1Password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259` is already present in `actions.yml` as v4.0.0.

## Checklist

- [x] The action is listed in the GitHub Actions Marketplace
- [ ] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
- [ ] Compiled JavaScript in `dist/` matches a clean rebuild (verify with `uv run utils/verify-action-build.py org/repo@hash`)
