### PR TITLE
stash/restore: back off between download retries

### DIFF
--- a/stash/restore/action.yml
+++ b/stash/restore/action.yml
@@ -52,6 +52,12 @@ inputs:
       the download will be retried until it succeeds or this many attempts have been
       made. Other exit codes are not retried.
     default: "3"
+  retry-delay:
+    description: >
+      Base number of seconds to wait between download attempts. The wait grows
+      exponentially with each attempt and is fully jittered, so jobs that fail
+      together do not retry together. Set to "0" to retry immediately.
+    default: "5"
   fail-on-download:
     description: >
       If true, the action will fail when a stash artifact was found but could not be
@@ -165,6 +171,7 @@ runs:
         STASH_DIR: "${{ steps.mung.outputs.stash_path }}"
         CLEAN: "${{ inputs.clean }}"
         RETRY_COUNT: "${{ inputs.retry-count }}"
+        RETRY_DELAY: "${{ inputs.retry-delay }}"
         FAIL_ON_DOWNLOAD: "${{ inputs.fail-on-download }}"
       run: |
         import os, sys

--- a/stash/restore/download_stash.py
+++ b/stash/restore/download_stash.py
@@ -19,16 +19,23 @@ Required env vars:
   STASH_DIR        - destination directory
   REPO             - owner/name of the repository
   RETRY_COUNT      - max download attempts (retries on gh exit code 1)
+  RETRY_DELAY      - base seconds for the backoff between attempts
   FAIL_ON_DOWNLOAD - "true" to exit 1 on download failure, else "false"
   CLEAN            - "true" to remove STASH_DIR before downloading
   GITHUB_OUTPUT    - file to write the `download` output to
 """
 
 import os
+import random
 import shutil
 import subprocess
 import sys
+import time
 from collections.abc import Callable, Mapping
+
+# Upper bound for a single backoff sleep, so a large RETRY_COUNT cannot
+# stall a job for minutes on end.
+MAX_RETRY_DELAY = 60.0
 
 
 def run_gh_download(run_id: str, name: str, dest: str, repo: str) -> int:
@@ -44,22 +51,37 @@ def run_gh_download(run_id: str, name: str, dest: str, repo: str) -> int:
     ).returncode
 
 
+def compute_backoff(attempt: int, base_delay: float, rand: Callable[[], float]) -> float:
+    """Return the number of seconds to wait after a failed ``attempt``.
+
+    Exponential growth with full jitter: the artifact backend resets
+    connections when many jobs of the same matrix pull the same large
+    stash at once, so retries that fire back-to-back all land inside the
+    same congestion window. Randomising the whole interval spreads the
+    retrying jobs out instead of re-synchronising them.
+    """
+    return rand() * min(MAX_RETRY_DELAY, base_delay * 2 ** (attempt - 1))
+
+
 def download_stash(
     env: Mapping[str, str],
     run_download: Callable[[str, str, str, str], int] = run_gh_download,
+    sleep: Callable[[float], None] = time.sleep,
+    rand: Callable[[], float] = random.random,
 ) -> int:
     """Run the clean/retry/fail-on-download logic.
 
     Returns the desired process exit code (0 for success or tolerated
     failure, 1 when the download failed and ``FAIL_ON_DOWNLOAD`` is
-    ``"true"``). The ``run_download`` hook exists so tests can stub out
-    the real ``gh`` call.
+    ``"true"``). The ``run_download``, ``sleep`` and ``rand`` hooks exist
+    so tests can stub out the real ``gh`` call and the backoff wait.
     """
     stash_run_id = env["STASH_RUN_ID"]
     stash_name = env["STASH_NAME"]
     stash_dir = env["STASH_DIR"]
     repo = env["REPO"]
     retry_count = int(env.get("RETRY_COUNT", "1"))
+    retry_delay = float(env.get("RETRY_DELAY", "0"))
     fail_on_download = env.get("FAIL_ON_DOWNLOAD", "false").lower() == "true"
     clean = env.get("CLEAN", "false").lower() == "true"
     github_output = env["GITHUB_OUTPUT"]
@@ -85,6 +107,11 @@ def download_stash(
             f"::warning ::gh run download failed with exit code 1 on "
             f"attempt {attempt}."
         )
+        if attempt < retry_count:
+            delay = compute_backoff(attempt, retry_delay, rand)
+            if delay > 0:
+                print(f"Waiting {delay:.1f}s before the next attempt...", flush=True)
+                sleep(delay)
 
     with open(github_output, "a", encoding="utf-8") as f:
         f.write(f"download={download}\n")

--- a/stash/restore/test_download_stash.py
+++ b/stash/restore/test_download_stash.py
@@ -17,7 +17,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from download_stash import download_stash
+from download_stash import MAX_RETRY_DELAY, compute_backoff, download_stash
 
 
 class FakeGh:
@@ -38,8 +38,19 @@ class FakeGh:
         return self.codes[idx]
 
 
+class FakeSleep:
+    """Records the backoff waits instead of actually sleeping."""
+
+    def __init__(self):
+        self.waits = []
+
+    def __call__(self, seconds):
+        self.waits.append(seconds)
+
+
 class TestDownloadStash(unittest.TestCase):
     def setUp(self):
+        self.sleep = FakeSleep()
         self._tmp = tempfile.TemporaryDirectory()
         self.tmp = Path(self._tmp.name)
         self.stash_dir = self.tmp / "target"
@@ -57,6 +68,7 @@ class TestDownloadStash(unittest.TestCase):
             "STASH_DIR": str(self.stash_dir),
             "REPO": "test/repo",
             "RETRY_COUNT": "3",
+            "RETRY_DELAY": "0",
             "FAIL_ON_DOWNLOAD": "false",
             "CLEAN": "false",
             "GITHUB_OUTPUT": str(self.output_file),
@@ -67,40 +79,40 @@ class TestDownloadStash(unittest.TestCase):
     def read_output(self):
         return self.output_file.read_text()
 
+    def run_download_stash(self, env, gh, rand=lambda: 1.0):
+        return download_stash(env, run_download=gh, sleep=self.sleep, rand=rand)
+
     def test_success_first_attempt(self):
         gh = FakeGh([0])
-        rc = download_stash(self.env(), run_download=gh)
+        rc = self.run_download_stash(self.env(), gh)
         self.assertEqual(rc, 0)
         self.assertIn("download=success", self.read_output())
         self.assertEqual(len(gh.calls), 1)
 
     def test_retry_on_exit_1_until_success(self):
         gh = FakeGh([1, 1, 0])
-        rc = download_stash(self.env(), run_download=gh)
+        rc = self.run_download_stash(self.env(), gh)
         self.assertEqual(rc, 0)
         self.assertIn("download=success", self.read_output())
         self.assertEqual(len(gh.calls), 3)
 
     def test_all_retries_fail_tolerated(self):
         gh = FakeGh([1])
-        rc = download_stash(self.env(), run_download=gh)
+        rc = self.run_download_stash(self.env(), gh)
         self.assertEqual(rc, 0)
         self.assertIn("download=failed", self.read_output())
         self.assertEqual(len(gh.calls), 3)
 
     def test_all_retries_fail_fail_on_download(self):
         gh = FakeGh([1])
-        rc = download_stash(
-            self.env(RETRY_COUNT="2", FAIL_ON_DOWNLOAD="true"),
-            run_download=gh,
-        )
+        rc = self.run_download_stash(self.env(RETRY_COUNT="2", FAIL_ON_DOWNLOAD="true"), gh)
         self.assertEqual(rc, 1)
         self.assertIn("download=failed", self.read_output())
         self.assertEqual(len(gh.calls), 2)
 
     def test_non_transient_exit_not_retried(self):
         gh = FakeGh([2])
-        rc = download_stash(self.env(RETRY_COUNT="5"), run_download=gh)
+        rc = self.run_download_stash(self.env(RETRY_COUNT="5"), gh)
         self.assertEqual(rc, 0)
         self.assertIn("download=failed", self.read_output())
         self.assertEqual(len(gh.calls), 1)
@@ -108,9 +120,7 @@ class TestDownloadStash(unittest.TestCase):
     def test_clean_removes_stash_dir(self):
         (self.stash_dir / "leftover").touch()
         gh = FakeGh([0])
-        rc = download_stash(
-            self.env(CLEAN="true", RETRY_COUNT="1"), run_download=gh
-        )
+        rc = self.run_download_stash(self.env(CLEAN="true", RETRY_COUNT="1"), gh)
         self.assertEqual(rc, 0)
         self.assertFalse((self.stash_dir / "leftover").exists())
         self.assertIn("download=success", self.read_output())
@@ -118,18 +128,52 @@ class TestDownloadStash(unittest.TestCase):
     def test_clean_false_preserves_stash_dir(self):
         (self.stash_dir / "leftover").touch()
         gh = FakeGh([0])
-        rc = download_stash(
-            self.env(CLEAN="false", RETRY_COUNT="1"), run_download=gh
-        )
+        rc = self.run_download_stash(self.env(CLEAN="false", RETRY_COUNT="1"), gh)
         self.assertEqual(rc, 0)
         self.assertTrue((self.stash_dir / "leftover").exists())
 
     def test_stops_on_first_non_transient(self):
         gh = FakeGh([1, 2, 0])
-        rc = download_stash(self.env(RETRY_COUNT="5"), run_download=gh)
+        rc = self.run_download_stash(self.env(RETRY_COUNT="5"), gh)
         self.assertEqual(rc, 0)
         self.assertIn("download=failed", self.read_output())
         self.assertEqual(len(gh.calls), 2)
+
+    def test_backoff_between_transient_failures(self):
+        gh = FakeGh([1, 1, 0])
+        rc = self.run_download_stash(self.env(RETRY_DELAY="5"), gh)
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.sleep.waits, [5.0, 10.0])
+
+    def test_no_backoff_after_final_attempt(self):
+        gh = FakeGh([1])
+        self.run_download_stash(self.env(RETRY_COUNT="2", RETRY_DELAY="5"), gh)
+        self.assertEqual(len(self.sleep.waits), 1)
+
+    def test_no_backoff_on_non_transient_exit(self):
+        gh = FakeGh([2])
+        self.run_download_stash(self.env(RETRY_DELAY="5"), gh)
+        self.assertEqual(self.sleep.waits, [])
+
+    def test_zero_retry_delay_does_not_sleep(self):
+        gh = FakeGh([1, 1, 0])
+        self.run_download_stash(self.env(RETRY_DELAY="0"), gh)
+        self.assertEqual(self.sleep.waits, [])
+
+    def test_retry_delay_defaults_to_no_wait(self):
+        gh = FakeGh([1, 1, 0])
+        env = self.env()
+        del env["RETRY_DELAY"]
+        self.run_download_stash(env, gh)
+        self.assertEqual(self.sleep.waits, [])
+
+    def test_backoff_is_jittered(self):
+        gh = FakeGh([1, 1, 0])
+        self.run_download_stash(self.env(RETRY_DELAY="8"), gh, rand=lambda: 0.25)
+        self.assertEqual(self.sleep.waits, [2.0, 4.0])
+
+    def test_backoff_is_capped(self):
+        self.assertEqual(compute_backoff(20, 5.0, lambda: 1.0), MAX_RETRY_DELAY)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Code change

## Summary

`stash/restore` retried a failed `gh run download` immediately, so every
attempt landed inside the same congestion window that caused the first
failure. When many jobs of one matrix pull the same large stash at once,
the artifact backend resets connections mid-stream — and the retry loop
re-synchronised the herd instead of breaking it up.

Seen on `apache/airflow` run 34200137532: 6 of the 14 Kubernetes jobs that
started within the same 90 seconds burned all three attempts on
`read: connection reset by peer` in under two minutes, while the 20 jobs of
the earlier wave restored the same artifact without trouble. The stash was
found and intact in every case.

- Adds a `retry-delay` input (default `5`) — base seconds for the wait
  between download attempts.
- Waits with exponential growth and **full jitter**, capped at 60s per
  sleep. Full jitter is the point: spacing the retries evenly would keep
  the failing jobs in lockstep, randomising the whole interval pulls them
  apart.
- No wait after the final attempt, and none for non-transient exit codes.
- `retry-delay: "0"` restores the previous immediate-retry behaviour.

## Type of change

- [X] Bug fix
- [X] Enhancement to existing code

## Testing

`stash/restore/test_download_stash.py` — 15 tests, all passing. The
`sleep`/`rand` hooks are injected so the suite asserts the computed waits
without sleeping (runs in 0.005s). New cases cover the backoff sequence,
jitter scaling, the 60s cap, no-wait-after-last-attempt, no-wait on
non-transient exits, and both the `"0"` and unset defaults.

`ruff check` reports the same 6 pre-existing findings before and after —
no new ones.

---
Drafted-by: Claude Opus 5; reviewed by @potiuk before posting
