### PR TITLE
Allow carabiner-dev/actions/install/ampel-bootstrap@2a11d59a (v1.1.7)

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -171,6 +171,10 @@ carabiner-dev/actions/install/ampel:
   94f29392187fe5082d1195a7d4cae3a7ddf09d9c:
     tag: v1.2.1
 carabiner-dev/actions/install/ampel-bootstrap:
+  2a11d59a135c5e291f305f249a92ad7903e3ee0f:
+    # transitive dep of carabiner-dev/actions/ampel/verify @ v1.2.0
+    tag: v1.1.7
+    expires_at: 2026-08-16
   # level-3 transitive: called by install/download-and-verify; commit is untagged
   # (per upstream: "bootstrap rotated to ampel v1.2.1")
   0a075bb75a68646d05f99c85cbbf2be40dd8e442:

--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -68,6 +68,7 @@
 - carabiner-dev/actions/install/ampel@2a11d59a135c5e291f305f249a92ad7903e3ee0f
 - carabiner-dev/actions/install/ampel@e0e3b8149dafed833431095bc148d50e7eade4e8
 - carabiner-dev/actions/install/ampel@94f29392187fe5082d1195a7d4cae3a7ddf09d9c
+- carabiner-dev/actions/install/ampel-bootstrap@2a11d59a135c5e291f305f249a92ad7903e3ee0f
 - carabiner-dev/actions/install/ampel-bootstrap@0a075bb75a68646d05f99c85cbbf2be40dd8e442
 - carabiner-dev/actions/install/ampel-bootstrap@9db1a064ca5691ef6f5d983031739ca287de0968
 - carabiner-dev/actions/install/ampel-bootstrap@b60791af41423360b892a1a3cee90cd4e131f381


### PR DESCRIPTION
## Problem

The nightly **Check for transitive failures** workflow has been failing on every run. The transitive chain

```
carabiner-dev/actions/ampel/verify@v1.2.0
  -> carabiner-dev/actions/install/download-and-verify@v1.1.7
    -> carabiner-dev/actions/install/ampel-bootstrap@v1.1.7
```

resolves to `carabiner-dev/actions/install/ampel-bootstrap@2a11d59a135c5e291f305f249a92ad7903e3ee0f`, which is **not in the allowlist**, so the runner blocks it.

## Fix

The commit `2a11d59a` (tag `v1.1.7`) is already approved for the sibling subpaths `install/ampel`, `install/bnd`, and `install/download-and-verify` — `ampel-bootstrap` was simply missed. This adds it to `actions.yml` (mirroring the siblings: `tag: v1.1.7`, `expires_at: 2026-08-16`) and regenerates `approved_patterns.yml` via `gateway`.

Same already-vetted monorepo commit, no new/untrusted dependency.

Generated-by: Claude Opus 4.8 (1M context)