### PR TITLE
Add NuGet/login action to allow list

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -755,6 +755,9 @@ ncipollo/release-action:
 nick-fields/retry:
   '*':
     keep: true
+NuGet/login:
+  8d196754b4036150537f80ac539e15c2f1028841:
+    tag: v1.2.0
 nwtgck/actions-netlify:
   4cbaf4c08f1a7bfa537d6113472ef4424e4eb654:
     tag: v3.0.0


### PR DESCRIPTION
Add NuGet/login to the allowlist:

NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 (v1.2.0)
Needed by: apache/opendal

OpenDAL needs to publish packages to NuGet during its release process.