### PR TITLE
verify-action-build: exempt test-fixture binaries from in-tree check

### DIFF
--- a/utils/tests/verify_action_build/test_security.py
+++ b/utils/tests/verify_action_build/test_security.py
@@ -1658,6 +1658,33 @@ class TestLooksLikeInTreeBinary:
             "node_modules/evil-pkg/scripts/externals/7zdec.exe"
         ) is True
 
+    def test_test_fixture_binaries_exempt(self):
+        # Binaries under a test-fixture tree are test *input*, never
+        # reached by the action's entrypoint, so they never run on a
+        # consumer's runner.  anchore/sbom-action@v0.24.2 was
+        # false-flagged for this sample app used in SBOM coverage tests.
+        assert _looks_like_in_tree_binary(
+            "tests/fixtures/image-debian-match-coverage/java/"
+            "example-java-app-maven-0.1.0.jar"
+        ) is False
+        # Other conventional spellings of the same thing.
+        for path in (
+            "test/fixtures/sample.jar",
+            "spec/fixtures/nested/deep/lib.so",
+            "__tests__/__fixtures__/app.exe",
+            "testdata/binary.dll",
+            "src/testdata/golden/tool",
+        ):
+            assert _looks_like_in_tree_binary(path) is False, path
+        # Precision: a test tree alone is not enough — a helper binary
+        # that really is executed still gets flagged.
+        assert _looks_like_in_tree_binary("tests/bin/helper.exe") is True
+        # ...and so is a fixtures tree outside any test directory, which
+        # is a shape real actions use for shipped sample data.
+        assert _looks_like_in_tree_binary("fixtures/payload.jar") is True
+        # The segments must be directories, not the filename itself.
+        assert _looks_like_in_tree_binary("dist/test-fixtures.jar") is True
+
     def test_matlab_platform_dir_naming(self):
         # MATLAB's launcher convention: dist/bin/<platform>/run-matlab-command
         # where <platform> is MATLAB's own arch identifier and the file has

--- a/utils/verify_action_build/security.py
+++ b/utils/verify_action_build/security.py
@@ -1872,6 +1872,34 @@ _IN_TREE_BINARY_EXEMPT_PATH_SUFFIXES = (
     "node_modules/@actions/tool-cache/scripts/externals/7zdec.exe",
 )
 
+# Directory segments that mark a test tree, and the fixture / sample-data
+# subtrees inside one.  A binary under BOTH (or under a ``testdata``
+# segment, Go's convention for the same thing) is test *input*: the
+# action's entrypoint never reaches it, so it never runs on a consumer's
+# runner and is not a supply-chain vector.  Same reasoning already
+# applied to only-in-rebuild output (cf. the #1123 precedent).
+#
+# Requiring both a test segment and a fixture segment keeps this narrow.
+# A top-level ``fixtures/`` tree, or a genuine helper binary sitting at
+# ``tests/bin/tool``, still gets flagged.
+_TEST_DIR_SEGMENTS = frozenset({"test", "tests", "spec", "specs", "__tests__"})
+_FIXTURE_DIR_SEGMENTS = frozenset({"fixture", "fixtures", "__fixtures__"})
+_TESTDATA_DIR_SEGMENTS = frozenset({"testdata", "test-data"})
+
+
+def _is_test_fixture_binary(path: str) -> bool:
+    """Return True if ``path`` sits inside a test-fixture tree.
+
+    Only the *directory* segments are considered, so a file merely named
+    like a fixture does not qualify.
+    """
+    segments = set(path.lower().split("/")[:-1])
+    if segments & _TESTDATA_DIR_SEGMENTS:
+        return True
+    return bool(segments & _TEST_DIR_SEGMENTS) and bool(
+        segments & _FIXTURE_DIR_SEGMENTS
+    )
+
 
 def _looks_like_in_tree_binary(path: str) -> bool:
     """Return True if ``path`` (a repo-relative blob path) looks like a
@@ -1886,6 +1914,8 @@ def _looks_like_in_tree_binary(path: str) -> bool:
     if name in _IN_TREE_BINARY_EXEMPT_NAMES:
         return False
     if path.lower().endswith(_IN_TREE_BINARY_EXEMPT_PATH_SUFFIXES):
+        return False
+    if _is_test_fixture_binary(path):
         return False
     lower = name.lower()
     if lower.endswith(_IN_TREE_BINARY_EXTENSIONS):


### PR DESCRIPTION
## What changed

- `_looks_like_in_tree_binary()` now exempts a binary whose *directory* path carries both a test segment (`test`, `tests`, `spec`, `specs`, `__tests__`) and a fixture segment (`fixture`, `fixtures`, `__fixtures__`), or a `testdata` / `test-data` segment.
- Rationale: a test fixture is test *input*. The action's entrypoint never reaches it, so it never runs on a consumer's runner and cannot be a supply-chain vector. Asking upstream for a SLSA attestation over sample data is the wrong ask. Same reasoning already applied to only-in-rebuild output (#1123).
- Requiring *both* segments keeps the rule narrow: `tests/bin/helper.exe` and a shipped top-level `fixtures/` tree are still flagged.

Unblocks #1218 (anchore/sbom-action v0.24.2), which ships `tests/fixtures/image-debian-match-coverage/java/example-java-app-maven-0.1.0.jar` for SBOM coverage tests and was rejected as an unverifiable in-tree binary.

## Test plan

- New `test_test_fixture_binaries_exempt` covers the exact #1218 path, four other conventional spellings, and three precision cases that must stay flagged.
- `uv run pytest utils/tests/` - 351 passed.
- `prek run --all-files` - clean.
