### PR TITLE
Remove compromised actions-cool actions; pin check-user-permission (closes #891)

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -34,13 +34,8 @@
   3a12b0ab99d9cd590a3e9b5a90ea017210ed9556:
     tag: v4.0.1
 actions-cool/check-user-permission:
-  '*':
-    keep: true
-actions-cool/issues-helper:
-  '*':
-    keep: true
-actions-cool/maintain-one-comment:
-  '*':
+  c21884f3dda18dafc2f8b402fe807ccc9ec1aa5e:
+    tag: v2.4.0
     keep: true
 addnab/docker-run-action:
   4f65fabd2431ebc8d299f8e5a018d79a769ae185:

--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -23,9 +23,7 @@
 - 1Password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556
 - 1Password/load-secrets-action/configure@92467eb28f72e8255933372f1e0707c567ce2259
 - 1Password/load-secrets-action/configure@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556
-- actions-cool/check-user-permission@*
-- actions-cool/issues-helper@*
-- actions-cool/maintain-one-comment@*
+- actions-cool/check-user-permission@c21884f3dda18dafc2f8b402fe807ccc9ec1aa5e
 - addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
 - AdoptOpenJDK/install-jdk@*
 - advanced-security/dismiss-alerts@046d6b48d2e43cf563f96f67332c47c432eff83e


### PR DESCRIPTION
Fixes #891.

**`actions-cool/issues-helper`** and **`actions-cool/maintain-one-comment`** were compromised -- an attacker moved every version tag to an imposter commit that exfiltrates CI/CD credentials (StepSecurity advisory linked in #891). GitHub **TOS-blocked both repos on 2026-05-19**, so they are no longer fetchable. Removed from the allowlist.

**`actions-cool/check-user-permission`** is the same org but was *not* compromised and is still live. It was allowlisted as a wildcard (`'*': keep`) -- more trust than warranted now that the org account was compromised. Rather than removing it (which would break `apache/camel`, the one ASF consumer, which pins it safely by SHA), this **pins it to `c21884f3dda18dafc2f8b402fe807ccc9ec1aa5e` (v2.4.0)** -- the exact SHA camel uses -- with `keep: true` so it stays approved but is **not** dependabot-tracked (no auto-pulling new versions from this org).

Verified across `apache/*`: only camel used check-user-permission (SHA-pinned, safe). The three repos that referenced the compromised actions by `@v3` (linkis, linkis-website, incubator-kie-kogito-docs) are already protected by GitHub's takedown -- their steps now simply fail to fetch the action rather than running malicious code.

`approved_patterns.yml` is updated to match (surgical diff; unrelated expiry churn left to the `update` / `remove_expired` jobs).

## Downstream cleanup (tracking)

Heads-up issues filed for the ASF repos that still reference the removed actions by the (now-blocked) `@v3` tag, so they can drop/replace the dead steps:

- apache/linkis#5455 -- `issues-helper@v3` in `auto-comment.yml`
- apache/linkis-website#846 -- `issues-helper@v3` in `auto-comment.yml` (dormant workflow)
- apache/incubator-kie-kogito-docs#760 -- `maintain-one-comment@v3` in the PR-preview workflows

None of these were exposed (no runs during the compromise window -- see the analysis comment above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
