### PR TITLE
Update rubygems/release-gem deprecation

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -853,11 +853,8 @@ rubygems/release-gem:
     tag: v1.2.0
     expires_at: 2026-09-05
   f0d7faff26625599a847d40d9fa28ace24c2aacc:
-    # Please add a `tag` when release-gem has a new release.
-    # Read more https://github.com/rubygems/release-gem/issues/36
-    # 
-    # After that, add a `expires_at` to 3 months out on previous version.
-    keep: true
+    tag: v1.3.0
+    expires_at: 2026-09-14
   052cc82692552de3ef2b81fd670e41d13cba8092:
     tag: v1.4.0
 runs-on/action:


### PR DESCRIPTION
Hi team,

New rubygems/release-gem action version and tag v1.3.0 deprecation. Upstream v1.3.0 got registration https://github.com/rubygems/release-gem/issues/36.