### PR TITLE
verify-action-build: treat only-in-rebuilt JS as informational

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ A clean result confirms that the compiled JS was built from the declared source.
 
 Non-minified compiled JS (e.g. Deno `deno task bundle` output, Dart `dart compile js` readable output) is handled differently: a clean rebuild for these tends to produce toolchain-version noise (esbuild/ncc/webpack boilerplate differences) rather than actionable diffs. The script keeps these files in place during the pre-rebuild deletion step and instead diffs them against the previously approved version of the action, so reviewers see real source changes rather than rebuild artifacts. The detection threshold mirrors the comparison heuristic — fewer than 10 lines or an average line length above 500 chars is treated as minified.
 
+Files that appear **only in the rebuild** are reported as informational rather than as a failure. The action does not publish them, so they never reach a consumer's runner and cannot be a supply-chain vector. In practice they are intermediate build output from a multi-stage build that upstream deliberately does not commit — for example `JetBrains/qodana-action` declares `main: scan/dist/index.js`, so the output directory resolves to the whole `scan/` sub-project and the rebuild's gitignored `scan/lib/*.js` (stage one of its `tsc` → `esbuild` build) lands inside the compared tree. The inverse remains a hard failure: JS present in the published tree but *absent* from the rebuild is unaccounted-for shipped code, as is a published tree with no compiled JS at all when the rebuild produced some — there is then nothing to reconcile the rebuild against.
+
 #### Security Review Checklist
 
 When reviewing an action (new or updated), watch for these potential issues in the source diff between the approved and new versions:

--- a/utils/tests/verify_action_build/test_diff_js.py
+++ b/utils/tests/verify_action_build/test_diff_js.py
@@ -123,3 +123,108 @@ class TestDiffJsKeptFiles:
         )
 
         assert result is True
+
+
+class TestDiffJsOnlyInRebuilt:
+    """A file present only in the rebuild is not published by the action, so
+    it never runs on a consumer's runner and cannot be a supply-chain
+    vector.  It is reported but must not fail the JS check.
+
+    The real-world shape is JetBrains/qodana-action: ``main:
+    scan/dist/index.js`` makes OUT_DIR resolve to the whole ``scan/``
+    sub-project (the Dockerfile takes the first path component), so the
+    rebuild's stage-one ``tsc`` output ``scan/lib/*.js`` — gitignored
+    upstream via ``**/lib``, never committed, and consumed only by the
+    ``esbuild`` bundling step that writes ``scan/dist/index.js`` — shows up
+    inside the compared tree.  Before this was informational it hard-failed
+    the check on every qodana-action bump (apache/infrastructure-actions
+    #960, #1123).
+    """
+
+    def _setup_qodana_shape(self, tmp_path: Path) -> tuple[Path, Path]:
+        original = tmp_path / "original-dist"
+        rebuilt = tmp_path / "rebuilt-dist"
+        for base in (original, rebuilt):
+            (base / "dist").mkdir(parents=True)
+            # The published, non-minified esbuild bundle plus a config file:
+            # identical on both sides here so the only difference under test
+            # is the extra intermediate output.
+            (base / "dist" / "index.js").write_text(
+                "// esbuild bundle\n" + "var x = 1;\n" * 50
+            )
+            (base / "jest.config.js").write_text("module.exports = {};\n" * 12)
+        # Stage-one `tsc --build` output (outDir: ./lib), gitignored upstream
+        # and absent from the published tree.
+        (rebuilt / "lib").mkdir()
+        for name in ("annotations", "main", "output", "utils"):
+            (rebuilt / "lib" / f"{name}.js").write_text(
+                f'"use strict";\nexports.{name} = 1;\n' * 20
+            )
+        return original, rebuilt
+
+    def test_intermediate_build_output_does_not_fail(self, tmp_path):
+        original, rebuilt = self._setup_qodana_shape(tmp_path)
+
+        result = diff_js_files(
+            original, rebuilt, "JetBrains", "qodana-action", "b588768b6e7e" * 3,
+            out_dir_name="scan",
+            kept_files={Path("dist/index.js"), Path("jest.config.js")},
+        )
+
+        assert result is True
+
+    def test_only_in_original_still_fails(self, tmp_path):
+        """The inverse case is a real signal: the action publishes JS the
+        rebuild does not produce, so we cannot account for what ships."""
+        original, rebuilt = self._setup_qodana_shape(tmp_path)
+        # Kept short so the rendered diff fits one page — show_colored_diff
+        # pages interactively above ~20 diff lines and would read stdin.
+        (original / "dist" / "extra.js").write_text("// unaccounted for\n")
+
+        result = diff_js_files(
+            original, rebuilt, "JetBrains", "qodana-action", "b588768b6e7e" * 3,
+            out_dir_name="scan",
+            kept_files={Path("dist/index.js"), Path("jest.config.js")},
+        )
+
+        assert result is False
+
+    def test_published_tree_with_no_compiled_js_fails(self, tmp_path):
+        """Guard against the informational handling letting a wholly
+        unverifiable action pass: if the rebuild emits JS but the action
+        publishes none, there is nothing to reconcile against."""
+        original = tmp_path / "original-dist"
+        rebuilt = tmp_path / "rebuilt-dist"
+        original.mkdir()
+        (rebuilt / "lib").mkdir(parents=True)
+        (rebuilt / "lib" / "main.js").write_text("// rebuilt only\n" * 20)
+
+        result = diff_js_files(
+            original, rebuilt, "Org", "Repo", "deadbeef" * 5,
+            out_dir_name="scan",
+        )
+
+        assert result is False
+
+    def test_minified_content_mismatch_still_fails(self, tmp_path):
+        """The downgrade must not weaken the check that matters: a published
+        minified bundle whose content differs from the rebuild is still a
+        hard failure."""
+        original = tmp_path / "original-dist"
+        rebuilt = tmp_path / "rebuilt-dist"
+        (original / "dist").mkdir(parents=True)
+        (rebuilt / "dist").mkdir(parents=True)
+        # One long line, so is_minified() holds (avg line length > 500) while
+        # the beautified diff still fits a single page.
+        (original / "dist" / "index.js").write_text(f'var a = "{"a" * 600}";\n')
+        (rebuilt / "dist" / "index.js").write_text(f'var a = "{"b" * 600}";\n')
+        # Extra intermediate output alongside the real mismatch.
+        (rebuilt / "lib").mkdir()
+        (rebuilt / "lib" / "main.js").write_text("// intermediate\n" * 20)
+
+        result = diff_js_files(
+            original, rebuilt, "Org", "Repo", "deadbeef" * 5,
+            out_dir_name="scan",
+        )
+
+        assert result is False

--- a/utils/verify_action_build/diff_js.py
+++ b/utils/verify_action_build/diff_js.py
@@ -63,6 +63,18 @@ def diff_js_files(
     they're non-minified bundles where a clean rebuild produces toolchain-
     version noise rather than actionable diffs, and are verified by the
     approved-vs-new source diff section instead.
+
+    Files present *only in the rebuild* are reported but do not fail the
+    check: a file the action does not publish never reaches a consumer's
+    runner, so it cannot be a supply-chain vector.  They are usually
+    intermediate build output that upstream deliberately does not commit —
+    e.g. JetBrains/qodana-action declares ``main: scan/dist/index.js``, so
+    OUT_DIR resolves to the whole ``scan/`` sub-project and the rebuild's
+    gitignored ``scan/lib/*.js`` (stage one of its ``tsc`` → ``esbuild``
+    build) lands in the compared tree.  Files only in the *original* remain
+    a hard failure, as does an original tree with no compiled JS at all
+    while the rebuild produced some — there is nothing published to
+    reconcile the rebuild against.
     """
     blob_url = f"https://github.com/{org}/{repo}/blob/{commit_hash}"
     kept_files = kept_files or set()
@@ -86,6 +98,18 @@ def diff_js_files(
     console.rule(f"[bold]Comparing {len(all_files)} JavaScript file(s)[/bold]")
 
     all_match = True
+
+    # The rebuild produced compiled JS but the published tree has none, so
+    # every file below is "only in rebuilt" and nothing can be reconciled
+    # against what actually ships.  Without this guard the per-file
+    # informational handling would let such an action pass unverified.
+    if not original_files and rebuilt_files:
+        console.print(
+            f"  [red]✗[/red] [red bold]No compiled JavaScript in the published "
+            f"{out_dir_name}/ to compare against[/red bold] — the rebuild produced "
+            f"{len(rebuilt_files)} file(s) but the action publishes none"
+        )
+        all_match = False
 
     def is_minified(content: str) -> bool:
         """Check if JS content appears to be minified."""
@@ -136,11 +160,13 @@ def diff_js_files(
             continue
 
         if rel_path not in original_files:
-            console.print(f"  [green]+[/green] {file_link} [dim](only in rebuilt)[/dim]")
-            with console.status(f"[dim]Beautifying {rel_path}...[/dim]"):
-                built_content = beautify_js(built_file.read_text(errors="replace"))
-            show_colored_diff(rel_path, "", built_content)
-            all_match = False
+            # Not published, so it never runs on a consumer's runner and
+            # cannot be a supply-chain vector.  Report it and move on — the
+            # content diff would just be a full dump of a file nobody ships.
+            console.print(
+                f"  [green]+[/green] {file_link} [dim](only in rebuilt — not published "
+                f"by the action; intermediate build output, informational)[/dim]"
+            )
             continue
 
         if rel_path not in rebuilt_files:


### PR DESCRIPTION
The JS build check hard-failed on any file present in the rebuild but absent
from the published tree. Such a file is not published by the action, so it
never reaches a consumer's runner and cannot be a supply-chain vector -- it is
normally intermediate output from a multi-stage build that upstream
deliberately does not commit.

`JetBrains/qodana-action` is the recurring case. It declares
`main: scan/dist/index.js`, so `OUT_DIR` resolves to the whole `scan/`
sub-project (the Dockerfile takes the first path component of `main:`), and the
rebuild's stage-one `tsc` output `scan/lib/*.js` lands inside the compared
tree. That output is gitignored upstream via `**/lib`, is never committed, and
is consumed only by the `esbuild` step that writes the published
`scan/dist/index.js`.

This failed the check on #960 -- the PR that approved v2026.1.3, merged over
the failure anyway -- and again now on #1123. Only the gradle-jar half of
#960's failure was ever fixed (in #951). Each run also triggers the
approved-lock-file retry rebuild, which re-emits the same files and fails
identically, burning ~3 minutes of CI that can never help for this shape.

## What changes

Only-in-rebuilt files are now reported rather than failed on.

What actually matters is unchanged:

- JS in the published tree that **differs** from the rebuild: still a hard
  failure.
- JS in the published tree that the rebuild **does not produce**: still a hard
  failure (unaccounted-for shipped code).
- New guard for the one case the downgrade could have masked: a published tree
  with **no** compiled JS while the rebuild produced some, where there is
  nothing to reconcile the rebuild against.

## Tests

Four regression tests using qodana-action's real shape (published
`scan/dist/index.js` + `scan/jest.config.js`; rebuild adds
`scan/lib/{annotations,main,output,utils}.js`), covering the false positive and
each preserved failure mode. Full suite: 311 passed. `prek run --all-files`
clean.

README's "Verifying Compiled JavaScript" section documents the new behaviour.
