### PR TITLE
Allowlist carabiner v1.2.0 transitive ampel-bootstrap + download-and-verify

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -200,6 +200,11 @@ carabiner-dev/actions/install/ampel-bootstrap:
   9db1a064ca5691ef6f5d983031739ca287de0968:
     expires_at: 2026-08-28
   b60791af41423360b892a1a3cee90cd4e131f381: {}
+  # transitive dep pulled by ampel/verify @ v1.2.0 (e0e3b814); allowlisted
+  # but not dependabot-tracked (b60791af above stays the live ref).
+  e0e3b8149dafed833431095bc148d50e7eade4e8:
+    tag: v1.2.0
+    expires_at: 2026-08-16
 carabiner-dev/actions/install/bnd:
   2a11d59a135c5e291f305f249a92ad7903e3ee0f:
     # transitive dep of carabiner-dev/actions/ampel/verify @ v1.2.0
@@ -221,6 +226,11 @@ carabiner-dev/actions/install/download-and-verify:
   9db1a064ca5691ef6f5d983031739ca287de0968:
     expires_at: 2026-08-28
   b60791af41423360b892a1a3cee90cd4e131f381: {}
+  # transitive dep pulled by ampel/verify @ v1.2.0 (e0e3b814); allowlisted
+  # but not dependabot-tracked (b60791af above stays the live ref).
+  e0e3b8149dafed833431095bc148d50e7eade4e8:
+    tag: v1.2.0
+    expires_at: 2026-08-16
 carloscastrojumo/github-cherry-pick-action:
   503773289f4a459069c832dc628826685b75b4b3:
     tag: v1.0.10

--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -78,6 +78,7 @@
 - carabiner-dev/actions/install/ampel-bootstrap@0a075bb75a68646d05f99c85cbbf2be40dd8e442
 - carabiner-dev/actions/install/ampel-bootstrap@9db1a064ca5691ef6f5d983031739ca287de0968
 - carabiner-dev/actions/install/ampel-bootstrap@b60791af41423360b892a1a3cee90cd4e131f381
+- carabiner-dev/actions/install/ampel-bootstrap@e0e3b8149dafed833431095bc148d50e7eade4e8
 - carabiner-dev/actions/install/bnd@2a11d59a135c5e291f305f249a92ad7903e3ee0f
 - carabiner-dev/actions/install/bnd@e0e3b8149dafed833431095bc148d50e7eade4e8
 - carabiner-dev/actions/install/bnd@94f29392187fe5082d1195a7d4cae3a7ddf09d9c
@@ -85,6 +86,7 @@
 - carabiner-dev/actions/install/download-and-verify@6022a065d6420de5d86333ecfb2b25c57f84b699
 - carabiner-dev/actions/install/download-and-verify@9db1a064ca5691ef6f5d983031739ca287de0968
 - carabiner-dev/actions/install/download-and-verify@b60791af41423360b892a1a3cee90cd4e131f381
+- carabiner-dev/actions/install/download-and-verify@e0e3b8149dafed833431095bc148d50e7eade4e8
 - carloscastrojumo/github-cherry-pick-action@503773289f4a459069c832dc628826685b75b4b3
 - carlosperate/arm-none-eabi-gcc-action@*
 - check-spelling/check-spelling@*


### PR DESCRIPTION
## Problem

The hourly **"Check for transitive failures in current latest actions"** workflow has been failing on **every scheduled run** since the carabiner v1.2.0 bump:

```
##[error] The action carabiner-dev/actions/install/ampel-bootstrap@e0e3b8149dafed833431095bc148d50e7eade4e8
is not allowed in apache/infrastructure-actions ...
```

`carabiner-dev/actions` is a monorepo, so every sub-action at tag `v1.2.0` is commit `e0e3b814`. `ampel/verify@v1.2.0` transitively resolves `install/ampel-bootstrap` and `install/download-and-verify` at that same `e0e3b814` commit, but only three of the five carabiner sub-actions in use had the v1.2.0 SHA allowlisted:

| sub-action | v1.2.0 (`e0e3b814`) before this PR |
|---|---|
| `ampel/verify` | ✅ |
| `install/ampel` | ✅ |
| `install/bnd` | ✅ |
| `install/ampel-bootstrap` | ❌ missing |
| `install/download-and-verify` | ❌ missing |

GitHub aborts on the first blocked action, so both needed adding.

## Fix

Add `e0e3b814` to both sub-action blocks in `actions.yml` as **allowlisted-but-expiring** transitive entries (mirroring the existing `2a11d59a`/`6022a065` transitive entries). The existing `9db1a064` stays the live, dependabot-tracked ref, so **the composite action is unchanged**. `approved_patterns.yml` was regenerated via the gateway sync (`update_actions` / `update_workflow` / `update_patterns`).

## Verification

- `gateway/test_gateway.py`: 8 passed
- Diff is exactly +2 lines in `approved_patterns.yml` (the two SHAs) and the documented entries in `actions.yml`; composite untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)