### PR TITLE
Allow Azure login v3 for reqsign workflows

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -114,6 +114,7 @@ aws-actions/configure-aws-credentials:
     tag: v6.1.1
 azure/login:
   532459ea530d8321f2fb9bb10d1e0bcf23869a43:
+    keep: true
     tag: v3.0.0
 azure/setup-helm:
   1a275c3b69536ee54be43f2070a358922e12c8d4:


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

**Name of action:** azure/login

**URL of action:** https://github.com/Azure/login

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** 532459ea530d8321f2fb9bb10d1e0bcf23869a43

Apache reqsign workflows use the lower-case `azure/login` action ref, and need the latest Azure Login v3.0.0 commit allowlisted exactly as referenced.

## Permissions

This PR only allowlists the pinned action ref. Workflow permissions remain defined by the consuming reqsign workflows.

## Related Actions

This is the current release of the existing Azure Login action; the lower-case owner/action spelling is intentional because the ASF checker is case-sensitive.

## Checklist

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
- [ ] Compiled JavaScript in `dist/` matches a clean rebuild (verify with `uv run utils/verify-action-build.py org/repo@hash`)
