### PR TITLE
Add italia/publiccode-parser-action to the allowlist

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -556,6 +556,9 @@ ilammy/msvc-dev-cmd:
 ilammy/setup-nasm:
   72793074d3c8cdda771dba85f6deafe00623038b:
     tag: v1.5.2
+italia/publiccode-parser-action:
+  '21086c73ec0563e14c6748787efa1b34b025ad8c':
+    tag: v1.5.1
 j178/prek-action:
   cbc2f23eb5539cf20d82d1aabd0d0ecbcc56f4e3:
     tag: v2.0.2


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

Validates publiccode.yml against [the spec](https://github.com/publiccodeyml/publiccode.yml) in CI.

Project `apache/syncope` publishes a `publiccode.yml` and it'd be nice to use CI to
validate it on every push and PR. See [apache/syncope#1384](https://github.com/apache/syncope/pull/1384).

[publiccode.yml](https://github.com/publiccodeyml/publiccode.yml) is the standard metadata format for [public-sector FLOSS](https://interoperable-europe.ec.europa.eu/collection/interoperable-europe-academy/news/new-courses-eu-open-source-solutions-catalogue-publiccodeyml).

This action runs the official parser/validator so the file stays correct
over time.

**Name of action:** publiccode.yml parser and validation Action

**URL of action:** https://github.com/italia/publiccode-parser-action

**Version to pin to (hash only):** 21086c73ec0563e14c6748787efa1b34b025ad8c (v1.5.1)

## Permissions

Default run (`comment-on-pr=false`) needs no special permissions and
makes no GitHub API calls. Pass/fail is the workflow status.

With `comment-on-pr=true` the action pipes parser output to reviewdog
(`-reporter=github-pr-review`) to post inline comments, so the calling
workflow needs `pull-requests: write` and `GITHUB_TOKEN`. Nothing
beyond that. No secrets are read, no env files (`GITHUB_ENV`,
`GITHUB_PATH`, `GITHUB_OUTPUT`) are touched.

## Security

Docker action, so the JS-rebuild verification script does not apply.

- `action.yml`: docker action, passes 4 inputs as args. No env/secret
  reads.
- `Dockerfile`: `FROM italia/publiccode-parser-go:v5.3.1` (same org,
  the actual validator). At build time it downloads reviewdog v0.21.0
  from GitHub releases, pinned by SHA256
  (`ad5ce7d5ffa52aaa7ec8710a8fa764181b6cecaab843cc791e1cce1680381569`)
  and checked with `sha256sum -c`.
- `entrypoint.sh`: Runs `publiccode-parser` on the given path, pipes to
  `reviewdog -reporter=github-pr-review` only when `comment-on-pr=true`.

## Related Actions

No existing approved action validates publiccode.yml. The only other
way to get the same check is to call the parser binary directly in a
workflow step (run the `italia/publiccode-parser-go` binary by
hand), which duplicates what this action already wraps and still pulls
third-party code.

## Checklist

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [ ] The action has a sufficient number of contributors or has contributors within the ASF community[^0]
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [ ] The action has CI/unit tests configured[^1]
- [ ] Compiled JavaScript in `dist/` matches a clean rebuild[^2]

[^0]: Not sure about that, having more contributors will be nice for sure :)
[^1]: the action wrapper has no test suite, but the validation logic lives in italia/publiccode-parser-go, which is tested. The wrapper is a thin shell launcher

[^2]: N/A, this is a Docker action with no compiled JS.

