### PR TITLE
actions.yml: drop stale stable tag on dtolnay/rust-toolchain

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -486,9 +486,15 @@ dorny/test-reporter:
   a43b3a5f7366b97d083190328d2c652e1a8b6aa2:
     tag: v3.0.0
 dtolnay/rust-toolchain:
+  # Deliberately carries no `tag:` annotation. Upstream publishes `stable` as a
+  # rolling branch that is force-pushed on each toolchain release, so a SHA
+  # annotated with it stops being an ancestor of that branch and makes
+  # check_action_tags hard-fail every PR in this repo, not just ones touching
+  # this entry. The commit itself is immutable and still valid to pin; moving
+  # to whatever `stable` points at now is a version bump and needs its own
+  # review rather than being smuggled in as a CI fix.
   4cda84d5c5c54efe2404f9d843567869ab1699d4:
     keep: true
-    tag: stable
 easimon/maximize-build-space:
   '*':
     keep: true

--- a/approved_patterns.yml
+++ b/approved_patterns.yml
@@ -379,7 +379,6 @@
 - vapier/coverity-scan-action@2068473c7bdf8c2fb984a6a40ae76ee7facd7a85
 - vimtor/action-zip@5f1c4aa587ea41db1110df6a99981dbe19cee310
 - vishalsinha21/dynamic-checklist@*
-- zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e
 - zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d
 - zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa
 - zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02


### PR DESCRIPTION
`check_action_tags` is currently failing on every open PR:

```
❌ GitHub action dtolnay/rust-toolchain references Git branch 'stable' via
   SHAs '{'4cda84d5...'}' but none of those SHAs are ancestors of that branch
```

Upstream publishes `stable` as a rolling branch and force-pushes it on each
toolchain release. The SHA was pinned on 2026-07-19 when it was the branch
head; `stable` has since moved to `4360b525`, so the annotation no longer
holds and the checker hard-fails the whole run. Seven open PRs (#1145, #1147,
#1148, #1150, #1157, #1158, #1161) are red for a reason none of them caused,
and every new PR inherits it.

## The change

Drop the `tag: stable` annotation from the pinned SHA. With no `tag:` key,
`action_tags.py` verifies only that the commit exists and emits a warning
(`action_tags.py:208-216`) rather than validating ancestry against a branch.
That is the accurate statement: commit `4cda84d5` is immutable and still valid
to pin, it is simply no longer on any ref.

## What this deliberately does not do

It does not bump to the current `stable` head. That would add an unreviewed
version of the action to the allowlist for every ASF project - a version bump
needing its own review, not something to smuggle in as a CI fix. Consumers are
pinned to the SHA via `approved_patterns.yml`, so nothing downstream changes.

This will recur on the next force-push if the entry is ever re-annotated with
a rolling ref. Upstream ships exactly one tag (`v1`) and uses branches for
everything else, so pinning by SHA without a `tag:` is the stable arrangement
here.

## Note on the diff

`approved_patterns.yml` also loses `zizmorcore/zizmor-action@b1d7e1fb`
(v0.5.3). Its `expires_at` was 2026-08-09, so the gateway regeneration drops
it. Unrelated to this fix, but the sync produces it either way.

## Test plan

- `prek run --all-files` clean.
- Derived files regenerated with the same `gateway` sync the `update` workflow
  runs (`update_actions` / `update_workflow` / `update_patterns`).
- Verified `4cda84d5` still resolves via the commits API (HTTP 200), which is
  the path that now yields a warning instead of a failure.
