### PR TITLE
Group github/codeql-action bumps into a single dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,13 @@ updates:
       - "/stash/save"
     cooldown:
       default-days: 7
+    groups:
+      # The codeql-action init/autobuild/analyze steps must all run the
+      # same version - split PRs cause a version mismatch that fails the
+      # Analyze jobs. Group them so a single PR bumps all of them together.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
   - package-ecosystem: "uv"
     directories:
       - "/"


### PR DESCRIPTION
The codeql-action `init`/`autobuild`/`analyze` steps must all run the same version. When dependabot split the 4.36.2 -> 4.36.3 bump into three per-sub-action PRs (#1023, #1024, #1025), each caused a version mismatch that failed the Analyze jobs, and they had to be consolidated by hand into #1023.

This adds a dependabot `groups` entry matching `github/codeql-action*` on the `/.github/workflows` github-actions block, so future codeql-action bumps land in a single PR that moves all steps together.