### PR TITLE
Keep Gradle setup-action v5

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -466,6 +466,11 @@ gradle/actions/dependency-submission:
   3f131e8634966bd73d06cc69884922b02e6faf92:
     tag: v6.2.0
 gradle/actions/setup-gradle:
+  0723195856401067f7a2779048b490ace7a47d7c:
+    tag: v5.0.2
+    # Projects have deliberately chosen to not use v6 of the setup-gradle action due to licensing model changes.
+    # See https://github.com/apache/infrastructure-actions/pull/953
+    keep: true
   39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f:
     tag: v6.0.1
     expires_at: 2026-07-05


### PR DESCRIPTION
Some project still use and want to stick with v5.

Version 6 of gradle/actions changes the licensing model for the default caching behavior used by setup-gradle. The action repository is still mostly MIT licensed, but the default "enhanced" caching provider uses the [proprietary gradle-actions-caching](https://github.com/gradle/actions/blob/v6.1.0/licenses/gradle-actions-caching-license.txt) component.

Gradle [documents](https://github.com/gradle/actions/blob/v6.1.0/DISTRIBUTION.md#3-usage-tiers) enhanced caching for public repositories as free, and private repository use as currently available in a free preview. The same documentation also says Gradle plans usage-based pricing for undefined "large-scale commercial organizations". Use of the proprietary caching component is governed by [Gradle's Terms of Use](https://gradle.com/legal/gradle-technologies-terms-of-use/), which may change over time.

Version 6 also provides an opt-in ["basic"](https://github.com/gradle/actions/blob/v6.1.0/docs/setup-gradle.md#basic-caching) caching provider under the MIT license, but it is not equivalent to the default enhanced provider. Basic caching uses actions/cache directly and lacks [enhanced](https://github.com/gradle/actions/blob/v6.1.0/docs/setup-gradle.md#enhanced-caching) caching's fine-grained Gradle User Home caching, intelligent cleanup, deduplication, or restore-key behavior. For Polaris CI, especially the incremental cache workflow, that would likely mean lower cache reuse and more cache growth over time.

This is difficult for Polaris because contributors may run CI in private repositories, including private forks used for security work. With v6 defaults, those workflows would depend on proprietary, mutable terms whose future private repository terms and limits are not yet defined. Switching v6 to basic caching avoids the proprietary component, but gives up caching behavior that the workflow currently relies on.