### PR TITLE
Add step-security/action-surefire-report v1.12.0 to allowlist

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -954,6 +954,9 @@ sbt/setup-sbt:
     expires_at: 2026-10-22
   bfea3c5f48abd221b04a6df4798aa5eb8b6a2baf:
     tag: v1.5.6
+ScalableCapital/action-surefire-report:
+  3b3f3f1178bc72d43fe062d5eb7fc316ee1663eb:
+    tag: v2.0.4
 scalacenter/sbt-dependency-submission:
   f43202114d7522a4b233e052f82c2eea8d658134:
     tag: v3.2.1

--- a/actions.yml
+++ b/actions.yml
@@ -954,9 +954,6 @@ sbt/setup-sbt:
     expires_at: 2026-10-22
   bfea3c5f48abd221b04a6df4798aa5eb8b6a2baf:
     tag: v1.5.6
-ScalableCapital/action-surefire-report:
-  3b3f3f1178bc72d43fe062d5eb7fc316ee1663eb:
-    tag: v2.0.4
 scalacenter/sbt-dependency-submission:
   f43202114d7522a4b233e052f82c2eea8d658134:
     tag: v3.2.1
@@ -1031,6 +1028,9 @@ SonarSource/sonarqube-scan-action/install-build-wrapper:
 stCarolas/setup-maven:
   '*':
     keep: true
+step-security/action-surefire-report:
+  85ac498005883fee784ede6514ac650e1fe023ad:
+    tag: v1.12.0
 subosito/flutter-action:
   '*':
     keep: true


### PR DESCRIPTION
[step-security/action-surefire-report](https://github.com/step-security/action-surefire-report) is a secure drop-in replacement for [ScaCap/action-surefire-report](https://github.com/ScaCap/action-surefire-report), the latter was banned in https://github.com/apache/infrastructure-actions/pull/828