### PR TITLE
ci: switch Pre-commit Checks workflow from pre-commit to prek

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -38,6 +38,6 @@ jobs:
       - name: Run pre-commit checks
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv tool install pre-commit
+          uv tool install prek
           uv tool ensurepath
-          pre-commit run --all-files --color always --show-diff-on-failure
+          prek run --all-files --color always --show-diff-on-failure


### PR DESCRIPTION
## Summary

AGENTS.md (since the prek migration) tells contributors to use [prek](https://github.com/j178/prek) locally and states *"the hooks are the same ones CI enforces"*, but the `Pre-commit Checks` workflow was still installing `pre-commit` via `uv tool install pre-commit`. Swap both lines so CI matches the local dev path: install prek via uv, then `prek run --all-files`.

Same hooks (prek reads `.pre-commit-config.yaml` verbatim), same install transport (`uv tool install …`), just the faster Rust-native runner end-to-end.

## Diff

```diff
-          uv tool install pre-commit
+          uv tool install prek
           uv tool ensurepath
-          pre-commit run --all-files --color always --show-diff-on-failure
+          prek run --all-files --color always --show-diff-on-failure
```

## Test plan
- [ ] CI's `pre-commit` job (renamed contents, same job name for branch-protection compatibility) runs prek and matches what `prek run --all-files` produces locally.