### PR TITLE
gateway: fix update_refs crash on untagged transitive entries

### DIFF
--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -234,7 +234,9 @@ def update_refs(
 
         refs = action_refs[name]
         if new_ref not in refs:
-            for _, details in refs.items():
+            for ref_key, details in list(refs.items()):
+                if details is None:
+                    refs[ref_key] = details = {}
                 if not details.get("keep"):
                     new_expiry = calculate_expiry(12)
                     if "expires_at" not in details or details["expires_at"] > new_expiry:

--- a/gateway/test_gateway.py
+++ b/gateway/test_gateway.py
@@ -82,6 +82,23 @@ def test_update_refs():
     update_refs(steps, refs)
     assert refs == expected_refs
 
+def test_update_refs_none_details():
+    steps = load_yaml_string('''
+    - uses: carabiner-dev/actions/install/ampel-bootstrap@9db1a064ca5691ef6f5d983031739ca287de0968
+    ''')
+
+    refs: ActionsYAML = load_yaml_string('''
+    carabiner-dev/actions/install/ampel-bootstrap:
+      0a075bb75a68646d05f99c85cbbf2be40dd8e442:
+    ''')
+
+    update_refs(steps, refs)
+
+    bootstrap = refs["carabiner-dev/actions/install/ampel-bootstrap"]
+    assert bootstrap["0a075bb75a68646d05f99c85cbbf2be40dd8e442"]["expires_at"] == calculate_expiry(12)
+    assert "9db1a064ca5691ef6f5d983031739ca287de0968" in bootstrap
+
+
 def test_update_refs_expiry():
     steps = [
         {"uses": "dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36"},


### PR DESCRIPTION
## Summary

- Fix `AttributeError: 'NoneType' object has no attribute 'get'` in `update_refs` when `actions.yml` has an entry like `<sha>:` with no nested value (parses as `None`).
- Two such untagged-transitive entries landed in #853 (`carabiner-dev/actions/install/ampel-bootstrap` and `install/download-and-verify`). Every subsequent dependabot bump touching those keys now fails the `update_actions` workflow — see the failing run on #856 (1.1.7 → 1.2.0): https://github.com/apache/infrastructure-actions/actions/runs/26071060591/job/76652366856?pr=856.
- Initialize the empty dict in place so the expiry path runs on those entries the same way it does on any other.
- Regression test added that parses the exact YAML shape and asserts the old SHA gets `expires_at` and the new SHA is added.

## Test plan

- [x] `uv run pytest gateway/test_gateway.py` (8/8 pass, including new `test_update_refs_none_details`)
- [x] Reproduced the failing scenario locally against the PR #856 composite action — workflow now succeeds and produces a clean `actions.yml` (old SHAs gain `expires_at`, new v1.2.0 SHAs added).
- [ ] After merge: re-run the `update_actions` job on PR #856 (or wait for the next dependabot bump) to confirm it no longer crashes.