### PR TITLE
allowlist: silence zizmor unpinned-tools on if:false 1Password load-secrets-action

### DIFF
--- a/.github/actions/for-dependabot-triggered-reviews/action.yml
+++ b/.github/actions/for-dependabot-triggered-reviews/action.yml
@@ -38,7 +38,7 @@ runs:
   using: "composite"
   steps:
     - uses: 1Password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259  # v4.0.0
-      if: false
+      if: false  # zizmor: ignore[unpinned-tools] step never runs; allowlist registration only
     - uses: 1Password/load-secrets-action/configure@92467eb28f72e8255933372f1e0707c567ce2259  # v4.0.0
       if: false
     - uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185  # v3


### PR DESCRIPTION
## Summary
- Adds an inline `# zizmor: ignore[unpinned-tools]` on the `if: false` line of `1Password/load-secrets-action` in `.github/actions/for-dependabot-triggered-reviews/action.yml`.
- Reason: zizmor v1.25.2 (pulled by `zizmorcore/zizmor-action@v0.5.6`) added the `unpinned-tools` audit, which flags the action because it installs the 1Password CLI from an unpinned URL when it runs. In this file the step has `if: false` — the entry exists purely so dependabot tracks the SHA for the allowlist; it never executes.
- Pattern matches existing `# zizmor: ignore[<rule>] <explanation>` ignores already in this repo (`secrets-outside-env`, `dependabot-cooldown`).

## Why not a `zizmor.yml` config-level ignore?
- zizmor's docs explicitly state composite-action findings cannot be silenced via the config file — inline is the only path here.
- Even if it were possible, config-level path matching is base-filename only, which would silence the rule across all 5 `action.yml` files in this repo.

## What this unblocks
- #885 (`build(deps): bump zizmorcore/zizmor-action from 0.5.5 to 0.5.6`) currently fails because v0.5.6 surfaces this single new finding. With this merged, dependabot rebases #885 against new main → zizmor scan reports zero findings → mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)