### PR TITLE
Fix current Zizmor workflow failures

### DIFF
--- a/.github/actions/for-dependabot-triggered-reviews/action.yml
+++ b/.github/actions/for-dependabot-triggered-reviews/action.yml
@@ -37,7 +37,7 @@ name: Gateway Action
 runs:
   using: "composite"
   steps:
-    - uses: 1Password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259  # v4.0.0
+    - uses: 1Password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259  # v4.0.0  # zizmor: ignore[unpinned-tools] generated sentinel step is never executed
       if: false
     - uses: 1Password/load-secrets-action/configure@92467eb28f72e8255933372f1e0707c567ce2259  # v4.0.0
       if: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -24,6 +24,7 @@
 # ///
 
 import os
+import re
 from datetime import date, timedelta
 from io import StringIO
 from pathlib import Path
@@ -49,6 +50,11 @@ ActionRefs = Dict[str, RefDetails]
 
 ActionsYAML = Dict[str, ActionRefs]
 """Dictionary mapping action names to their reference details"""
+
+ZIZMOR_UNPINNED_TOOLS_IGNORE = "zizmor: ignore[unpinned-tools] generated sentinel step is never executed"
+ZIZMOR_UNPINNED_TOOLS_ACTIONS = {
+    "1Password/load-secrets-action",
+}
 
 
 def calculate_expiry(weeks=4):
@@ -199,7 +205,12 @@ runs:
         elif len(ref_to_update) == 1:
             ref = ref_to_update[0]
             details = refs[ref]
-            steps.append(f"    - uses: {name}@{ref}" + (f"  # {details['tag']}" if details and 'tag' in details else ''))
+            comments = []
+            if details and 'tag' in details:
+                comments.append(details['tag'])
+            if name in ZIZMOR_UNPINNED_TOOLS_ACTIONS:
+                comments.append(f"# {ZIZMOR_UNPINNED_TOOLS_IGNORE}")
+            steps.append(f"    - uses: {name}@{ref}" + (f"  # {'  '.join(comments)}" if comments else ''))
             steps.append( "      if: false")
 
     return header + "\n".join(steps) + "\n" + "    - run: echo Success!\n" + "      shell: bash\n"
@@ -227,7 +238,12 @@ def update_refs(
         name, new_ref = uses.split("@")
         new_tag = None
         if hasattr(step, 'ca') and 'uses' in step.ca.items:
-            new_tag = step.ca.items['uses'][2].value[1:].strip()
+            uses_comment = step.ca.items['uses'][2].value[1:].strip()
+            if (
+                not uses_comment.startswith("zizmor:")
+                and (match := re.match(r"(?P<tag>\S+)(?:\s+#?\s*zizmor:.*)?$", uses_comment))
+            ):
+                new_tag = match.group("tag")
 
         if name not in action_refs:
             action_refs[name] = {}

--- a/gateway/test_gateway.py
+++ b/gateway/test_gateway.py
@@ -187,6 +187,53 @@ def test_update_tagged_ref():
     update_refs(steps, refs)
     assert refs == expected_refs
 
+def test_update_tagged_ref_with_generated_zizmor_ignore():
+    steps = load_yaml_string(f'''
+    - uses: 1Password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259   # v4.0.0  # {ZIZMOR_UNPINNED_TOOLS_IGNORE}
+    ''')
+
+    refs: ActionsYAML = {}
+
+    update_refs(steps, refs)
+
+    assert refs == {
+        "1Password/load-secrets-action": {
+            "92467eb28f72e8255933372f1e0707c567ce2259": {
+                "tag": "v4.0.0",
+            }
+        },
+    }
+
+def test_generate_composite_action_includes_zizmor_ignore_only_for_selected_actions():
+    actions: ActionsYAML = {
+        "1Password/load-secrets-action": {
+            "92467eb28f72e8255933372f1e0707c567ce2259": {
+                "tag": "v4.0.0",
+            }
+        },
+        "DavidAnson/markdownlint-cli2-action": {
+            "ded1f9488f68a970bc66ea5619e13e9b52e601cd": {
+                "tag": "v23.2.0",
+            }
+        },
+        "carabiner-dev/actions/install/ampel-bootstrap": {
+            "9db1a064ca5691ef6f5d983031739ca287de0968": {},
+        },
+    }
+
+    generated = generate_composite_action(actions)
+
+    assert (
+        f"1Password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259  "
+        f"# v4.0.0  # {ZIZMOR_UNPINNED_TOOLS_IGNORE}"
+    ) in generated
+    assert (
+        "DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd  "
+        "# v23.2.0"
+    ) in generated
+    assert "carabiner-dev/actions/install/ampel-bootstrap@9db1a064ca5691ef6f5d983031739ca287de0968\n" in generated
+    assert generated.count(ZIZMOR_UNPINNED_TOOLS_IGNORE) == 1
+
 
 def test_create_pattern():
     actions = {


### PR DESCRIPTION
1. `.github/workflows/codeql.yml` uses the "full" version
2. Let `gateway.py` emit a zizmor ignore rule for the 1password action