### PR TITLE
Add goreleaser/goreleaser-action to the GitHub Actions allowlist

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -1,26 +1,23 @@
 #
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
 #   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
-# Main configuration file. We manually add trusted actions here.
-# Version updates can be triggered by merging dependabot PRs
+# "License"); you may not use this file except in compliance
+# distributed with this work for additional information
 # into .github/workflows/dummy-workflow.yml . This will also
+# KIND, either express or implied.  See the License for the
+# Licensed to the Apache Software Foundation (ASF) under one
+# Main configuration file. We manually add trusted actions here.
+# or more contributor license agreements.  See the NOTICE file
+# regarding copyright ownership.  The ASF licenses this file
+# software distributed under the License is distributed on an
+# specific language governing permissions and limitations
+# to you under the Apache License, Version 2.0 (the
+# under the License.
+# Unless required by applicable law or agreed to in writing,
 # update expiry dates for previous versions.
+# Version updates can be triggered by merging dependabot PRs
 # Versions that are known to be problematic should be removed explicitly manually.
+# with the License.  You may obtain a copy of the License at
 1Password/load-secrets-action:
   8d0d610af187e78a2772c2d18d627f4c52d3fbfb:
     tag: v3.1.0
@@ -342,6 +339,9 @@ dependabot/fetch-metadata:
 dlang-community/setup-dlang:
   '*':
     keep: true
+docker://pandoc/core:
+  sha256:48e15e83db0df6fb39b24adb0210ecbde85003a3a8139d526e29c98f95ac0a93:
+    tag: 3.7.0.2
 docker/bake-action:
   aefd381cbaa93c62a1e8b02194ae420cc36269d2:
     tag: v4.7.0
@@ -408,11 +408,6 @@ docker/setup-qemu-action:
     expires_at: 2026-07-28
   06116385d9baf250c9f4dcb4858b16962ea869c3:
     tag: v4.1.0
-docker://jekyll/jekyll:
-  sha256:400b8d1569f118bca8a3a09a25f32803b00a55d1ea241feaf5f904d66ca9c625:
-docker://pandoc/core:
-  sha256:48e15e83db0df6fb39b24adb0210ecbde85003a3a8139d526e29c98f95ac0a93:
-    tag: 3.7.0.2
 dorny/paths-filter:
   de90cc6fb38fc0963ad72b210f1f284cd68cea36:
     tag: v3.0.2
@@ -489,6 +484,9 @@ google-github-actions/auth:
 google-github-actions/setup-gcloud:
   aa5489c8933f4cc7a4f7d45035b3b1440c9c10db:
     tag: v3.0.1
+goreleaser/goreleaser-action:
+  '5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89':
+    keep: true
 gr2m/twitter-together:
   '*':
     keep: true

--- a/actions.yml
+++ b/actions.yml
@@ -1,23 +1,26 @@
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# "License"); you may not use this file except in compliance
-# distributed with this work for additional information
-# into .github/workflows/dummy-workflow.yml . This will also
-# KIND, either express or implied.  See the License for the
 # Licensed to the Apache Software Foundation (ASF) under one
-# Main configuration file. We manually add trusted actions here.
 # or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
-# software distributed under the License is distributed on an
-# specific language governing permissions and limitations
 # to you under the Apache License, Version 2.0 (the
-# under the License.
-# Unless required by applicable law or agreed to in writing,
-# update expiry dates for previous versions.
-# Version updates can be triggered by merging dependabot PRs
-# Versions that are known to be problematic should be removed explicitly manually.
+# "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Main configuration file. We manually add trusted actions here.
+# Version updates can be triggered by merging dependabot PRs
+# into .github/workflows/dummy-workflow.yml . This will also
+# update expiry dates for previous versions.
+# Versions that are known to be problematic should be removed explicitly manually.
 1Password/load-secrets-action:
   8d0d610af187e78a2772c2d18d627f4c52d3fbfb:
     tag: v3.1.0
@@ -339,9 +342,6 @@ dependabot/fetch-metadata:
 dlang-community/setup-dlang:
   '*':
     keep: true
-docker://pandoc/core:
-  sha256:48e15e83db0df6fb39b24adb0210ecbde85003a3a8139d526e29c98f95ac0a93:
-    tag: 3.7.0.2
 docker/bake-action:
   aefd381cbaa93c62a1e8b02194ae420cc36269d2:
     tag: v4.7.0
@@ -408,6 +408,11 @@ docker/setup-qemu-action:
     expires_at: 2026-07-28
   06116385d9baf250c9f4dcb4858b16962ea869c3:
     tag: v4.1.0
+docker://jekyll/jekyll:
+  sha256:400b8d1569f118bca8a3a09a25f32803b00a55d1ea241feaf5f904d66ca9c625:
+docker://pandoc/core:
+  sha256:48e15e83db0df6fb39b24adb0210ecbde85003a3a8139d526e29c98f95ac0a93:
+    tag: 3.7.0.2
 dorny/paths-filter:
   de90cc6fb38fc0963ad72b210f1f284cd68cea36:
     tag: v3.0.2
@@ -485,8 +490,8 @@ google-github-actions/setup-gcloud:
   aa5489c8933f4cc7a4f7d45035b3b1440c9c10db:
     tag: v3.0.1
 goreleaser/goreleaser-action:
-  '5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89':
-    keep: true
+  5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89:
+    tag: v7.2.2
 gr2m/twitter-together:
   '*':
     keep: true


### PR DESCRIPTION
Add `goreleaser/goreleaser-action` to the allowlist:

- `goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89`

Needed by: `apache/terraform-provider-iceberg`