### PR TITLE
verify-action-build: recognise aube-lock.yaml as a node lock file

### DIFF
--- a/utils/tests/verify_action_build/test_security.py
+++ b/utils/tests/verify_action_build/test_security.py
@@ -678,6 +678,17 @@ class TestAnalyzeLockFiles:
         }
         assert self._run(files) == []
 
+    def test_node_package_json_with_aube_lock_passes(self):
+        # apache/infrastructure-actions#1167: jdx/mise-action v4.2.4 moved its
+        # build to aube (jdx/aube), which writes aube-lock.yaml in pnpm's
+        # lockfileVersion 9 format — resolved versions plus sha512 integrity
+        # for every transitive dep, so the pinning guarantee is unchanged.
+        files = {
+            "package.json": '{"name":"x","dependencies":{"a":"1.0.0"}}',
+            "aube-lock.yaml": "lockfileVersion: '9.0'\n",
+        }
+        assert self._run(files) == []
+
     def test_node_package_json_without_lock_fails(self):
         # ``dependencies`` are declared, so the lock-file requirement applies.
         errors = self._run({

--- a/utils/verify_action_build/diff_source.py
+++ b/utils/verify_action_build/diff_source.py
@@ -55,7 +55,7 @@ def diff_approved_vs_new(
     excluded_dirs = {"dist", "node_modules", ".git", ".github", "__tests__", "__mocks__"}
     lock_files = {
         "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lockb",
-        "shrinkwrap.json", "npm-shrinkwrap.json",
+        "aube-lock.yaml", "shrinkwrap.json", "npm-shrinkwrap.json",
     }
     source_extensions = {".js", ".ts", ".mjs", ".cjs", ".mts", ".cts", ".json", ".yml", ".yaml"}
 

--- a/utils/verify_action_build/dockerfiles/build_action.Dockerfile
+++ b/utils/verify_action_build/dockerfiles/build_action.Dockerfile
@@ -177,7 +177,7 @@ RUN OUT_DIR=$(cat /out-dir.txt); \
 ARG APPROVED_HASH=""
 RUN if [ -n "$APPROVED_HASH" ]; then \
       echo "approved-hash: $APPROVED_HASH" >> /build-info.log; \
-      for f in package.json package-lock.json yarn.lock pnpm-lock.yaml; do \
+      for f in package.json package-lock.json yarn.lock pnpm-lock.yaml aube-lock.yaml; do \
         if [ -f "$f" ]; then \
           if git show "$APPROVED_HASH:$f" > "/tmp/approved-$f" 2>/dev/null; then \
             cp "/tmp/approved-$f" "$f"; \
@@ -215,6 +215,12 @@ RUN if [ "$(cat /has-node-modules.txt)" = "true" ]; then \
         corepack prepare --activate 2>/dev/null; \
         pnpm install --prod 2>/dev/null || pnpm install 2>/dev/null || true; \
         echo "node_modules-reinstall: pnpm --prod (in $BUILD_DIR)" >> /build-info.log; \
+      elif [ -f aube-lock.yaml ]; then \
+        cp aube-lock.yaml pnpm-lock.yaml; \
+        corepack prepare --activate 2>/dev/null; \
+        pnpm install --no-frozen-lockfile --prod 2>/dev/null || pnpm install --no-frozen-lockfile 2>/dev/null || true; \
+        rm -f pnpm-lock.yaml; \
+        echo "node_modules-reinstall: pnpm --prod via aube-lock.yaml (in $BUILD_DIR)" >> /build-info.log; \
       else \
         npm ci --production 2>/dev/null || npm install --production 2>/dev/null || true; \
         echo "node_modules-reinstall: npm --production (in $BUILD_DIR)" >> /build-info.log; \
@@ -236,6 +242,12 @@ RUN BUILD_DIR=$(cat /build-dir.txt); \
       corepack prepare --activate 2>/dev/null; \
       pnpm install 2>/dev/null || true; \
       echo "pkg-manager: pnpm (in $BUILD_DIR)" >> /build-info.log; \
+    elif [ -f aube-lock.yaml ]; then \
+      cp aube-lock.yaml pnpm-lock.yaml; \
+      corepack prepare --activate 2>/dev/null; \
+      pnpm install --no-frozen-lockfile 2>/dev/null || true; \
+      rm -f pnpm-lock.yaml; \
+      echo "pkg-manager: pnpm via aube-lock.yaml (in $BUILD_DIR)" >> /build-info.log; \
     else \
       npm ci 2>/dev/null || npm install 2>/dev/null || true; \
       echo "pkg-manager: npm (in $BUILD_DIR)" >> /build-info.log; \

--- a/utils/verify_action_build/security.py
+++ b/utils/verify_action_build/security.py
@@ -680,7 +680,10 @@ def analyze_lock_files(
 
     # (ecosystem, manifest, [acceptable lock files in priority order])
     ecosystems: list[tuple[str, str, list[str]]] = [
-        ("node",   "package.json",   ["package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lock", "bun.lockb"]),
+        # aube (jdx/aube) writes aube-lock.yaml in pnpm's lockfileVersion 9
+        # format — same resolved-version + sha512-integrity guarantees the
+        # other node lock files give, under a different filename.
+        ("node",   "package.json",   ["package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lock", "bun.lockb", "aube-lock.yaml"]),
         ("python", "pyproject.toml", ["uv.lock", "poetry.lock", "pdm.lock", "requirements.txt"]),
         ("python", "Pipfile",        ["Pipfile.lock"]),
         ("deno",   "deno.json",      ["deno.lock"]),
@@ -917,7 +920,7 @@ def analyze_dependency_pinning(
         except (json.JSONDecodeError, KeyError):
             pass
 
-    lock_files = ["package-lock.json", "yarn.lock", "pnpm-lock.yaml"]
+    lock_files = ["package-lock.json", "yarn.lock", "pnpm-lock.yaml", "aube-lock.yaml"]
     if sub_path:
         lock_files = [f"{sub_path}/{lf}" for lf in lock_files] + lock_files
     for lf_path in lock_files:


### PR DESCRIPTION
# Code change

## Summary

`jdx/mise-action` v4.2.4 moved its build to [aube](https://github.com/jdx/aube), which writes `aube-lock.yaml` instead of `package-lock.json`. The file is pnpm's lockfileVersion 9 format and carries resolved versions plus sha512 integrity for all 460 transitive deps, so the pinning guarantee is the same one the other node lock files give. The presence check only knew the five established filenames, so #1167 hard-failed with "no matching lock file" on a repo that has one.

- Accept `aube-lock.yaml` in the lock-file presence check and the dependency-pinning note (`security.py`), and exclude it from the source diff as a generated lock file (`diff_source.py`).
- Teach the rebuild to install from it. pnpm reads the file once renamed; `--no-frozen-lockfile` is required because aube records an undeclared direct `tslib` dep that trips pnpm's manifest check. Without this branch the rebuild silently fell through to an unpinned `npm install`.

## Type of change

- [x] Bug fix
- [x] Enhancement to existing code

## Testing

- `uv run pytest utils/tests/` - 330 passed, including a new lock-file-presence case for `aube-lock.yaml`.
- Against the real commit from #1167, `analyze_lock_files('jdx', 'mise-action', '7e36c90d9ab29c415a2384db3006f3ec8a8cc654')` now reports `node: package.json -> aube-lock.yaml` with no errors.
- Verified pnpm 11 consumes the real `aube-lock.yaml` in a `node:24-slim` container: it validates all 460 entries and installs the lockfile-pinned versions.

---
Drafted-by: Claude Code (Opus 5); reviewed by @potiuk before posting
