### PR TITLE
Remove 14 unused wildcard actions from allowlist (part of #666)

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -157,9 +157,6 @@ burnett01/rsync-deployments:
 burrunan/gradle-cache-action:
   '*':
     keep: true
-bytedeco/javacpp-presets:
-  '*':
-    keep: true
 carabiner-dev/actions/ampel/verify:
   e0e3b8149dafed833431095bc148d50e7eade4e8:
     tag: v1.2.0
@@ -229,25 +226,16 @@ carloscastrojumo/github-cherry-pick-action:
 carlosperate/arm-none-eabi-gcc-action:
   '*':
     keep: true
-check-spelling/check-spelling:
-  '*':
-    keep: true
 chromaui/action:
   '*':
     keep: true
 cicirello/javadoc-cleanup:
   '*':
     keep: true
-clechasseur/rs-cargo:
-  '*':
-    keep: true
 codecov/codecov-action:
   '*':
     keep: true
 codelytv/pr-size-labeler:
-  '*':
-    keep: true
-codspeedhq/action:
   '*':
     keep: true
 commit-check/commit-check-action:
@@ -281,9 +269,6 @@ conda-incubator/setup-miniconda:
   '*':
     keep: true
 container-tools/kind-action:
-  '*':
-    keep: true
-container-tools/microshift-action:
   '*':
     keep: true
 coursier/cache-action:
@@ -335,9 +320,6 @@ dawidd6/action-send-mail:
     expires_at: 2026-09-19
   94de994a9f6fffee200243214e17002e2920bb59:
     tag: v18
-delaguardo/setup-graalvm:
-  '*':
-    keep: true
 dependabot/fetch-metadata:
   ffa630c65fa7e0ecfa0625b5ceda64399aea1b36:
     tag: v3.0.0
@@ -461,9 +443,6 @@ erlef/setup-beam:
 geekyeggo/delete-artifact:
   '*':
     keep: true
-golang/govulncheck-action:
-  '*':
-    keep: true
 golangci/*:
   '*':
     keep: true
@@ -556,9 +535,6 @@ gradle/develocity-actions/setup-maven:
     expires_at: 2026-09-13
   0e1f30c14ab56d0c1ecf229a0ffc3eb3e40e4642:
     tag: v2.2
-gsactions/commit-message-checker:
-  '*':
-    keep: true
 hadolint/hadolint-action:
   2332a7b74a6de0dda2e2221d575162eba76ba5e5:
     tag: v3.3.0
@@ -604,9 +580,6 @@ j178/prek-action:
 JamesIves/github-pages-deploy-action:
   d92aa235d04922e8f08b40ce78cc5442fcfbfa2f:
     tag: v4.8.0
-jarvusinnovations/background-action:
-  '*':
-    keep: true
 jasonetco/create-an-issue:
   1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5:
     tag: v2
@@ -741,9 +714,6 @@ mozilla-actions/sccache-action:
   9e7fa8a12102821edf02ca5dbea1acd0f89a2696:
     tag: v0.0.10
 msys2/setup-msys2:
-  '*':
-    keep: true
-mvasigh/dispatch-action:
   '*':
     keep: true
 nanasess/setup-chromedriver:
@@ -972,9 +942,6 @@ shivammathur/setup-php:
 shogo82148/actions-setup-perl:
   '*':
     keep: true
-shufo/auto-assign-reviewer-by-files:
-  '*':
-    keep: true
 sigstore/cosign-installer:
   faadad0cce49287aee09b3a48701e75088a2c6ad:
     expires_at: 2026-12-31
@@ -1058,9 +1025,6 @@ test-summary/action:
 testlens-app/setup-testlens:
   '*':
     keep: true
-timonvs/pr-labeler-action:
-  '*':
-    keep: true
 TobKed/label-when-approved-action:
   '*':
     keep: true
@@ -1083,12 +1047,6 @@ vimtor/action-zip:
   5f1c4aa587ea41db1110df6a99981dbe19cee310:
     tag: v1
 vishalsinha21/dynamic-checklist:
-  '*':
-    keep: true
-wei/curl:
-  '*':
-    keep: true
-xpol/setup-lua:
   '*':
     keep: true
 zizmorcore/zizmor-action:

--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -64,7 +64,6 @@
 - burnett01/rsync-deployments@66257cad6bfeb2171d3b6bfa6c9a22279dd9c3a1
 - burnett01/rsync-deployments@4d419d1dc46d4a8a2b6ceab2f951f0f93b2da8f5
 - burrunan/gradle-cache-action@*
-- bytedeco/javacpp-presets@*
 - carabiner-dev/actions/ampel/verify@e0e3b8149dafed833431095bc148d50e7eade4e8
 - carabiner-dev/actions/ampel/verify@94f29392187fe5082d1195a7d4cae3a7ddf09d9c
 - carabiner-dev/actions/install/ampel@2a11d59a135c5e291f305f249a92ad7903e3ee0f
@@ -87,13 +86,10 @@
 - carabiner-dev/actions/install/download-and-verify@f882fa9eb795141737eecac4ffb056df5ad14954
 - carloscastrojumo/github-cherry-pick-action@503773289f4a459069c832dc628826685b75b4b3
 - carlosperate/arm-none-eabi-gcc-action@*
-- check-spelling/check-spelling@*
 - chromaui/action@*
 - cicirello/javadoc-cleanup@*
-- clechasseur/rs-cargo@*
 - codecov/codecov-action@*
 - codelytv/pr-size-labeler@*
-- codspeedhq/action@*
 - commit-check/commit-check-action@2fe41833054c561710099d8e3e22bbeab4fe204a
 - commit-check/commit-check-action@7c158d4541309c5952de3343151750882b036d10
 - commit-check/commit-check-action@2239d8980732e84a380552fdd71e1d49e149baf3
@@ -105,7 +101,6 @@
 - commit-check/commit-check-action@bbb6580f01838e475563514f115ec7ef41c9ddc7
 - conda-incubator/setup-miniconda@*
 - container-tools/kind-action@*
-- container-tools/microshift-action@*
 - coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475
 - coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d
 - coursier/setup-action@*
@@ -123,7 +118,6 @@
 - dawidd6/action-send-mail@d38f3f7cd391cdebfe0d38efc3998b935e951c4f
 - dawidd6/action-send-mail@42942bc2f8fba4e611b459a018967a6a7c78c68c
 - dawidd6/action-send-mail@94de994a9f6fffee200243214e17002e2920bb59
-- delaguardo/setup-graalvm@*
 - dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36
 - dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98
 - dlang-community/setup-dlang@*
@@ -165,7 +159,6 @@
 - erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93
 - erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124
 - geekyeggo/delete-artifact@*
-- golang/govulncheck-action@*
 - golangci/*@*
 - golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20
 - golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
@@ -196,7 +189,6 @@
 - gradle/develocity-actions/maven-publish-build-scan@0e1f30c14ab56d0c1ecf229a0ffc3eb3e40e4642
 - gradle/develocity-actions/setup-maven@974e8dbcbda40db6828fc35f349c80a7c0e71529
 - gradle/develocity-actions/setup-maven@0e1f30c14ab56d0c1ecf229a0ffc3eb3e40e4642
-- gsactions/commit-message-checker@*
 - hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
 - hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85
 - hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e
@@ -212,7 +204,6 @@
 - j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d
 - j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d
 - JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f
-- jarvusinnovations/background-action@*
 - jasonetco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5
 - jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db
 - JetBrains/qodana-action@89eb4357efd2b52e639f3216e63edaf33b82622b
@@ -259,7 +250,6 @@
 - mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad
 - mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696
 - msys2/setup-msys2@*
-- mvasigh/dispatch-action@*
 - nanasess/setup-chromedriver@*
 - ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
 - nick-fields/retry@*
@@ -333,7 +323,6 @@
 - securego/gosec@*
 - shivammathur/setup-php@*
 - shogo82148/actions-setup-perl@*
-- shufo/auto-assign-reviewer-by-files@*
 - sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad
 - slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95
 - slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c
@@ -361,7 +350,6 @@
 - terraform-linters/setup-tflint@6e1e0642c0289bd619021bf6b34e3c08ed1e005a
 - test-summary/action@*
 - testlens-app/setup-testlens@*
-- timonvs/pr-labeler-action@*
 - TobKed/label-when-approved-action@*
 - untitaker/hyperlink@fb5bb9c5011a3d143a54b4b30aedc30ec5bc0f89
 - untitaker/hyperlink@9375bc4063712ad490d5eb3d54df0b6aade15e54
@@ -370,8 +358,6 @@
 - vapier/coverity-scan-action@2068473c7bdf8c2fb984a6a40ae76ee7facd7a85
 - vimtor/action-zip@5f1c4aa587ea41db1110df6a99981dbe19cee310
 - vishalsinha21/dynamic-checklist@*
-- wei/curl@*
-- xpol/setup-lua@*
 - zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e
 - zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d
 - zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa


### PR DESCRIPTION
Part of #666, motivated by #891.

Each of these actions is allowlisted with a wildcard (`'*': keep: true`) but is **not referenced by any `apache/*` repository** (checked via org-wide code search on default branches). A wildcard approves *any* ref of an action, which -- as the actions-cool compromise (#891) showed -- is the exact door a hijacked tag walks through. Removing unused wildcards shrinks that attack surface and keeps the list under its size cap; any of these can be re-added on demand (with review) if a project actually needs it.

### Removed (14)

```
bytedeco/javacpp-presets           jarvusinnovations/background-action
check-spelling/check-spelling      mvasigh/dispatch-action
clechasseur/rs-cargo               shufo/auto-assign-reviewer-by-files
codspeedhq/action                  timonvs/pr-labeler-action
container-tools/microshift-action  wei/curl
delaguardo/setup-graalvm           xpol/setup-lua
golang/govulncheck-action          gsactions/commit-message-checker
```

`approved_patterns.yml` updated to match (surgical diff).

### Not touched

- **4 namespace-wildcards** (`golangci/*`, `r-lib/actions/*`, `quarto-dev/quarto-actions/*`, `rustsec/*`) are in active use -- kept, flagged in #666 as candidates to narrow to specific sub-actions in a follow-up.
- **83 single-action wildcards** in active use are kept.

### Caveat

"Unused" = no usage found on indexed default branches; a usage on a non-default branch or an un-indexed repo would not appear. Treated as strong candidates, not blind deletions. Full analysis in #666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
