### PR TITLE
Bump dtolnay/rust-toolchain stable pin to current branch head

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -401,7 +401,7 @@ dorny/test-reporter:
   a43b3a5f7366b97d083190328d2c652e1a8b6aa2:
     tag: v3.0.0
 dtolnay/rust-toolchain:
-  29eef336d9b2848a0b548edc03f92a220660cdb8:
+  4be7066ada62dd38de10e7b70166bc74ed198c30:
     keep: true
     tag: stable
 easimon/maximize-build-space:


### PR DESCRIPTION
## What

Updates the `dtolnay/rust-toolchain` pin in `actions.yml` from
`29eef336d9b2848a0b548edc03f92a220660cdb8` to the current `stable`
branch head `4be7066ada62dd38de10e7b70166bc74ed198c30` (2026-06-30).

## Why

`dtolnay/rust-toolchain`'s `stable` is a moving branch that upstream
force-updates. The old pinned SHA has diverged from it (behind by 1,
ahead by 3), so it's no longer an ancestor of `stable`. This made the
`check_action_tags` job emit:

> FAILURE: GitHub action dtolnay/rust-toolchain references Git branch
> 'stable' via SHA '29eef336…' but none of those SHAs are ancestors of
> that branch

Because that check validates the whole allow-list, the failure landed on
**every** open PR that touches the allow-list trio — currently ~10
Dependabot bumps plus community PR #992 — none of which are related to
this entry. Restoring the ancestor relationship unblocks them all.

## Notes

- The `update` job regenerates `approved_patterns.yml` and the Dependabot
  composite from this on merge.
- The `stable` pin will need periodic refreshes whenever upstream moves
  the branch again; this is inherent to pinning a moving ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)