### PR TITLE
Allow matlab-actions/run-tests v3.1.1

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -687,6 +687,8 @@ matlab-actions/run-tests:
   4be3345d41da8b1bf8cc5cb01a5e19c4611cb15d:
     tag: v3.0.0
     expires_at: 2026-07-05
+  4c375221b861dd3f7ea9b31704a3cf45d35073f1:
+    tag: v3.1.2
 matlab-actions/setup-matlab:
   aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4:
     tag: v2.7.0


### PR DESCRIPTION
To address: [#49962](https://github.com/apache/arrow/pull/49962), we would like to allow `v3.1.1` of the `matlab-actions/run-tests` action.

**Note**: `v3.1.1` is *not* a  Prerelease, so we don't expect to run into the "commit churn" which was addressed by #735 for this version. On behalf of the MathWorks CI Team - our sincere apologies for the  inconvenience this issue caused.

**Note**: It is unclear what is preventing `matlab-actions/run-tests` from eventually ending up in the same state again if a future upgrade is also a Prerelease. Does some kind of additional logic need to be added to the infrastructure to "ignore" prereleases for Dependabot upgrades?