### PR TITLE
gateway: emit zizmor unpinned-tools ignore off the uses: line (closes #952)

### DIFF
--- a/.github/actions/for-dependabot-triggered-reviews/action.yml
+++ b/.github/actions/for-dependabot-triggered-reviews/action.yml
@@ -37,8 +37,8 @@ name: Gateway Action
 runs:
   using: "composite"
   steps:
-    - uses: 1Password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556  # v4.0.1  # zizmor: ignore[unpinned-tools] generated sentinel step is never executed
-      if: false
+    - uses: 1Password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556  # v4.0.1
+      if: false  # zizmor: ignore[unpinned-tools] generated sentinel step is never executed
       with:
         version: "2.30.0"
     - uses: 1Password/load-secrets-action/configure@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556  # v4.0.1

--- a/gateway/gateway.py
+++ b/gateway/gateway.py
@@ -216,13 +216,21 @@ runs:
         elif len(ref_to_update) == 1:
             ref = ref_to_update[0]
             details = refs[ref]
-            comments = []
-            if details and 'tag' in details:
-                comments.append(details['tag'])
-            if name in ZIZMOR_UNPINNED_TOOLS_ACTIONS:
-                comments.append(f"# {ZIZMOR_UNPINNED_TOOLS_IGNORE}")
-            steps.append(f"    - uses: {name}@{ref}" + (f"  # {'  '.join(comments)}" if comments else ''))
-            steps.append( "      if: false")
+            tag_comment = f"  # {details['tag']}" if details and 'tag' in details else ''
+            steps.append(f"    - uses: {name}@{ref}{tag_comment}")
+            # The zizmor `unpinned-tools` ignore is emitted on the `if: false`
+            # line -- within the sentinel step's finding span, per
+            # https://docs.zizmor.sh/usage/#ignoring-results -- rather than on
+            # the `uses:` line. That keeps the version tag as the trailing token
+            # of the `uses:` comment, so Dependabot's comment-updater keeps
+            # `# <tag>` in sync when it bumps the hash (it skips comments with
+            # text after the version). See #952.
+            if_comment = (
+                f"  # {ZIZMOR_UNPINNED_TOOLS_IGNORE}"
+                if name in ZIZMOR_UNPINNED_TOOLS_ACTIONS
+                else ''
+            )
+            steps.append(f"      if: false{if_comment}")
             # zizmor's `unpinned-tools` audit flags certain actions whose
             # default behavior is to install the "latest" version of an
             # external tool. The remediation is to set `with.version` to

--- a/gateway/test_gateway.py
+++ b/gateway/test_gateway.py
@@ -223,10 +223,18 @@ def test_generate_composite_action_includes_zizmor_ignore_only_for_selected_acti
 
     generated = generate_composite_action(actions)
 
+    # The version tag stays the trailing token on the `uses:` line (so
+    # Dependabot keeps it in sync); the zizmor ignore moves to the `if: false`
+    # line, within the sentinel step's finding span. See #952.
     assert (
-        f"1Password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259  "
-        f"# v4.0.0  # {ZIZMOR_UNPINNED_TOOLS_IGNORE}"
+        "1Password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259  "
+        "# v4.0.0\n"
     ) in generated
+    assert f"      if: false  # {ZIZMOR_UNPINNED_TOOLS_IGNORE}\n" in generated
+    # ... and never on the uses: line, which would break Dependabot's updater.
+    for line in generated.splitlines():
+        if "1Password/load-secrets-action@92467" in line:
+            assert "zizmor: ignore" not in line
     assert (
         "DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd  "
         "# v23.2.0"


### PR DESCRIPTION
Fixes #952.

## Problem

Dependabot's `github_actions` comment-updater only rewrites a `# vX.Y.Z` comment when the version is the *trailing* token -- `file_updater.rb` deliberately skips comments with text after the version (`comment.end_with?(version)`). The gateway emitted the sentinel step's zizmor ignore right after the version on the `uses:` line:

```
- uses: 1Password/load-secrets-action@<sha>  # v4.0.0  # zizmor: ignore[unpinned-tools] ...
```

so on a bump Dependabot updated the hash but left `# v4.0.0` stale, and zizmor's `ref-version-mismatch` (medium) then failed CI -- fixed by hand in #932 and set to recur on every future bump of an ignored action.

## Fix

Emit the ignore on the `if: false` line instead:

```yaml
    - uses: 1Password/load-secrets-action@<sha>  # v4.0.1
      if: false  # zizmor: ignore[unpinned-tools] generated sentinel step is never executed
      with:
        version: "2.30.0"
```

It's still within the sentinel step's finding span ([zizmor docs](https://docs.zizmor.sh/usage/#ignoring-results)), so `unpinned-tools` stays suppressed, while the version tag is now the trailing token on the `uses:` line, so Dependabot keeps it in sync.

- `gateway.py`: build the `uses:` comment from the tag only; append the ignore to the `if: false` line.
- Regenerated `.github/actions/for-dependabot-triggered-reviews/action.yml` (2-line diff).
- `test_gateway.py`: assert the new placement and that the ignore never lands on the `uses:` line.
- Verified: `gateway` / `allowlist-check` tests pass, prek clean, zizmor clean on the composite, and the composite -> `actions.yml` read-back round-trips with no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
