### PR TITLE
release-actions: tag only, stop attempting GitHub Releases

### DIFF
--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -19,10 +19,11 @@
 # Cuts path-prefixed, per-action releases so downstream projects can pin a
 # version (and Dependabot can propose bumps). On every push to main the
 # release_actions.py script works out which action(s) changed, computes the
-# next version from the newest existing <leaf>/vX.Y.Z tag, creates the tag,
-# moves the <leaf>/vX major tag and publishes a GitHub Release. The bump type
-# defaults to patch and can be raised per PR with a release:minor /
-# release:major label (or suppressed with release:skip). See RELEASING.md.
+# next version from the newest existing <leaf>/vX.Y.Z tag, creates the tag and
+# moves the <leaf>/vX major tag. Tags only -- no GitHub Release is published,
+# since Dependabot resolves versions from tags. The bump type defaults to patch
+# and can be raised per PR with a release:minor / release:major label (or
+# suppressed with release:skip). See RELEASING.md.
 name: Release actions
 
 on:

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ was added to Dependabot in
 [dependabot/dependabot-core#11286](https://github.com/dependabot/dependabot-core/pull/11286),
 contributed specifically for this repository.
 
+A release is the tag pair (`<prefix>/vX.Y.Z` plus the moving `<prefix>/vN`) and
+nothing more — this repo publishes no GitHub Release objects, because
+Dependabot resolves versions from the tags themselves.
+
 Tracking `@main` (as in the quick-start above) also works and always gives you
 the latest code, but it drifts from any pinned SHA and Zizmor will flag the
 unpinned ref. See [RELEASING.md](RELEASING.md) for how releases are cut.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,8 +60,20 @@ on every push to `main` that touches an action's files. The workflow runs
 2. Picks the bump type (see below).
 3. For each affected action, computes the next version from the newest
    existing `<prefix>/vX.Y.Z` tag (the first release seeds `v1.0.0`), creates
-   the annotated tag, moves the `<prefix>/vN` major tag and publishes a GitHub
-   Release with auto-generated notes.
+   the annotated tag and moves the `<prefix>/vN` major tag.
+
+### Tags only — no GitHub Releases
+
+A release here is **a pair of git tags and nothing else**. No GitHub Release
+object is created.
+
+That is deliberate: Dependabot's `github_actions` ecosystem discovers versions
+by listing *tags* and filtering them by prefix, so a Release is not part of any
+path a consumer or a bump PR depends on. The only thing its absence costs is
+the "Release notes" section of Dependabot's PR body, which is cosmetic.
+
+If GitHub Releases are wanted later, they can be added on top of the existing
+tags without disturbing them.
 
 ### Choosing the bump
 

--- a/scripts/release_actions.py
+++ b/scripts/release_actions.py
@@ -234,18 +234,22 @@ def create_release(
     action: Action,
     version: tuple[int, int, int],
     sha: str,
-    repo: str,
     *,
     apply: bool,
 ) -> None:
-    """Create the ``X.Y.Z`` tag, move the major tag, publish a GitHub release."""
+    """Create the ``X.Y.Z`` tag and move the ``<prefix>/vN`` major tag.
+
+    Tags only: no GitHub Release is published. Dependabot's ``github_actions``
+    ecosystem resolves versions from the tags themselves, so a Release adds
+    nothing a consumer or a bump PR depends on.
+    """
     version_tag = format_tag(action.tag_prefix, version)
     major_tag = format_major_tag(action.tag_prefix, version)
     title = f"{action.consumed_path} {version_tag.split('/', 1)[1]}"
 
     print(f"  -> {version_tag}  (major {major_tag})  @ {sha[:12]}")
     if not apply:
-        print("     [dry-run] skipping tag/push/release")
+        print("     [dry-run] skipping tag/push")
         return
 
     # Annotated version tag (immutable), pushed once.
@@ -256,23 +260,7 @@ def create_release(
     _run(["git", "tag", "-f", "-a", major_tag, "-m", f"{action.consumed_path} {major_tag.split('/', 1)[1]}", sha])
     _run(["git", "push", "--force", "origin", major_tag])
 
-    # GitHub Release with auto-generated notes for the version tag.
-    _run(
-        [
-            "gh",
-            "release",
-            "create",
-            version_tag,
-            "--repo",
-            repo,
-            "--title",
-            title,
-            "--generate-notes",
-            "--target",
-            sha,
-        ],
-        check=False,
-    )
+    print(f"     tagged {version_tag} and {major_tag}")
 
 
 # --------------------------------------------------------------------------- #
@@ -340,7 +328,7 @@ def main(argv: list[str] | None = None) -> int:
         cur_str = format_tag(action.tag_prefix, current) if current else "(none)"
         print(f"{action.consumed_path}: {cur_str} --{bump}--> "
               f"{format_tag(action.tag_prefix, new_version)}")
-        create_release(action, new_version, after, args.repo, apply=args.apply)
+        create_release(action, new_version, after, apply=args.apply)
 
     return 0
 

--- a/scripts/test_release_actions.py
+++ b/scripts/test_release_actions.py
@@ -165,3 +165,32 @@ def test_commit_token_skip():
 
 def test_labels_are_case_insensitive():
     assert ra.determine_bump(["Release:Major"], "") == "major"
+
+
+# --------------------------------------------------------------------------- #
+# tags only: no GitHub Release is ever published
+# --------------------------------------------------------------------------- #
+def test_create_release_pushes_both_tags(monkeypatch):
+    cmds = []
+    monkeypatch.setattr(ra, "_run", lambda cmd, **k: cmds.append(cmd) or "")
+    ra.create_release(ra.ACTIONS[0], (1, 2, 3), "a" * 40, apply=True)
+    pushed = [c for c in cmds if c[:2] == ["git", "push"]]
+    assert any("allowlist-check/v1.2.3" in c for c in pushed)
+    assert any("allowlist-check/v1" in c for c in pushed)
+
+
+def test_create_release_never_invokes_gh_release(monkeypatch):
+    # Dependabot resolves versions from tags; publishing a Release is not part
+    # of any path a consumer depends on, so the script must not attempt one.
+    cmds = []
+    monkeypatch.setattr(ra, "_run", lambda cmd, **k: cmds.append(cmd) or "")
+    ra.create_release(ra.ACTIONS[2], (1, 0, 0), "b" * 40, apply=True)
+    assert not any(c[:1] == ["gh"] for c in cmds), cmds
+    assert not any("release" in part for c in cmds for part in c[:2]), cmds
+
+
+def test_create_release_dry_run_touches_nothing(monkeypatch):
+    cmds = []
+    monkeypatch.setattr(ra, "_run", lambda cmd, **k: cmds.append(cmd) or "")
+    ra.create_release(ra.ACTIONS[1], (2, 0, 0), "c" * 40, apply=False)
+    assert cmds == []


### PR DESCRIPTION
Dependabot resolves versions by listing **tags** and filtering by prefix, so a GitHub Release is not part of any path a consumer or a bump PR depends on. Attempting one bought nothing and failed anyway - seeding both `allowlist-check` and `pelican` returned `HTTP 422` from `gh release create`, and `_run(check=False)` discarded the reason, leaving a green run with tags pushed and no Release.

Rather than debug the 422 for an object nothing consumes, drop the attempt.

- `create_release()` creates the version tag, moves the `<prefix>/vN` major tag, and stops. Its `repo` argument is gone (still used for the PR-label lookup, just not here).
- `RELEASING.md` gains a "Tags only - no GitHub Releases" section explaining why, and what it costs (the cosmetic "Release notes" block in Dependabot PR bodies).
- `README.md` states that a release is the tag pair and nothing more, so nobody goes looking for a Releases page.
- Workflow header comment corrected - it claimed a Release was published.

All four actions are already seeded at `v1.0.0` on this basis:

```
allowlist-check/v1.0.0  allowlist-check/v1
pelican/v1.0.0          pelican/v1
save/v1.0.0             save/v1
restore/v1.0.0          restore/v1
```

all pointing at `61dcea11f19e` on `main`.

## Test plan

- 3 new tests: both tags pushed, `gh release` never invoked, dry-run touches nothing.
- `uv run pytest scripts/ utils/tests/` - 335 passed.
- Dry run against the real seeded tags reads them correctly: `pelican: pelican/v1.0.0 --patch--> pelican/v1.0.1`.
- `prek run --all-files` - clean.

Generated-by: Claude Opus 5 (1M context) via Claude Code