### PR TITLE
Allowlist carabiner ampel-bootstrap@v1.2.1 (fix transitive-failures canary)

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -195,6 +195,11 @@ carabiner-dev/actions/install/ampel-bootstrap:
     tag: v1.2.0
     expires_at: 2026-08-16
   f882fa9eb795141737eecac4ffb056df5ad14954: {}
+  # transitive dep pulled by install/download-and-verify @ v1.2.1 (f882fa9e);
+  # completes the v1.2.1 (94f29392) approval so the transitive-failures canary resolves.
+  94f29392187fe5082d1195a7d4cae3a7ddf09d9c:
+    tag: v1.2.1
+    expires_at: 2026-10-05
 carabiner-dev/actions/install/bnd:
   2a11d59a135c5e291f305f249a92ad7903e3ee0f:
     # transitive dep of carabiner-dev/actions/ampel/verify @ v1.2.0

--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -76,6 +76,7 @@
 - carabiner-dev/actions/install/ampel-bootstrap@b60791af41423360b892a1a3cee90cd4e131f381
 - carabiner-dev/actions/install/ampel-bootstrap@e0e3b8149dafed833431095bc148d50e7eade4e8
 - carabiner-dev/actions/install/ampel-bootstrap@f882fa9eb795141737eecac4ffb056df5ad14954
+- carabiner-dev/actions/install/ampel-bootstrap@94f29392187fe5082d1195a7d4cae3a7ddf09d9c
 - carabiner-dev/actions/install/bnd@2a11d59a135c5e291f305f249a92ad7903e3ee0f
 - carabiner-dev/actions/install/bnd@e0e3b8149dafed833431095bc148d50e7eade4e8
 - carabiner-dev/actions/install/bnd@94f29392187fe5082d1195a7d4cae3a7ddf09d9c


### PR DESCRIPTION
## Problem

The scheduled **Check for transitive failures** canary has been failing on every run (all day 2026-07-12). The composite probes `carabiner-dev/actions/install/download-and-verify@f882fa9e` (v1.2.1), whose `action.yml` pulls `carabiner-dev/actions/install/ampel-bootstrap@94f29392` (v1.2.1) -- a **transitive** dependency that was not on the allowlist -- so GitHub's org policy blocks the whole composite from loading:

```
##[error]The action carabiner-dev/actions/install/ampel-bootstrap@94f29392187fe5082d1195a7d4cae3a7ddf09d9c
is not allowed in apache/infrastructure-actions ...
```

## Root cause

The v1.2.1 bump (`94f29392`) was allowlisted for `ampel/verify`, `install/ampel` and `install/bnd`, but the transitive `install/ampel-bootstrap@94f29392` ref was missed. It isn't a directly-probed step (it's reached via `download-and-verify@f882fa9e`), so the `update` job never learned about it and it had to be added by hand -- like the other transitive carabiner refs in `actions.yml`.

Traced chain confirming it's the only gap:
- `download-and-verify@f882fa9e` (v1.2.1, probed) -> `ampel-bootstrap@94f29392` (v1.2.1) **<- was missing**
- the v1.1.7 branch (`ampel/verify@94f29392` -> `install/{ampel,bnd}@2a11d59a` -> `download-and-verify@6022a065` -> `ampel-bootstrap@...`) resolves entirely through already-allowlisted SHAs.

## Fix

Add `ampel-bootstrap@94f29392` (v1.2.1) with a 12-week expiry (the gateway's standard for transitive refs), and regenerate `approved_patterns.yml`. It's the **same commit** already trusted via three sibling subpaths, so no new trust surface. The composite is unchanged -- the entry carries an expiry, so it's not a dependabot-update candidate.

Once this syncs to the org allow list, the canary should go green on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
