### PR TITLE
gateway: emit with.version for known unpinned-tools actions (unblocks #885)

### DIFF
--- a/.github/actions/for-dependabot-triggered-reviews/action.yml
+++ b/.github/actions/for-dependabot-triggered-reviews/action.yml
@@ -39,8 +39,12 @@ runs:
   steps:
     - uses: 1Password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259  # v4.0.0
       if: false
+      with:
+        version: "2.30.0"
     - uses: 1Password/load-secrets-action/configure@92467eb28f72e8255933372f1e0707c567ce2259  # v4.0.0
       if: false
+      with:
+        version: "2.30.0"
     - uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185  # v3
       if: false
     - uses: advanced-security/dismiss-alerts@046d6b48d2e43cf563f96f67332c47c432eff83e  # v2.0.2

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -201,8 +201,36 @@ runs:
             details = refs[ref]
             steps.append(f"    - uses: {name}@{ref}" + (f"  # {details['tag']}" if details and 'tag' in details else ''))
             steps.append( "      if: false")
+            # zizmor's `unpinned-tools` audit flags certain actions whose
+            # default behavior is to install the "latest" version of an
+            # external tool. The remediation is to set `with.version` to
+            # a specific value. These steps never execute (`if: false`);
+            # the value is cosmetic, only here so the static analyser is
+            # satisfied. See https://docs.zizmor.sh/audits/#unpinned-tools
+            pin = _unpinned_tool_version_pin(name)
+            if pin is not None:
+                steps.append("      with:")
+                steps.append(f'        version: "{pin}"')
 
     return header + "\n".join(steps) + "\n" + "    - run: echo Success!\n" + "      shell: bash\n"
+
+
+# zizmor's `unpinned-tools` audit (zizmor source:
+# crates/zizmor/src/audit/unpinned_tools.rs) reports a Medium finding when one
+# of these actions is used without a static `with.version`. Keys are matched
+# case-insensitively against the bare repo name and any subpath under it.
+_UNPINNED_TOOLS_VERSION_PINS = {
+    "1password/load-secrets-action": "2.30.0",
+    "aquasecurity/setup-trivy": "v0.55.0",
+}
+
+
+def _unpinned_tool_version_pin(name: str) -> str | None:
+    name_l = name.lower()
+    for prefix, version in _UNPINNED_TOOLS_VERSION_PINS.items():
+        if name_l == prefix or name_l.startswith(prefix + "/"):
+            return version
+    return None
 
 
 def update_refs(


### PR DESCRIPTION
## Summary

#886 tried to silence zizmor 1.25.2's new `unpinned-tools` audit on `1Password/load-secrets-action` with an inline `# zizmor: ignore[]` comment, but placed it on the `if: false` line. zizmor only honours the ignore on the line where the finding lives (line 40 — the `- uses:` line), so the suppression never took effect, and **#885 (zizmor 0.5.5 → 0.5.6) has been stuck failing CI ever since.**

## Why not just move the inline ignore to the right line?

Two reasons:

1. **Fragile to dependabot rewrites** — the `- uses:` line already carries dependabot's `# v4.0.0` version comment. Dependabot rewrites that comment on every bump and would strip an appended zizmor-ignore tail.
2. **No fallback via `zizmor.yml` config** — the [zizmor configuration docs](https://docs.zizmor.sh/configuration/) state explicitly: *"Composite action findings cannot be ignored via `zizmor.yml` currently. They can be ignored inline [with comments]."*

## Why pin `with.version` instead

The audit's actual remediation (per its source at `crates/zizmor/src/audit/unpinned_tools.rs`) is to set a static `with.version` value. The audit fires only when the input is missing or set to literal `latest`. Setting it to any specific string silences the finding cleanly. Since these composite entries are `if: false` (allowlist registration only — they never execute), the version value is cosmetic; only the static analyser cares.

## Changes

- **`gateway/gateway.py`** — new `_unpinned_tool_version_pin()` helper + `_UNPINNED_TOOLS_VERSION_PINS` table so the composite generator emits a `with.version` block for any action zizmor's `unpinned-tools` audit knows about (`1password/load-secrets-action` today; `aquasecurity/setup-trivy` preemptive, even though we don't carry it on the allowlist).
- **Composite** — targeted manual edit applying the same `with.version` block to the existing `1Password/load-secrets-action` and `…/configure` entries. The next full regeneration (post #892's pipeline recovery) will produce identical content; the manual edit only fast-paths the fix so #885 can land immediately.
- Also drops the no-op `# zizmor: ignore[unpinned-tools]` tail comment that #886 added on the `if: false` line — the version pin is the real suppression mechanism now.

## Test plan

- [x] Locally with `zizmor 1.25.2` (the version bundled by `zizmor-action@v0.5.6`): `zizmor --min-severity medium --min-confidence medium .github/ allowlist-check/ pelican/ stash/` → **"No findings to report. Good job!"** (down from 1 medium).
- [x] `uv run pytest gateway/` → 8 passed.
- [x] Confirmed manual composite edit and a full regen produce identical `with.version` content for the 1Password entries (the only differences are unrelated version drift from the still-broken update workflow on main — which #892 will heal).
- [ ] After merge: re-trigger #885 (`@dependabot rebase`) → expect `Run zizmor 🌈` to pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)