### PR TITLE
verify-action-build: recognize fileSHA256()-style file-hash helpers as verification

### DIFF
--- a/utils/tests/verify_action_build/test_security.py
+++ b/utils/tests/verify_action_build/test_security.py
@@ -1360,6 +1360,43 @@ await validateChecksum(checksum, downloadPath, arch, platform, version);
         ):
             assert self._has_verification(snippet) is True, snippet
 
+    def test_file_sha_helper_name_recognized(self):
+        # ``fileSHA256(path)`` shape: a helper whose name denotes hashing a
+        # file with an explicit SHA algorithm.  Several actions define the
+        # ``createHash`` body in a sibling util module, so the call name is
+        # the in-file verification evidence.
+        for func_name in (
+            "fileSHA256",
+            "fileSHA512",
+            "getSHA256",
+            "sha256File",
+        ):
+            content = f"const checksum = await {func_name}(pathToCLIZip)\n"
+            assert self._has_verification(content) is True, func_name
+
+    def test_file_sha_helper_real_setup_opentofu_snippet_recognized(self):
+        # Faithful trim of opentofu/setup-opentofu@v2.0.2's real download →
+        # verify sequence in ``lib/setup-tofu.js``.  ``fileSHA256`` is imported
+        # from the sibling ``./util.js`` (where the ``createHash('sha256')``
+        # body lives), and the artifact is rejected when its hash isn't in the
+        # release's ``SHA256SUMS`` list.  Without recognizing the call name the
+        # v2.0.2 bump (#980) false-flagged this download as unverified.
+        content = """\
+import { downloadTool, extractZip } from '@actions/tool-cache';
+import { fileSHA256 } from './util.js';
+
+async function downloadAndExtractCLI (url, checksums) {
+  const pathToCLIZip = await downloadTool(url);
+  if (checksums.length > 0) {
+    const checksum = await fileSHA256(pathToCLIZip);
+    if (!checksums.includes(checksum)) {
+      throw new Error(`Failed to validate OpenTofu CLI zip checksum.`);
+    }
+  }
+}
+"""
+        assert self._has_verification(content) is True
+
     def test_existing_crypto_dotted_form_still_matches(self):
         # Regression: the original ``crypto\.createHash\(`` matcher
         # must still fire — existing actions that use the dotted form.

--- a/utils/verify_action_build/security.py
+++ b/utils/verify_action_build/security.py
@@ -1220,6 +1220,16 @@ _JS_VERIFICATION_PATTERNS = [
         r"\bvalidate(?:Checksum|Hash|Digest|SHA\d*|FileChecksum)\b",
         re.IGNORECASE,
     ),
+    # Helper call whose name denotes hashing a file with an explicit SHA
+    # algorithm — e.g. ``fileSHA256(path)``, ``getSHA512(...)``.  As with the
+    # ``validate*`` helpers above, the ``createHash`` implementation often
+    # lives in a sibling util module, so within the downloader file the call
+    # name is the surviving verification evidence.  opentofu/setup-opentofu's
+    # ``lib/setup-tofu.js`` computes ``await fileSHA256(pathToCLIZip)`` (the
+    # ``createHash('sha256')`` body is in ``lib/util.js``) and throws when the
+    # hash isn't in the release's ``SHA256SUMS`` list; without this the v2.0.2
+    # bump (#980) false-flagged the download as unverified.
+    re.compile(r"\b\w*SHA(?:1|256|384|512)\w*\s*\(", re.IGNORECASE),
 ]
 
 _JS_SOURCE_EXTENSIONS = (".ts", ".js", ".mjs", ".cjs")


### PR DESCRIPTION
## Problem

The `verify` job on #980 (opentofu/setup-opentofu v2.0.1 → v2.0.2) fails with:

> ✗ lib/setup-tofu.js: 1 unverified JS download(s) (no checksum/signature check in file)

But the action **does** verify. `lib/setup-tofu.js` downloads the CLI zip and then:

```js
const checksum = await fileSHA256(pathToCLIZip);
if (!checksums.includes(checksum)) {
  throw new Error(`Failed to validate OpenTofu CLI zip checksum.`);
}
```

`fileSHA256` is imported from the sibling `lib/util.js`, where the actual
`createHash('sha256')` body lives, and `resolveChecksums()` falls back to the
release's published `SHA256SUMS`. Within the downloader file the only
verification evidence is the `fileSHA256(...)` **call name** — which no
`_JS_VERIFICATION_PATTERN` matched. So this is a false positive (case E), not a
real gap.

This is the same shape as the astral-sh/setup-uv `validateChecksum()` fix
(#910/#916): the hashing implementation lives in a sibling module and the call
name is the surviving in-file evidence.

## Fix

Add one pattern recognizing a helper call whose name contains an explicit SHA
algorithm (`fileSHA256(`, `getSHA512(`, `sha256File(`, …). It stays tight enough
not to match `createHash('sha256')` (the paren precedes the algorithm there) or
non-SHA hashes.

Two regression tests: the bare helper-name family, and a faithful trim of the
real opentofu download→verify sequence.

## Verification

- `uv run pytest utils/tests/` → 294 passed
- `prek run` on the changed files → clean

Once merged, #980 (and future opentofu/setup-opentofu bumps) verify cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)