### PR TITLE
verify: accept validate* checksum helpers as JS download verification (unblocks #910)

### DIFF
--- a/utils/tests/verify_action_build/test_security.py
+++ b/utils/tests/verify_action_build/test_security.py
@@ -1283,6 +1283,42 @@ const createHash = customLibrary.createHash('blake2')
             content = f"const sha = {func_name}(downloadPath)\n"
             assert self._has_verification(content) is True, func_name
 
+    def test_validate_checksum_function_name_recognized(self):
+        # astral-sh/setup-uv@v8.2.0 shape: ``src/download/download-version.ts``
+        # downloads via ``tc.downloadTool`` then calls ``validateChecksum(...)``,
+        # whose implementation was extracted into a sibling module
+        # (``./checksum/checksum``).  The call name is the in-file evidence the
+        # scanner must accept; without it, #910 false-flagged the download as
+        # unverified.
+        for func_name in (
+            "validateChecksum",
+            "validateFileCheckSum",
+            "validateHash",
+            "validateDigest",
+            "validateSHA256",
+        ):
+            content = (
+                "const downloadPath = await tc.downloadTool(url)\n"
+                f"await {func_name}(checksum, downloadPath, arch, platform, version)\n"
+            )
+            assert self._has_verification(content) is True, func_name
+
+    def test_validate_checksum_real_setup_uv_snippet_recognized(self):
+        # Faithful trim of the real download → validate sequence so the
+        # regression is anchored to the actual source, not just the bare name.
+        content = """\
+import * as tc from "@actions/tool-cache";
+import { validateChecksum } from "./checksum/checksum";
+
+const downloadPath = await tc.downloadTool(
+  downloadUrl,
+  undefined,
+  githubToken,
+);
+await validateChecksum(checksum, downloadPath, arch, platform, version);
+"""
+        assert self._has_verification(content) is True
+
     def test_verify_hash_function_recognized(self):
         # Whether named ``verifyHash`` or referenced inline.
         for snippet in (

--- a/utils/verify_action_build/security.py
+++ b/utils/verify_action_build/security.py
@@ -1207,6 +1207,19 @@ _JS_VERIFICATION_PATTERNS = [
     re.compile(r"\bcalculate(?:SHA[\d]+|Checksum|Digest)\b", re.IGNORECASE),
     re.compile(r"\bverifyHash\b"),
     re.compile(r"\bcomputeChecksum\b"),
+    # ``validate*`` checksum helpers — the call site counts as verification
+    # even when the helper's implementation lives in a sibling module.
+    # astral-sh/setup-uv's ``src/download/download-version.ts`` downloads via
+    # ``tc.downloadTool`` then immediately calls ``validateChecksum(checksum,
+    # downloadPath, …)`` (imported from ``./checksum/checksum``), which SHA-256s
+    # the artifact against a provided checksum or the built-in KNOWN_CHECKSUMS
+    # table.  v8.2.0 extracted that validation into the sibling module, moving
+    # the ``createHash`` token out of this file and tripping the same-file
+    # heuristic — the call name is the evidence that survives the refactor.
+    re.compile(
+        r"\bvalidate(?:Checksum|Hash|Digest|SHA\d*|FileChecksum)\b",
+        re.IGNORECASE,
+    ),
 ]
 
 _JS_SOURCE_EXTENSIONS = (".ts", ".js", ".mjs", ".cjs")


### PR DESCRIPTION
## Summary
`verify-action-build`'s binary-download check false-flagged the routine `astral-sh/setup-uv` bump in #910 as an unverified download.

The flagged line is `src/download/download-version.ts:128`:

```ts
const downloadPath = await tc.downloadTool(downloadUrl, undefined, githubToken);
await validateChecksum(checksum, downloadPath, arch, platform, version);
```

The download **is** verified — `validateChecksum` (imported from the sibling `./checksum/checksum`) SHA-256s the artifact against a user-provided checksum or the built-in `KNOWN_CHECKSUMS` table. v8.2.0 just extracted that validation into the sibling module, moving the `createHash` token out of `download-version.ts` and tripping the same-file heuristic (which only knew `verify*`/`compute*`/`calculate*` helper names).

## Fix
Add the `validate*` checksum-helper family to `_JS_VERIFICATION_PATTERNS`. The call name is the in-file evidence that survives the refactor.

## Test plan
- [x] Regression tests in `test_security.py` (bare names + a faithful trim of the real setup-uv download→validate sequence).
- [x] `uv run pytest utils/tests/` → 278 passed.
- [x] `verify_action_build --from-pr 910` → exit 0, "verification present in file".
- [x] prek clean.

Case **E** in the `analyze-action-pr` skill — JS analogue of #800 (sibling `sha256sum -c` counts as verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)