### PR TITLE
action-tags: make failures more prominent

### DIFF
--- a/gateway/action_tags.py
+++ b/gateway/action_tags.py
@@ -60,6 +60,13 @@ class ActionTagsCheckResult(object):
     def has_warnings(self) -> bool:
         return len(self.warnings) > 0
 
+    def markdown(self) -> str:
+        return ("# Result summary\n\n"
+            + "## Failures\n\n* ❌ "
+            + "\n* ❌ ".join(self.failures)
+            + "\n\n## Warnings\n\n* ⚡ "
+            + "\n* ⚡ ".join(self.warnings))
+
     def __str__(self):
         return (
             ''.join([f"FAILURE: {failure}\n" for failure in self.failures])

--- a/gateway/run_action_tags.py
+++ b/gateway/run_action_tags.py
@@ -53,6 +53,10 @@ def run_main():
 
     result = verify_actions(actions_yaml)
     if result.has_failures():
+        print(os.environ.get('GITHUB_STEP_SUMMARY'))
+        if 'GITHUB_STEP_SUMMARY' in os.environ:
+            with open(os.environ['GITHUB_STEP_SUMMARY'], mode='w') as f:
+                f.write(result.markdown())
         raise Exception(f"Verify actions result summary:\n{result}")
 
 


### PR DESCRIPTION
by adding them to the GHA summary

especially useful because the failure of this job _can_ flag issues that are actually unrelated to the PR it's running on