### PR TITLE
verify-action-build: detect MATLAB platform-named binary dirs

### DIFF
--- a/utils/tests/verify_action_build/test_security.py
+++ b/utils/tests/verify_action_build/test_security.py
@@ -1302,6 +1302,32 @@ class TestLooksLikeInTreeBinary:
         assert _looks_like_in_tree_binary("dist/licenses.txt") is False
         assert _looks_like_in_tree_binary("licenses.txt") is False
 
+    def test_matlab_platform_dir_naming(self):
+        # MATLAB's launcher convention: dist/bin/<platform>/run-matlab-command
+        # where <platform> is MATLAB's own arch identifier and the file has
+        # no extension.  matlab-actions/run-tests@v3.1.1 ships these:
+        for path in (
+            "dist/bin/glnxa64/run-matlab-command",
+            "dist/bin/maca64/run-matlab-command",
+            "dist/bin/maci64/run-matlab-command",
+        ):
+            assert _looks_like_in_tree_binary(path), path
+        # The .exe sibling was already caught by extension; keep it green.
+        assert _looks_like_in_tree_binary("dist/bin/win64/run-matlab-command.exe")
+
+    def test_matlab_sibling_text_files_not_flagged(self):
+        # license.txt and thirdpartylicenses.txt sit in dist/bin/ directly,
+        # not under a <platform>/ subdir — and licenses.txt is exempt by
+        # name anyway.
+        assert not _looks_like_in_tree_binary("dist/bin/license.txt")
+        assert not _looks_like_in_tree_binary("dist/bin/thirdpartylicenses.txt")
+
+    def test_platform_dir_requires_parent(self):
+        # A file *named* glnxa64 at the repo root is not a binary launcher.
+        # The signal is parent-directory == platform, not filename.
+        assert not _looks_like_in_tree_binary("glnxa64")
+        assert not _looks_like_in_tree_binary("docs/glnxa64.md")
+
 
 class TestParseSha256sums:
     """Parse the standard ``<sha>  <filename>`` format used by ``sha256sum``

--- a/utils/verify_action_build/security.py
+++ b/utils/verify_action_build/security.py
@@ -1651,6 +1651,18 @@ _PLATFORM_ARCH_BINARY_RE = re.compile(
     r"(?:\.exe)?$"
 )
 
+# Some toolchains drop platform info into the *parent directory* rather
+# than the filename, so the cross-compile regex above misses them.
+# MATLAB's launcher ships at ``dist/bin/<platform>/run-matlab-command``
+# where ``<platform>`` is MATLAB's own identifier (``glnxa64`` = Linux
+# x86_64, ``maca64`` = macOS arm64, ``maci64`` = macOS x86_64).  The
+# Windows sibling has a ``.exe`` and is already caught by extension.
+_PLATFORM_DIR_NAMES = frozenset({
+    "glnxa64",
+    "maca64",
+    "maci64",
+})
+
 # Filename patterns that LOOK binary but are conventional in JS/TS or other
 # textual sources — don't false-positive these.
 _IN_TREE_BINARY_EXEMPT_NAMES = {
@@ -1664,8 +1676,9 @@ def _looks_like_in_tree_binary(path: str) -> bool:
     pre-compiled native binary by name alone.
 
     Cheap path-only heuristic — no fetch, no magic-byte sniff.  Known
-    binary extensions and cross-compile platform/arch suffixes both
-    trigger; conventional text artifacts are exempted.
+    binary extensions, cross-compile platform/arch suffixes and
+    platform-named parent directories all trigger; conventional text
+    artifacts are exempted.
     """
     name = path.rsplit("/", 1)[-1]
     if name in _IN_TREE_BINARY_EXEMPT_NAMES:
@@ -1674,6 +1687,9 @@ def _looks_like_in_tree_binary(path: str) -> bool:
     if lower.endswith(_IN_TREE_BINARY_EXTENSIONS):
         return True
     if _PLATFORM_ARCH_BINARY_RE.search(lower):
+        return True
+    parts = path.split("/")
+    if len(parts) >= 2 and parts[-2] in _PLATFORM_DIR_NAMES:
         return True
     return False
 


### PR DESCRIPTION
## Summary

- `_looks_like_in_tree_binary` flagged `dist/bin/win64/run-matlab-command.exe` (via its `.exe`) but missed the three Unix siblings at `dist/bin/{glnxa64,maca64,maci64}/run-matlab-command` — they have no extension and don't fit the cross-compile `<name>-<os>-<arch>` regex.
- Add a parent-directory rule: if the immediate parent dir is a known MATLAB platform identifier (`glnxa64`, `maca64`, `maci64`), the file is treated as a launcher binary. Windows already worked via extension.
- Pin regression tests against the actual `matlab-actions/run-tests@v3.1.1` shape so future bumps can't regress the catch.

Surfaced while triaging apache/infrastructure-actions#846 (upstream provenance ask: matlab-actions/run-tests#94).

## Test plan

- [x] `uv run pytest utils/tests/` — 273 passed
- [x] `prek run --all-files` — clean