### PR TITLE
Update pnpm/action-setup tag in actions.yml

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -834,8 +834,8 @@ phoenix-actions/test-reporting:
   7317eea6e13c47348dd0bb318669485157c518d6:
     tag: v16
 pnpm/action-setup:
-  '*':
-    keep: true
+  0977fd99725f1db4007ccb2928dbb4e90d06cc86:
+    tag: v6.0.10
 posit-dev/setup-air:
   cf390573ff4fe0f198f35df3a642b1409328d859:
     tag: v1.0.1


### PR DESCRIPTION
This one will cause some pain for a few teams as it is used by maybe 10 (P)PMCs.

It highlights how some (P)PMCs do not worry about their github action versions because some of them use v2 and now we have v6.0.10 as most recent version.

https://github.com/search?q=org%3Aapache+pnpm%2Faction-setup&type=code

I'll leave it to the reviewers to decide if we've reached the stage where we need to start actually pushing out stricter version management.