### PR TITLE
feat(allowlist-check): allow-list for GitHub self-repository syntax

### DIFF
--- a/allowlist-check/check_asf_allowlist.py
+++ b/allowlist-check/check_asf_allowlist.py
@@ -49,9 +49,10 @@ TRUSTED_OWNERS = {"actions", "github", "apache"}
 DEFAULT_GITHUB_YAML_GLOB = ".github/**/*.yml"
 
 # Prefixes that indicate local or non-GitHub refs (not subject to allowlist)
-# ./  — local composite actions within the same repo
-# docker:// — container actions pulled directly from a registry
-SKIPPED_PREFIXES = ("./", "docker://")
+# ./         — local composite actions within the same repo
+# docker://  — container actions pulled directly from a registry
+# $/         - local composite actions self-repository syntax, similar to ./ but recommended by GitHub
+SKIPPED_PREFIXES = ("./", "docker://", "$/")
 
 # YAML key that references a GitHub Action
 USES_KEY = "uses"

--- a/allowlist-check/test_check_asf_allowlist.py
+++ b/allowlist-check/test_check_asf_allowlist.py
@@ -239,6 +239,7 @@ class TestCollectActionRefs(unittest.TestCase):
                 steps:
                   - uses: ./local-action
                   - uses: actions/checkout@v4
+                  - uses: $/local-self-repo-action
             """,
         )
         scan_glob = os.path.join(self.tmpdir, ".github/**/*.yml")


### PR DESCRIPTION
Allow-list for newly arrived GitHub self-repository syntax ([source](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/)). This is recommended by GitHub themselves as it enables sibling actions/workflows to match the same Git ref running by the repo. The syntax is also recommended by `zizmor`.

Disclaimer: I'm from Superset and is helping fellow maintainers to adopt the more secure syntax ([PR](https://github.com/apache/superset/pull/43996)). Sibling projects can adopt this as well