### PR TITLE
dependabot: group uv dev tooling and runtime patch/minor bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,11 @@
 
 version: 2
 updates:
+  # Deliberately ungrouped: every bump here is an allow-list change that gets
+  # its own security review and its own `verify` run, and is approved or held
+  # on its own merits. Grouping would tie an action that fails verification to
+  # unrelated ones that passed, so a single bad actor would block the batch.
+  # Do not add a `groups:` key to this ecosystem.
   - package-ecosystem: "github-actions" # zizmor: ignore[dependabot-cooldown] see #683 and #712
     commit-message:
       prefix: "action-allowlist-review"
@@ -64,3 +69,24 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      # Lint/test tooling from the PEP 735 `dev` group. These never ship in
+      # the published action, so reviewing them one PR per tool buys nothing
+      # — five separate PRs landed on 2026-08-28 (#1208-#1212) for ruff,
+      # mypy and types-pyyaml across two directories. Dependabot opens one
+      # PR per directory per group, so this collapses those to two.
+      dev-tooling:
+        dependency-type: "development"
+        patterns:
+          - "*"
+      # Runtime dependencies are grouped only for patch and minor bumps.
+      # A major bump of something the action actually ships stays outside
+      # every group and so gets its own PR, which is where it belongs: it
+      # can break consumers and deserves to be reviewed and released alone.
+      runtime-minor-patch:
+        dependency-type: "production"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This repository hosts GitHub Actions developed by the ASF community and approved
   - [Reviewing](#reviewing)
   - [Updating Version of Already Approved Action](#updating-version-of-already-approved-action)
     - [Automated Verification in CI](#automated-verification-in-ci)
+    - [Dependabot Update Grouping](#dependabot-update-grouping)
     - [Dependabot Cooldown Period](#dependabot-cooldown-period)
   - [Manual Version Addition](#manual-addition-of-specific-versions)
   - [Automatic Expiration of Old Versions](#automatic-expiration-of-old-versions)
@@ -332,6 +333,23 @@ Additional flags:
 
 > [!NOTE]
 > **Prerequisites:** `docker` and `uv`. When using the default mode (without `--no-gh`), `gh` (GitHub CLI, authenticated via `gh auth login`) is also required. The build runs in a `node:20-slim` container so no local Node.js installation is needed.
+
+#### Dependabot Update Grouping
+
+`.github/dependabot.yml` groups updates so that related bumps arrive as one PR:
+
+| Ecosystem | Group | What it collects |
+|---|---|---|
+| `github-actions` (`/.github/workflows`, …) | `codeql-action` | `github/codeql-action*` — init/autobuild/analyze must run the same version, so a split PR fails the Analyze jobs |
+| `uv` (`/`, `/pelican/`, `/stash/`) | `dev-tooling` | everything in the PEP 735 `dev` group (ruff, mypy, pytest, pylint, `types-*`) — lint/test tooling that never ships in the published action |
+| `uv` | `runtime-minor-patch` | patch and minor bumps of runtime dependencies |
+
+Dependabot opens one PR per directory per group, so `/pelican` and `/stash` each get a single dev-tooling PR rather than one per tool.
+
+Two things stay deliberately ungrouped:
+
+- **Major bumps of runtime dependencies** match no group, so each gets its own PR. A major version of something the action ships can break consumers and deserves to be reviewed and released on its own.
+- **The allow-list ecosystem** (`/.github/actions/for-dependabot-triggered-reviews`). Every bump there is an allow-list change with its own security review and its own `verify` run, approved or held on its own merits. Grouping would tie an action that fails verification to unrelated ones that passed, so a single bad actor would block the whole batch.
 
 #### Dependabot Cooldown Period
 


### PR DESCRIPTION
# Code change

## Summary

Grouping was already in place for `github/codeql-action*`, but the `uv` ecosystem had none - so five separate PRs landed today (#1208-#1212) for ruff, mypy and types-pyyaml across `/pelican` and `/stash`. All five are PEP 735 `dev` group tooling that never ships in the published action, so one PR per tool buys no review value.

- `dev-tooling` group (`dependency-type: development`, `patterns: ["*"]`) - collects the lint/test tooling. Dependabot opens one PR per directory per group, so today's five become two.
- `runtime-minor-patch` group (`dependency-type: production`, minor + patch only) - keeps routine runtime bumps together.
- Major bumps of runtime dependencies match no group and so keep their own PR. A major version of something the action ships can break consumers and deserves to be reviewed and released alone.
- The allow-list ecosystem stays ungrouped, and now carries a comment saying why: every bump there gets its own security review and its own `verify` run, so grouping would tie an action that fails verification to unrelated ones that passed.
- README documents the grouping table and both deliberate exclusions.

Dependabot classifies these correctly today - #1155 (`markdown`) reports `dependency-type: direct:production` and #1190 (`ruff`) reports `direct:development` - so both groups match what is already being emitted.

## Type of change

- [x] Workflow or CI change
- [x] Documentation update

## Testing

- `.github/dependabot.yml` parses and resolves to the three expected ecosystems with the intended group keys.
- `prek run --all-files` clean.
- No code paths touched; the effect is visible on Dependabot's next weekly `uv` run.

---
Drafted-by: Claude Code (Opus 5); reviewed by @potiuk before posting
