### PR TITLE
Restore Dependabot updates for pypa/gh-action-pypi-publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,19 +355,23 @@ This repository uses a [Dependabot cooldown period](https://docs.github.com/en/c
 If you need to add a specific version of an already approved action (especially an older one):
 
 1. **Fork** this repository
-2. **Add** a new version entry to an existing action in `actions.yml` with the following format:
+2. **Add** a new version entry to an existing action in `actions.yml`. Choose its metadata based on
+   why the version is needed.
+
+For the newest version:
 
 ```yaml
 existing/action:
   '<exact-commit-sha>':
-    keep: true
     tag: vX.Y.Z
 ```
 
-if this is the newest version of the action (make sure to remove the `keep: true` from the
-previously newest version and add `expires_at: <date>` to it, if you want to set an expiration date for it),
+The current version must have neither `keep` nor `expires_at`, so that it is included in the
+composite action watched by Dependabot. Each action must have at most one such version. When adding
+a new current version manually, add `expires_at: <date>` to the previous current version to give
+projects time to migrate.
 
-or
+For an older version that is needed temporarily:
 
 ```yaml
 existing/action:
@@ -376,7 +380,20 @@ existing/action:
     tag: vX.Y.Z
 ```
 
-If you add older version of the action and want to set an expiration date for it.
+Use `keep: true` only as an exceptional alternative when an older version must remain available
+indefinitely:
+
+```yaml
+existing/action:
+  '<exact-commit-sha>':
+    # Explain why this version must remain available indefinitely.
+    keep: true
+    tag: vX.Y.Z
+```
+
+A reference with `keep: true` is retained indefinitely and is not watched for updates by
+Dependabot. To keep the action updated, it must also have a separate current version with neither
+`keep` nor `expires_at`. Never set both `keep` and `expires_at` on the same reference.
 
 
 3. **Create a PR** against the `main` branch

--- a/actions.yml
+++ b/actions.yml
@@ -851,7 +851,6 @@ pypa/gh-action-pip-audit:
     tag: v1.1.0
 pypa/gh-action-pypi-publish:
   ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e:
-    keep: true
     tag: v1.13.0
 pyTooling/Actions:
   '*':


### PR DESCRIPTION
## Summary

`pypa/gh-action-pypi-publish` v1.13.0 is currently marked with `keep: true`.
Kept references are intentionally omitted from the composite action watched by Dependabot.
Consequently, the allowlist missed three upstream releases: v1.14.0, v1.14.1, and v1.14.2.

This removes `keep` from the current v1.13.0 reference, allowing the update workflow to expose it
to Dependabot again. This PR deliberately does not approve any of the missed releases. After this
change is merged, Dependabot can propose the latest release in a separate PR, where it can undergo
the repository's normal verification and review process. Once that later update is merged,
v1.13.0 will receive the normal 12-week expiration period.

The manual-version documentation is also corrected to distinguish the tracked current version,
temporarily retained older versions, and exceptional versions that must remain available
indefinitely.

## Type of change

- [ ] New utility or action
- [x] Bug fix
- [ ] Enhancement to existing code
- [ ] Workflow or CI change
- [x] Documentation update
- [ ] Other

## Testing

`uv run pytest gateway/test_gateway.py -q` passes all 10 tests. An in-memory run of the composite
generator also confirms that pypi-publish is absent before removing `keep` and appears as the
tracked v1.13.0 reference afterward.
