### PR TITLE
Add jdx/mise-action to the GitHub Actions allowlist

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -1,23 +1,26 @@
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# "License"); you may not use this file except in compliance
-# distributed with this work for additional information
-# into .github/workflows/dummy-workflow.yml . This will also
-# KIND, either express or implied.  See the License for the
 # Licensed to the Apache Software Foundation (ASF) under one
-# Main configuration file. We manually add trusted actions here.
 # or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
-# software distributed under the License is distributed on an
-# specific language governing permissions and limitations
 # to you under the Apache License, Version 2.0 (the
-# under the License.
-# Unless required by applicable law or agreed to in writing,
-# update expiry dates for previous versions.
-# Version updates can be triggered by merging dependabot PRs
-# Versions that are known to be problematic should be removed explicitly manually.
+# "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Main configuration file. We manually add trusted actions here.
+# Version updates can be triggered by merging dependabot PRs
+# into .github/workflows/dummy-workflow.yml . This will also
+# update expiry dates for previous versions.
+# Versions that are known to be problematic should be removed explicitly manually.
 1Password/load-secrets-action:
   92467eb28f72e8255933372f1e0707c567ce2259:
     tag: v4.0.0
@@ -335,9 +338,6 @@ dependabot/fetch-metadata:
 dlang-community/setup-dlang:
   '*':
     keep: true
-docker://pandoc/core:
-  sha256:48e15e83db0df6fb39b24adb0210ecbde85003a3a8139d526e29c98f95ac0a93:
-    tag: 3.7.0.2
 docker/bake-action:
   aefd381cbaa93c62a1e8b02194ae420cc36269d2:
     tag: v4.7.0
@@ -404,6 +404,11 @@ docker/setup-qemu-action:
     expires_at: 2026-09-24
   96fe6ef7f33517b61c61be40b68a1882f3264fb8:
     tag: v4.2.0
+docker://jekyll/jekyll:
+  sha256:400b8d1569f118bca8a3a09a25f32803b00a55d1ea241feaf5f904d66ca9c625:
+docker://pandoc/core:
+  sha256:48e15e83db0df6fb39b24adb0210ecbde85003a3a8139d526e29c98f95ac0a93:
+    tag: 3.7.0.2
 dorny/paths-filter:
   fbd0ab8f3e69293af611ebaee6363fc25e6d187d:
     tag: v4.0.1

--- a/actions.yml
+++ b/actions.yml
@@ -1,26 +1,23 @@
 #
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
 #   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
-# Main configuration file. We manually add trusted actions here.
-# Version updates can be triggered by merging dependabot PRs
+# "License"); you may not use this file except in compliance
+# distributed with this work for additional information
 # into .github/workflows/dummy-workflow.yml . This will also
+# KIND, either express or implied.  See the License for the
+# Licensed to the Apache Software Foundation (ASF) under one
+# Main configuration file. We manually add trusted actions here.
+# or more contributor license agreements.  See the NOTICE file
+# regarding copyright ownership.  The ASF licenses this file
+# software distributed under the License is distributed on an
+# specific language governing permissions and limitations
+# to you under the Apache License, Version 2.0 (the
+# under the License.
+# Unless required by applicable law or agreed to in writing,
 # update expiry dates for previous versions.
+# Version updates can be triggered by merging dependabot PRs
 # Versions that are known to be problematic should be removed explicitly manually.
+# with the License.  You may obtain a copy of the License at
 1Password/load-secrets-action:
   92467eb28f72e8255933372f1e0707c567ce2259:
     tag: v4.0.0
@@ -338,6 +335,9 @@ dependabot/fetch-metadata:
 dlang-community/setup-dlang:
   '*':
     keep: true
+docker://pandoc/core:
+  sha256:48e15e83db0df6fb39b24adb0210ecbde85003a3a8139d526e29c98f95ac0a93:
+    tag: 3.7.0.2
 docker/bake-action:
   aefd381cbaa93c62a1e8b02194ae420cc36269d2:
     tag: v4.7.0
@@ -404,11 +404,6 @@ docker/setup-qemu-action:
     expires_at: 2026-09-24
   96fe6ef7f33517b61c61be40b68a1882f3264fb8:
     tag: v4.2.0
-docker://jekyll/jekyll:
-  sha256:400b8d1569f118bca8a3a09a25f32803b00a55d1ea241feaf5f904d66ca9c625:
-docker://pandoc/core:
-  sha256:48e15e83db0df6fb39b24adb0210ecbde85003a3a8139d526e29c98f95ac0a93:
-    tag: 3.7.0.2
 dorny/paths-filter:
   fbd0ab8f3e69293af611ebaee6363fc25e6d187d:
     tag: v4.0.1
@@ -595,6 +590,9 @@ jarvusinnovations/background-action:
 jasonetco/create-an-issue:
   1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5:
     tag: v2
+jdx/mise-action:
+  '5228313ee0372e111a38da051671ca30fc5a96db':
+    keep: true
 JetBrains/qodana-action:
   89eb4357efd2b52e639f3216e63edaf33b82622b:
     tag: v2025.3.2


### PR DESCRIPTION
Add `jdx/mise-action` to the allowlist:

- `jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db`

Needed by: `apache/iceberg-rust`