### PR TITLE
verify: exempt gradle-wrapper.jar from in-tree binary check

### DIFF
--- a/utils/tests/verify_action_build/test_security.py
+++ b/utils/tests/verify_action_build/test_security.py
@@ -1405,6 +1405,22 @@ class TestLooksLikeInTreeBinary:
         assert _looks_like_in_tree_binary("dist/licenses.txt") is False
         assert _looks_like_in_tree_binary("licenses.txt") is False
 
+    def test_gradle_wrapper_jar_exempt(self):
+        # gradle/wrapper/gradle-wrapper.jar is Gradle's build wrapper:
+        # build-time tooling of the upstream repo, never executed on a
+        # consumer's runner, and checksum-verifiable in its own right.
+        # JetBrains/qodana-action (a node24 action) ships it and was
+        # false-flagged before this exemption.
+        assert _looks_like_in_tree_binary("gradle/wrapper/gradle-wrapper.jar") is False
+        # Exempt under a nested action sub-path too.
+        assert _looks_like_in_tree_binary(
+            "subdir/gradle/wrapper/gradle-wrapper.jar"
+        ) is False
+        # Precision: a stray jar of the same name elsewhere is still caught,
+        # as is any other .jar (the suffix match needs the canonical path).
+        assert _looks_like_in_tree_binary("dist/gradle-wrapper.jar") is True
+        assert _looks_like_in_tree_binary("Library.jar") is True
+
     def test_matlab_platform_dir_naming(self):
         # MATLAB's launcher convention: dist/bin/<platform>/run-matlab-command
         # where <platform> is MATLAB's own arch identifier and the file has

--- a/utils/verify_action_build/security.py
+++ b/utils/verify_action_build/security.py
@@ -1694,6 +1694,21 @@ _IN_TREE_BINARY_EXEMPT_NAMES = {
     "licenses.txt",
 }
 
+# Repo-relative path suffixes for binaries that are build-time tooling of
+# the *upstream* repo rather than action-runtime code, and are themselves
+# independently verifiable — so flagging them as opaque runtime binaries
+# is a false positive.  Matched by full canonical suffix (not bare name)
+# so a same-named blob dropped elsewhere is still caught.
+_IN_TREE_BINARY_EXEMPT_PATH_SUFFIXES = (
+    # Gradle's build wrapper, committed to virtually every Gradle project.
+    # It is invoked by ``./gradlew`` during the upstream repo's own build —
+    # never executed on a consumer's runner when the action runs — and is
+    # checksum-verifiable against Gradle's published list (cf.
+    # gradle/wrapper-validation-action).  Seen on JetBrains/qodana-action,
+    # a node24 action that never shells out to Gradle at runtime.
+    "gradle/wrapper/gradle-wrapper.jar",
+)
+
 
 def _looks_like_in_tree_binary(path: str) -> bool:
     """Return True if ``path`` (a repo-relative blob path) looks like a
@@ -1706,6 +1721,8 @@ def _looks_like_in_tree_binary(path: str) -> bool:
     """
     name = path.rsplit("/", 1)[-1]
     if name in _IN_TREE_BINARY_EXEMPT_NAMES:
+        return False
+    if path.lower().endswith(_IN_TREE_BINARY_EXEMPT_PATH_SUFFIXES):
         return False
     lower = name.lower()
     if lower.endswith(_IN_TREE_BINARY_EXTENSIONS):


### PR DESCRIPTION
## What

Exempt `gradle/wrapper/gradle-wrapper.jar` from the in-tree binary check.

## Why

The in-tree binary check scans the whole action repo for pre-compiled native binaries and rejects any without verifiable provenance. It false-flagged `gradle/wrapper/gradle-wrapper.jar` on `JetBrains/qodana-action` (surfaced while triaging the 2026.1.0 → 2026.1.3 bump in #944).

That jar is **Gradle's build wrapper** — build-time tooling of the upstream repo, invoked by `./gradlew` during its own build, **never executed on a consumer's runner when the action runs** (qodana-action is a `node24` action that runs `dist/index.js`). It is also checksum-verifiable in its own right against Gradle's published list (cf. `gradle/wrapper-validation-action`). Flagging it as opaque action-runtime code is a false positive.

## How

- Add `_IN_TREE_BINARY_EXEMPT_PATH_SUFFIXES`, matched on the **canonical** `gradle/wrapper/gradle-wrapper.jar` path suffix (not bare name), so a same-named blob dropped anywhere else is still caught.
- Regression test covering: canonical path exempt, nested sub-path exempt, stray `dist/gradle-wrapper.jar` still flagged, generic `.jar` still flagged.

`uv run pytest utils/tests/verify_action_build/test_security.py` → 147 passed. prek clean.

Generated-by: Claude Opus 4.8 (1M context)
