### PR TITLE
Stop push workflows firing on release tags

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,6 +20,10 @@ name: Linting and MyPy (Pelican)
 
 on:
   push:
+    # Branches only: release tags (pelican/v1.0.0, ...) touch these paths and
+    # re-running the linters on a tag adds nothing over the branch run.
+    branches:
+      - '**'
     paths:
       - 'pelican/**.py'
       - 'pelican/pyproject.toml'

--- a/.github/workflows/pelican-action-test.yml
+++ b/.github/workflows/pelican-action-test.yml
@@ -19,6 +19,12 @@
 name: Test the Pelican build action
 on:
   push:
+    # Branches only. Release tags (pelican/v1.0.0, pelican/v1, ...) touch the
+    # same paths, and github.ref_name for a tag push is the tag name, which
+    # would make TARGET below "testsite-pelican/v1" -- not a branch this
+    # workflow can create. Naming any branches filter excludes tag pushes.
+    branches:
+      - '**'
     paths:
       - 'pelican/**'
       - '.github/workflows/pelican-action-test.yml'


### PR DESCRIPTION
Split out of the now-closed #1106 - this part is needed regardless of whether Releases are ever published.

The per-action release tags (`pelican/v1.0.0`, `save/v1`, ...) touch the same paths these two workflows filter on, and neither named a `branches` filter, so a **tag** push triggered them.

`pelican-action-test` then derived `TARGET` from `github.ref_name`, which for a tag push is the tag itself, and tried to create a branch `testsite-pelican/v1`:

```
error: branch 'testsite-pelican/v1' not found
error: pathspec 'testsite-pelican/v1' did not match any file(s) known to git
Process completed with exit code 128
```

Seen live in [run 30289925857](https://github.com/apache/infrastructure-actions/actions/runs/30289925857).

- Naming any `branches` filter restricts a push trigger to branch pushes, so `'**'` keeps current behaviour and excludes tags.
- Applied to `pelican-action-test.yml` (the actual breakage) and `linting.yml`, which had the same gap and would also fire on `pelican/*` tags.
- I swept every workflow in `.github/workflows/`; these two were the only push triggers without a branches filter.

Without this, the failure recurs on every tag the release scheme creates.

## Test plan

- Both files re-parse with the intended trigger (`branches: ['**']`, paths unchanged).
- `prek run --all-files` - clean.

Generated-by: Claude Opus 5 (1M context) via Claude Code