### PR TITLE
allowlist: add carabiner-dev install/download-and-verify transitive dep

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -191,6 +191,10 @@ carabiner-dev/actions/install/bnd:
   e0e3b8149dafed833431095bc148d50e7eade4e8:
     tag: v1.2.0
 carabiner-dev/actions/install/download-and-verify:
+  2a11d59a135c5e291f305f249a92ad7903e3ee0f:
+    # transitive dep of carabiner-dev/actions/ampel/verify @ v1.2.0
+    tag: v1.1.7
+    expires_at: 2026-08-16
   # level-2 transitive: called by install/{ampel,bnd} @ v1.1.7; commit is untagged
   6022a065d6420de5d86333ecfb2b25c57f84b699:
     expires_at: 2026-08-16


### PR DESCRIPTION
## Summary
- Add `carabiner-dev/actions/install/download-and-verify@v1.1.7`
  (`2a11d59a135c5e291f305f249a92ad7903e3ee0f`) to the allowlist.
  Same monorepo commit already approved for `install/ampel` and
  `install/bnd` via #831 — `download-and-verify` is a sibling
  subpath under the same SHA, reachable transitively from
  `ampel/verify@v1.2.0`.
- Fixes the recurring `check-for-transitive-failures` failures
  (e.g. [run 26602787860](https://github.com/apache/infrastructure-actions/actions/runs/26602787860)):
  GitHub Actions rejects the transitive `download-and-verify@2a11d59a`
  ref because it isn't on the org allowlist.

## Test plan
- [ ] After merge, `update.yml` regenerates `approved_patterns.yml`
      + the composite from `actions.yml`.
- [ ] ASF Infra's allowlist sync picks up the new SHA; the next
      hourly `check-for-transitive-failures` run passes.