### PR TITLE
Allow jdx/mise-action v4.2.4

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -686,6 +686,8 @@ jasonetco/create-an-issue:
 jdx/mise-action:
   5228313ee0372e111a38da051671ca30fc5a96db:
     keep: true
+  7e36c90d9ab29c415a2384db3006f3ec8a8cc654:
+    tag: v4.2.4
 JetBrains/qodana-action:
   d7b5ec2fbec32197ef447c450e00589ed5f34fd5:
     tag: v2026.1.0

--- a/actions.yml
+++ b/actions.yml
@@ -629,6 +629,8 @@ jasonetco/create-an-issue:
 jdx/mise-action:
   5228313ee0372e111a38da051671ca30fc5a96db:
     keep: true
+  7e36c90d9ab29c415a2384db3006f3ec8a8cc654:
+    tag: v4.2.4
 JetBrains/qodana-action:
   d7b5ec2fbec32197ef447c450e00589ed5f34fd5:
     tag: v2026.1.0


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

**Name of action:** `jdx/mise-action`

**URL of action:** https://github.com/jdx/mise-action

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):** `7e36c90d9ab29c415a2384db3006f3ec8a8cc654` (`v4.2.4`)

Apache DataSketches TCK is migrating its tool setup and checks to mise in apache/datasketches-tck#3. The currently approved `v3.6.3` release runs on Node.js 20, which GitHub Actions now warns is deprecated. `v4.2.4` runs on Node.js 24 and includes the latest PATH propagation and lock-detection fixes. The existing approved SHA is retained for current consumers.

## Permissions

The action uses the automatic GitHub token for authenticated release API requests and reads or writes the GitHub Actions cache by default. It does not require repository write access. Its optional OIDC-based cache integration is disabled by default and is not used by DataSketches TCK.

## Related Actions

`jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db` (`v3.6.3`) is already approved. This request adds the current v4 release rather than replacing the existing SHA.

## Checklist

- [x] The action is listed in the GitHub Actions Marketplace
- [ ] The action is not already on the list of approved actions (v3.6.3 is already approved)
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
- [x] Compiled JavaScript in `dist/` matches a clean rebuild (verify with `uv run utils/verify-action-build.py org/repo@hash`)

## Verification note

`uv run utils/verify-action-build.py --ci jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654` confirms Node.js 24, signed-checksum download verification, and that the compiled JavaScript matches a clean rebuild. The command currently exits non-zero on lock-file presence because v4.2.4 uses `aube-lock.yaml`, which the verifier does not yet recognize. This PR is draft pending guidance on adding aube support to the verifier.

---
Drafted-by: Codex (GPT-5)
