### PR TITLE
allowlist: add carabiner-dev install/{download-and-verify,ampel-bootstrap} (levels 2-3)

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -181,18 +181,16 @@ carabiner-dev/actions/install/ampel:
     # transitive dep of carabiner-dev/actions/ampel/verify @ v1.2.0
     tag: v1.1.7
 carabiner-dev/actions/install/ampel-bootstrap:
+  # level-3 transitive: called by install/download-and-verify; commit is untagged
+  # (per upstream: "bootstrap rotated to ampel v1.2.1")
   0a075bb75a68646d05f99c85cbbf2be40dd8e442:
-    # level-3 transitive: called by install/download-and-verify
-    # (per upstream: "bootstrap rotated to ampel v1.2.1")
-    tag: v1.1.7
 carabiner-dev/actions/install/bnd:
   2a11d59a135c5e291f305f249a92ad7903e3ee0f:
     # transitive dep of carabiner-dev/actions/ampel/verify @ v1.2.0
     tag: v1.1.7
 carabiner-dev/actions/install/download-and-verify:
+  # level-2 transitive: called by install/{ampel,bnd} @ v1.1.7; commit is untagged
   6022a065d6420de5d86333ecfb2b25c57f84b699:
-    # level-2 transitive: called by install/{ampel,bnd} @ v1.1.7
-    tag: v1.1.7
 carloscastrojumo/github-cherry-pick-action:
   503773289f4a459069c832dc628826685b75b4b3:
     tag: v1.0.10

--- a/actions.yml
+++ b/actions.yml
@@ -184,6 +184,15 @@ carabiner-dev/actions/install/bnd:
   2a11d59a135c5e291f305f249a92ad7903e3ee0f:
     # transitive dep of carabiner-dev/actions/ampel/verify @ v1.2.0
     tag: v1.1.7
+carabiner-dev/actions/install/download-and-verify:
+  6022a065d6420de5d86333ecfb2b25c57f84b699:
+    # level-2 transitive: called by install/{ampel,bnd} @ v1.1.7
+    tag: v1.1.7
+carabiner-dev/actions/install/ampel-bootstrap:
+  0a075bb75a68646d05f99c85cbbf2be40dd8e442:
+    # level-3 transitive: called by install/download-and-verify
+    # (per upstream: "bootstrap rotated to ampel v1.2.1")
+    tag: v1.1.7
 carloscastrojumo/github-cherry-pick-action:
   503773289f4a459069c832dc628826685b75b4b3:
     tag: v1.0.10

--- a/actions.yml
+++ b/actions.yml
@@ -180,6 +180,11 @@ carabiner-dev/actions/install/ampel:
   2a11d59a135c5e291f305f249a92ad7903e3ee0f:
     # transitive dep of carabiner-dev/actions/ampel/verify @ v1.2.0
     tag: v1.1.7
+carabiner-dev/actions/install/ampel-bootstrap:
+  0a075bb75a68646d05f99c85cbbf2be40dd8e442:
+    # level-3 transitive: called by install/download-and-verify
+    # (per upstream: "bootstrap rotated to ampel v1.2.1")
+    tag: v1.1.7
 carabiner-dev/actions/install/bnd:
   2a11d59a135c5e291f305f249a92ad7903e3ee0f:
     # transitive dep of carabiner-dev/actions/ampel/verify @ v1.2.0
@@ -187,11 +192,6 @@ carabiner-dev/actions/install/bnd:
 carabiner-dev/actions/install/download-and-verify:
   6022a065d6420de5d86333ecfb2b25c57f84b699:
     # level-2 transitive: called by install/{ampel,bnd} @ v1.1.7
-    tag: v1.1.7
-carabiner-dev/actions/install/ampel-bootstrap:
-  0a075bb75a68646d05f99c85cbbf2be40dd8e442:
-    # level-3 transitive: called by install/download-and-verify
-    # (per upstream: "bootstrap rotated to ampel v1.2.1")
     tag: v1.1.7
 carloscastrojumo/github-cherry-pick-action:
   503773289f4a459069c832dc628826685b75b4b3:


### PR DESCRIPTION
## Summary

Follow-up to #831 — that PR added the level-1 transitive siblings `install/{ampel,bnd}@v1.1.7`, but the sibling-call chain rooted at `carabiner-dev/actions/ampel/verify@v1.2.0` is actually four levels deep:

```
ampel/verify @ v1.2.0 (e0e3b81…)
  └── install/{ampel,bnd} @ v1.1.7 (2a11d59…)             [added by #831]
        └── install/download-and-verify (6022a06…)        [this PR]
              └── install/ampel-bootstrap (0a075bb…)      [this PR]
```

`ampel-bootstrap` is a leaf — no further sibling refs.

The hourly `check-for-transitive-failures` workflow has continued to fail post-#831 with `carabiner-dev/actions/install/download-and-verify@6022a065d6420de5d86333ecfb2b25c57f84b699 is not allowed` (e.g. [run 26062684716](https://github.com/apache/infrastructure-actions/actions/runs/26062684716)). After this PR the next failure (if any) would be on `ampel-bootstrap`, which is also pre-emptively added here.

## Test plan
- [ ] On merge, `update_composite_action.yml` regenerates `approved_patterns.yml` + the dependabot composite from `actions.yml`.
- [ ] ASF Infra's allowlist sync picks up the two new SHAs; the next hourly `check-for-transitive-failures` run is green.

## Related
- #831 — original (level-1) fix
- #852 — tracking issue for the underlying sibling-chain pattern-explosion (pp's scaling concern, also see [his comment](https://github.com/apache/infrastructure-actions/pull/831#issuecomment-4474700884))
- carabiner-dev/actions#57 — upstream ask to enable immutable releases + tag-pin siblings