### PR TITLE
allowlist-check: document the $/ self-repository prefix

### DIFF
--- a/allowlist-check/README.md
+++ b/allowlist-check/README.md
@@ -89,6 +89,7 @@ Actions from these GitHub organizations are implicitly trusted and don't need to
 ### Skipped
 
 - **Local refs** (`./`) — paths within the same repo are not subject to the org allowlist
+- **Self-repository refs** (`$/`) — same-repo paths resolved at the commit being run; GitHub's recommended form of `./`, likewise not subject to the org allowlist
 - **Docker refs** (`docker://`) — container actions pulled directly from a registry
 - **Empty YAML files** — skipped
 - **Malformed YAML files** — fails with an error


### PR DESCRIPTION
Follow-up to #1254, which added `$/` to `SKIPPED_PREFIXES` in `check_asf_allowlist.py` but left `allowlist-check/README.md` documenting only `./` and `docker://` under "Skipped".

`$/` is GitHub's [self-repository syntax](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/) (shipped 2026-07-30): a `uses:` value starting with `$/` resolves to the workflow's own repository at the exact commit being run, works everywhere the workspace-relative `./` works, and is now GitHub's recommended way to compose actions and reusable workflows within a repository. Like `./`, those refs are same-repo and therefore not subject to the org-level allowlist.

Docs-only change; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nd9Q3i3Yaz34QEU97Zmaac