### PR TITLE
Allowlist carabiner v1.2.6 transitive action refs

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -196,6 +196,11 @@ carabiner-dev/actions/install/ampel:
     expires_at: 2026-10-20
   36a39ef667efe7112df8b1a534a4e37f35fad6fd:
     tag: v1.2.6
+  # transitive: ampel/verify @ v1.2.6 (36a39ef6) pins its internal action refs
+  # to this untagged commit. Verified carabiner release-bot commit, ancestor of
+  # 36a39ef6.
+  2fec8bd8e1dcfdea26080648070b4827f1fa0584:
+    expires_at: 2026-10-21
 carabiner-dev/actions/install/ampel-bootstrap:
   2a11d59a135c5e291f305f249a92ad7903e3ee0f:
     # transitive dep of carabiner-dev/actions/ampel/verify @ v1.2.0
@@ -233,6 +238,12 @@ carabiner-dev/actions/install/ampel-bootstrap:
   60563b5460a9e4ae9921c0da551b4ddd6059ff45:
     expires_at: 2026-10-20
   4c23ca5801511c2f0e9dd8c8dd011cab26a46be4: {}
+  # transitive: install/download-and-verify @ 4c23ca58 pins this ref, and
+  # @ 2fec8bd8 in turn pins 16009dca. Verified carabiner release-bot commits.
+  2fec8bd8e1dcfdea26080648070b4827f1fa0584:
+    expires_at: 2026-10-21
+  16009dca48ac369882d4333f1d15d7cd3a4ded31:
+    expires_at: 2026-10-21
 carabiner-dev/actions/install/bnd:
   2a11d59a135c5e291f305f249a92ad7903e3ee0f:
     # transitive dep of carabiner-dev/actions/ampel/verify @ v1.2.0
@@ -284,6 +295,13 @@ carabiner-dev/actions/install/download-and-verify:
   60563b5460a9e4ae9921c0da551b4ddd6059ff45:
     expires_at: 2026-10-20
   4c23ca5801511c2f0e9dd8c8dd011cab26a46be4: {}
+  # transitive: install/{ampel,bnd} @ v1.2.6 (36a39ef6) pin this ref, and
+  # install/ampel @ 2fec8bd8 in turn pins 16009dca. Verified carabiner
+  # release-bot commits.
+  2fec8bd8e1dcfdea26080648070b4827f1fa0584:
+    expires_at: 2026-10-21
+  16009dca48ac369882d4333f1d15d7cd3a4ded31:
+    expires_at: 2026-10-21
 carloscastrojumo/github-cherry-pick-action:
   503773289f4a459069c832dc628826685b75b4b3:
     tag: v1.0.10

--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -76,6 +76,7 @@
 - carabiner-dev/actions/install/ampel@619a474b2178d06ccf274349397cd67a7802a4fe
 - carabiner-dev/actions/install/ampel@2a4b2cd115ede14629b03ef7e77586d3269d4c72
 - carabiner-dev/actions/install/ampel@36a39ef667efe7112df8b1a534a4e37f35fad6fd
+- carabiner-dev/actions/install/ampel@2fec8bd8e1dcfdea26080648070b4827f1fa0584
 - carabiner-dev/actions/install/ampel-bootstrap@2a11d59a135c5e291f305f249a92ad7903e3ee0f
 - carabiner-dev/actions/install/ampel-bootstrap@0a075bb75a68646d05f99c85cbbf2be40dd8e442
 - carabiner-dev/actions/install/ampel-bootstrap@9db1a064ca5691ef6f5d983031739ca287de0968
@@ -88,6 +89,8 @@
 - carabiner-dev/actions/install/ampel-bootstrap@619a474b2178d06ccf274349397cd67a7802a4fe
 - carabiner-dev/actions/install/ampel-bootstrap@60563b5460a9e4ae9921c0da551b4ddd6059ff45
 - carabiner-dev/actions/install/ampel-bootstrap@4c23ca5801511c2f0e9dd8c8dd011cab26a46be4
+- carabiner-dev/actions/install/ampel-bootstrap@2fec8bd8e1dcfdea26080648070b4827f1fa0584
+- carabiner-dev/actions/install/ampel-bootstrap@16009dca48ac369882d4333f1d15d7cd3a4ded31
 - carabiner-dev/actions/install/bnd@2a11d59a135c5e291f305f249a92ad7903e3ee0f
 - carabiner-dev/actions/install/bnd@e0e3b8149dafed833431095bc148d50e7eade4e8
 - carabiner-dev/actions/install/bnd@94f29392187fe5082d1195a7d4cae3a7ddf09d9c
@@ -105,6 +108,8 @@
 - carabiner-dev/actions/install/download-and-verify@be6b4fa42fa3a8432416475d74218b9aa51ea527
 - carabiner-dev/actions/install/download-and-verify@60563b5460a9e4ae9921c0da551b4ddd6059ff45
 - carabiner-dev/actions/install/download-and-verify@4c23ca5801511c2f0e9dd8c8dd011cab26a46be4
+- carabiner-dev/actions/install/download-and-verify@2fec8bd8e1dcfdea26080648070b4827f1fa0584
+- carabiner-dev/actions/install/download-and-verify@16009dca48ac369882d4333f1d15d7cd3a4ded31
 - carloscastrojumo/github-cherry-pick-action@503773289f4a459069c832dc628826685b75b4b3
 - carlosperate/arm-none-eabi-gcc-action@*
 - chromaui/action@*


### PR DESCRIPTION
Follow-up from merging #1109, #1113, #1114, #1115 and #1116.

Those bumps added the top-level carabiner refs (`36a39ef6` for v1.2.6, `4c23ca58` for the untagged bootstrap/download-and-verify pair) but not the internal refs those versions pin. The org-wide allowlist resolves transitively, so it rejects them at run time and the hourly canary in `check-for-transitive-failures.yml` has been failing on:

```
The action carabiner-dev/actions/install/ampel@2fec8bd8e1dcfdea26080648070b4827f1fa0584
is not allowed in apache/infrastructure-actions because all actions must be from a
repository owned by your enterprise, created by GitHub, or match one of the patterns: ...
```

`verify-action-build` did flag these during review, as `hash-pinned, NOT in our approved list` on all four carabiner PRs. The warnings were read as advisory and merged over. They were not advisory.

This is not the ASF Infra sync lag that the workflow header warns about: `2fec8bd8` and `16009dca` were absent from both `actions.yml` and `approved_patterns.yml`, so there was nothing for the external sync to pick up.

## Reference chain

Resolved by reading each `action.yml` at the merged hashes rather than from log output:

| Referrer | Pulls |
|---|---|
| `ampel/verify@36a39ef6` (v1.2.6) | `install/ampel@2fec8bd8`, `actions/upload-artifact@ea165f8d` |
| `install/ampel@36a39ef6` (v1.2.6) | `install/download-and-verify@2fec8bd8` |
| `install/bnd@36a39ef6` (v1.2.6) | `install/download-and-verify@2fec8bd8` |
| `install/download-and-verify@4c23ca58` | `install/ampel-bootstrap@2fec8bd8` |
| `install/ampel@2fec8bd8` | `install/download-and-verify@16009dca` |
| `install/download-and-verify@2fec8bd8` | `install/ampel-bootstrap@16009dca` |
| `install/download-and-verify@16009dca` | `install/ampel-bootstrap@619a474b` (already allowlisted) |
| `install/ampel-bootstrap@*` | terminal, no nested `uses:` |

So the closure needs five new path/hash pairs:

- `install/ampel@2fec8bd8`
- `install/download-and-verify@2fec8bd8`, `@16009dca`
- `install/ampel-bootstrap@2fec8bd8`, `@16009dca`

`actions/upload-artifact@ea165f8d` needs no entry - GitHub-authored actions are implicitly allowed, and `approved_patterns.yml` carries no `actions/*` entries at all.

## Provenance

Every added commit is a verified `miniprow[bot]` (carabiner release-bot) commit, and each is an ancestor of the next, terminating at a hash this repo already trusts:

```
619a474b (already allowlisted) <- 16009dca <- 2fec8bd8 <- 36a39ef6 (v1.2.6)
```

Confirmed via `repos/carabiner-dev/actions/compare/<a>...<b>` - `ahead by 19`, `4`, and `2` respectively.

## Notes on the shape of the change

Each entry carries `expires_at`, not `{}`. `generate_composite_action` treats a ref with no `expires_at`/`keep` as the dependabot-tracked live ref and raises `multiple candidates for auto-updates` if a key has two - which is exactly what an initial `{}` version of this patch hit. Expiry is `calculate_expiry(12)` from today, 2026-10-21, matching the neighbouring entries.

`approved_patterns.yml` is regenerated and included so the diff shows precisely what reaches the org allowlist. `update.yml` regenerates it again on merge; the operation is idempotent. The composite action is deliberately unchanged - transitive refs do not belong in it.

## Test plan

- `uv run pytest utils/tests/` - 307 passed.
- `prek run --all-files` - clean, no files modified (including the `Sort actions.yml` hook).
- Local `gateway.update_actions` + `update_workflow` + `update_patterns` run: succeeds, produces exactly the 5 `approved_patterns.yml` lines in this diff and no composite change. `approved_patterns.yml` is at 362 entries against the 800 warning threshold.
- The canary itself can only be confirmed after merge plus the external ASF Infra allowlist sync. `eb1897b8dc4b` for `astral-sh/setup-uv` was the blocker before these merges and is still absent from both files; if it is still referenced anywhere it will likely be what the canary surfaces next, since the check fails fast on the first disallowed action.

Generated-by: Claude Opus 5 (1M context) via Claude Code
