### PR TITLE
utils: add org-wide queued/running Actions job snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This repository hosts GitHub Actions developed by the ASF community and approved
   - [Automatic Expiration of Old Versions](#automatic-expiration-of-old-versions)
   - [Removing a Version](#removing-a-version-manually)
 - [Auditing Repositories for Actions Security Tooling](#auditing-repositories-for-actions-security-tooling)
+- [Snapshotting Queued and Running Actions Jobs](#snapshotting-queued-and-running-actions-jobs)
 
 ## Checking the Action Usage in an ASF Project
 
@@ -550,3 +551,105 @@ When not in `--dry-run` mode, the script prompts for confirmation before creatin
 #### Idempotency
 
 The script is safe to re-run. Before creating a PR for a repository, it checks whether a PR with the branch name `asf-actions-security-audit` already exists — open, closed, or merged — and skips the repo if so.
+
+## Snapshotting Queued and Running Actions Jobs
+
+When the ASF runners feel slow, the first question is always "who is using them right now, and
+who is waiting?" The `actions-queue-status.py` script answers that across the whole organisation
+without needing org-admin rights.
+
+### Why This Matters
+
+The obvious endpoint — `GET /orgs/apache/actions/runners`, which reports each runner's `status`
+and `busy` flag — requires `admin:org`, so only Infra can call it. Everyone else debugging a slow
+queue is left guessing. Check-run state, on the other hand, is readable by anyone who can read the
+repository, and a check run maps one-to-one onto a workflow job. That is enough to see which
+repositories are consuming capacity and which are stuck behind it.
+
+There is no org-wide REST endpoint for queued jobs at all — the only alternatives are polling every
+repository one at a time or running a `workflow_job` webhook listener. This script batches the
+question into a handful of GraphQL requests instead.
+
+### Prerequisites
+
+- **Python 3.11+** and [**uv**](https://docs.astral.sh/uv/) (dependencies are declared inline via PEP 723)
+- **`gh`** (GitHub CLI, authenticated via `gh auth login`) — or pass `--github-token` with a token
+  that can read the org's repositories and use `--no-gh`
+
+### Usage
+
+```bash
+# Whole org: discover every repo with workflows, then snapshot job state
+uv run utils/actions-queue-status.py
+
+# Save the discovered repo list so later runs can skip discovery
+uv run utils/actions-queue-status.py --save-repos /tmp/asf-repos.txt
+uv run utils/actions-queue-status.py --repos-file /tmp/asf-repos.txt --top 40
+
+# Write both orderings to CSV: <path>-by-running.csv and <path>-by-queued.csv
+uv run utils/actions-queue-status.py --csv /tmp/asf-ci.csv
+
+# A single project, sampling more of its open PRs
+uv run utils/actions-queue-status.py --repos-file <(echo airflow) --prs 25
+```
+
+Output is two tables — repositories sorted by running jobs, and by queued jobs — plus a one-line
+total. `--json` prints the same data as JSON.
+
+#### Options
+
+| Flag | Description |
+|------|-------------|
+| `--org ORG` | Organisation to sweep (default: `apache`). |
+| `--batch-size N` | Repositories per GraphQL query (default: 20). |
+| `--prs N` | Open PRs sampled per repository, most recently updated first (default: 3). |
+| `--suites N` | Check suites read per commit (default: 5). |
+| `--workers N` | Batched queries in flight (default: 3). |
+| `--top N` | Rows shown per table (default: 25). |
+| `--include-archived` | Include archived repositories. |
+| `--repos-file PATH` | Skip discovery and read repository names from a file. |
+| `--save-repos PATH` | Write the discovered repository list to a file. |
+| `--csv PATH` | Write both orderings as CSV alongside `PATH`. |
+| `--json` | Print JSON instead of tables. |
+| `--github-token TOKEN` | GitHub token. Defaults to `GH_TOKEN` or `GITHUB_TOKEN`. |
+| `--no-gh` | Use Python `requests` instead of the `gh` CLI. Requires a token. |
+
+#### How Discovery Works
+
+Rather than guessing from `pushedAt` or probing each repository over REST, the discovery query
+reads the workflows directory straight out of the git tree:
+
+```graphql
+workflows: object(expression: "HEAD:.github/workflows") {
+  ... on Tree { entries { name } }
+}
+```
+
+A repository counts as using Actions only when that tree exists and holds at least one `.yml` or
+`.yaml` entry. Archived, disabled and empty repositories are skipped.
+
+#### Rate Limits
+
+A full sweep of the `apache` organisation is not free: GraphQL charges by node count, so the
+per-query cost grows with `--batch-size`, `--prs` and `--suites` together. Three safeguards keep a
+sweep inside the caller's hourly allowance:
+
+- every query asks for `rateLimit { cost remaining resetAt }`, and the sweep stops with a warning
+  once fewer than 200 points remain, reporting partial counts rather than dying;
+- transient failures (502, and rate-limit rejections) are retried with 4s/16s/64s backoff, because
+  GitHub enforces a per-minute points cap as well as the hourly one;
+- `--workers` defaults to 3 — higher concurrency reliably trips that per-minute cap mid-sweep.
+
+Note that the REST `/rate_limit` endpoint is **not** a reliable pre-flight check here: it can report
+a full GraphQL budget (`5000/5000, used=0`) while the API is actively rejecting queries with
+`RATE_LIMIT`. The `rateLimit` block returned inside each query is the trustworthy signal.
+
+#### Known Limits
+
+- `--prs` samples the most recently updated open PRs rather than all of them, so a repository with
+  hundreds of open PRs is under-counted. Raise `--prs` when focusing on one project; a full count
+  needs REST.
+- GraphQL exposes no runner identity — no labels, no runner name, no self-hosted versus
+  GitHub-hosted split. A job held back by a `concurrency` group is indistinguishable from one
+  waiting for capacity. For true runner state, Infra can use
+  `GET /orgs/apache/actions/runners` (`admin:org`), whose objects carry `status` and `busy`.

--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ total. `--json` prints the same data as JSON.
 | `--json` | Print JSON instead of tables. |
 | `--github-token TOKEN` | GitHub token. Defaults to `GH_TOKEN` or `GITHUB_TOKEN`. |
 | `--no-gh` | Use Python `requests` instead of the `gh` CLI. Requires a token. |
+| `--no-rest-fallback` | Skip the exact REST re-count for repos with more open PRs than `--prs`. |
 
 #### How Discovery Works
 
@@ -630,8 +631,18 @@ A repository counts as using Actions only when that tree exists and holds at lea
 
 #### Rate Limits
 
-A full sweep of the `apache` organisation is not free: GraphQL charges by node count, so the
-per-query cost grows with `--batch-size`, `--prs` and `--suites` together. Three safeguards keep a
+A full sweep of the `apache` organisation is not free: GraphQL charges by node count, and the cost
+climbs sharply with `--prs`. Measured over the ~1,250 `apache` repositories that use Actions, a
+sweep costs roughly 250 points at `--prs 3`, 2,700 at `--prs 5` and 21,000 at `--prs 10`, against
+a budget of 5,000 points per hour.
+
+Raising `--prs` is a worse trade than it looks. It buys coverage of *quiet* repositories -- the
+open-PR distribution is long-tailed, so `--prs 3` already covers 46% of them outright and `--prs 5`
+only reaches 57% -- and every repository it fails to cover costs about one cheap REST call instead.
+The two budgets are separate pools of 5,000, and a full REST pass uses only ~2,100-2,800 calls, so
+GraphQL points are the scarce resource, not REST calls. Keeping the cheap pass genuinely cheap is
+therefore also what keeps the sweep accurate. Each run prints the open-PR distribution during
+discovery, so the trade-off can be re-checked against the organisation as it is today. Three safeguards keep a
 sweep inside the caller's hourly allowance:
 
 - every query asks for `rateLimit { cost remaining resetAt }`, and the sweep stops with a warning
@@ -644,12 +655,37 @@ Note that the REST `/rate_limit` endpoint is **not** a reliable pre-flight check
 a full GraphQL budget (`5000/5000, used=0`) while the API is actively rejecting queries with
 `RATE_LIMIT`. The `rateLimit` block returned inside each query is the trustworthy signal.
 
+#### Why Some Repositories Are Counted Over REST
+
+GraphQL caps `pullRequests(first:)` at 100, and a sweep samples far fewer than that, so a
+repository with more open PRs than `--prs` is necessarily under-counted — `apache/airflow` reported
+0 running jobs from a 3-PR sample while REST found 176 in the same repository.
+
+So the sweep uses each API where it is strongest. Every repo's query also returns the two
+`totalCount`s that reveal whether the sample was complete: `pullRequests(states: OPEN)` and
+`checkSuites` per commit. A repository's GraphQL numbers stand only when **both** limits held --
+no more open PRs than `--prs`, and no commit carrying more check suites than `--suites`. Checking
+only the PR count is not enough: `apache/skywalking-java` has a single open PR but thirteen active
+runs on its head commit, and reading five of them reported 32 queued jobs where the true figure was
+203. Everything else is re-counted over REST, which has no org-wide endpoint but is exact per
+repository: list the runs that are still active, then count their jobs. In practice that is a small minority of repositories, so the sweep keeps
+GraphQL's batching for the bulk of the org and pays REST's per-repo cost only where it buys
+accuracy. The `source` column records which API produced each row, and `--no-rest-fallback` turns
+the second pass off.
+
 #### Known Limits
 
-- `--prs` samples the most recently updated open PRs rather than all of them, so a repository with
-  hundreds of open PRs is under-counted. Raise `--prs` when focusing on one project; a full count
-  needs REST.
-- GraphQL exposes no runner identity — no labels, no runner name, no self-hosted versus
-  GitHub-hosted split. A job held back by a `concurrency` group is indistinguishable from one
-  waiting for capacity. For true runner state, Infra can use
-  `GET /orgs/apache/actions/runners` (`admin:org`), whose objects carry `status` and `busy`.
+- Neither API attributes a job to a runner -- no labels, no runner name, no self-hosted versus
+  GitHub-hosted split -- so a job held back by a `concurrency` group cannot be told apart from one
+  waiting for capacity. Runs blocked on maintainer approval are reported separately in the
+  `runs_awaiting_approval` column, since those are not capacity waits either. For true runner
+  state, Infra can use `GET /orgs/apache/actions/runners` (`admin:org`), whose objects carry
+  `status` and `busy`.
+- GraphQL reaches workflow runs through check suites, which hang off commits, so the cheap pass
+  sees only the default branch head and open PR heads. A run started by a push to another branch,
+  by a tag, or by a schedule on a non-default branch is invisible to it, and no `totalCount`
+  reveals that. Such a repository is only counted if something else routes it to REST. In a paired
+  run against a full REST sweep the residual difference was 8 repositories out of ~160, all small,
+  and indistinguishable from ordinary churn over the twenty minutes separating the two passes.
+- The snapshot is a moment, not an average. A busy organisation moves enough in twenty minutes to
+  change totals by a third, so compare runs taken close together or not at all.

--- a/utils/actions-queue-status.py
+++ b/utils/actions-queue-status.py
@@ -39,7 +39,9 @@ Two phases, both GraphQL:
    tree directly, so a repo counts as using Actions only when it really has workflow
    files on its default branch.
 2. Status — batch the surviving repos into aliased queries (one request covers many
-   repos) and count check runs, which map one-to-one onto workflow jobs.
+   repos) and count check runs, which map one-to-one onto workflow jobs. A repo with
+   more open PRs than the sample size cannot be covered that way, so those — and only
+   those — are re-counted exactly over REST.
 
 Usage:
     uv run utils/actions-queue-status.py
@@ -66,6 +68,13 @@ from rich.table import Table
 console = Console(stderr=True)
 
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+GITHUB_REST_URL = "https://api.github.com"
+
+# Run states that still hold — or are still waiting for — a runner. "waiting" and
+# "action_required" are approval gates rather than capacity waits, and are counted
+# separately so the two are not confused.
+ACTIVE_RUN_STATES = {"queued", "in_progress", "waiting", "pending", "requested", "action_required"}
+APPROVAL_RUN_STATES = {"waiting", "action_required", "requested", "pending"}
 
 # GitHub answers a query it considers too expensive with a bare 502 rather than a typed
 # error, and enforces the points budget per minute as well as per hour — so a burst
@@ -85,6 +94,7 @@ query($org: String!, $after: String) {
         isArchived
         isDisabled
         defaultBranchRef { name }
+        pullRequests(states: OPEN) { totalCount }
         workflows: object(expression: "HEAD:.github/workflows") {
           ... on Tree { entries { name } }
         }
@@ -100,11 +110,13 @@ fragment CI on Repository {
   nameWithOwner
   defaultBranchRef { target { ... on Commit { ...Suites } } }
   pullRequests(states: OPEN, first: %(prs)d, orderBy: {field: UPDATED_AT, direction: DESC}) {
+    totalCount
     nodes { commits(last: 1) { nodes { commit { ...Suites } } } }
   }
 }
 fragment Suites on Commit {
   checkSuites(first: %(suites)d) {
+    totalCount
     nodes {
       status
       workflowRun { workflow { name } }
@@ -115,7 +127,15 @@ fragment Suites on Commit {
 }
 """
 
-CSV_HEADER = ["repo", "queued_jobs", "running_jobs", "suites_queued", "suites_in_progress", "workflows"]
+CSV_HEADER = [
+    "repo",
+    "queued_jobs",
+    "running_jobs",
+    "open_prs",
+    "runs_awaiting_approval",
+    "source",
+    "workflows",
+]
 
 
 class BudgetExhausted(RuntimeError):
@@ -201,6 +221,33 @@ class GraphQLClient:
             time.sleep(4 ** (attempt + 1))
         return {"__error__": error}
 
+    def rest(self, path: str, attempts: int = 3) -> dict | None:
+        """GET a REST endpoint, retrying transient failures. None when it cannot be read."""
+        for attempt in range(attempts):
+            if self.use_requests:
+                response = requests.get(
+                    f"{GITHUB_REST_URL}/{path}",
+                    headers={"Authorization": f"bearer {self.token}", "Accept": "application/json"},
+                    timeout=60,
+                )
+                if response.status_code == 200:
+                    return response.json()
+                error = f"HTTP {response.status_code}"
+            else:
+                result = subprocess.run(
+                    ["gh", "api", "--method", "GET", path], capture_output=True, text=True, check=False
+                )
+                if result.returncode == 0:
+                    try:
+                        return json.loads(result.stdout)
+                    except json.JSONDecodeError:
+                        return None
+                error = (result.stderr or "")[:150]
+            if not any(marker in error for marker in RETRYABLE):
+                return None
+            time.sleep(5 * (attempt + 1))
+        return None
+
     def check_budget(self) -> None:
         """Stop the sweep before it drains the caller's hourly GraphQL allowance."""
         remaining = self.remaining
@@ -227,9 +274,26 @@ def has_workflows(node: dict) -> bool:
     return any(entry["name"].endswith((".yml", ".yaml")) for entry in tree.get("entries", []))
 
 
+def report_pr_distribution(open_pr_counts: list[int]) -> None:
+    """Show how many repos each candidate --prs value would cover outright.
+
+    The knee of this curve is what --prs should be set to: below it, GraphQL cannot cover
+    the repo and REST re-counts it anyway; above it, the sweep pays node cost for PRs that
+    almost no repository has.
+    """
+    if not open_pr_counts:
+        return
+    total = len(open_pr_counts)
+    console.print("[cyan]Open-PR distribution (repos GraphQL could cover outright):[/]")
+    for threshold in (1, 3, 5, 10, 25, 50):
+        covered = sum(1 for count in open_pr_counts if count <= threshold)
+        console.print(f"[dim]  --prs {threshold:>3}: {covered:>5} / {total} repos ({covered / total:.0%})[/]")
+
+
 def discover_repos(client: GraphQLClient, org: str, include_archived: bool) -> list[str]:
     """Return every non-archived repo in the org that defines workflow files."""
     repos: list[str] = []
+    open_pr_counts: list[int] = []
     scanned = 0
     cursor = None
     while True:
@@ -252,6 +316,7 @@ def discover_repos(client: GraphQLClient, org: str, include_archived: bool) -> l
                 continue
             if has_workflows(node):
                 repos.append(node["name"])
+                open_pr_counts.append((node.get("pullRequests") or {}).get("totalCount", 0))
         console.print(
             f"[dim]  scanned {scanned} repos, {len(repos)} with workflows "
             f"(points left {client.remaining})[/]"
@@ -260,6 +325,7 @@ def discover_repos(client: GraphQLClient, org: str, include_archived: bool) -> l
             break
         cursor = page["pageInfo"]["endCursor"]
     console.print(f"[cyan]Discovery: {scanned} repos scanned, {len(repos)} use GitHub Actions[/]")
+    report_pr_distribution(open_pr_counts)
     return repos
 
 
@@ -290,9 +356,12 @@ def collect_commits(repo_node: dict) -> list[dict]:
 def summarize_repo(repo_node: dict) -> dict:
     """Reduce one repo's check suites to queued/running job counts."""
     queued = running = suites_queued = suites_running = 0
+    max_suites_on_a_commit = 0
     workflows: dict[str, int] = {}
     for commit in collect_commits(repo_node):
-        for suite in (commit.get("checkSuites") or {}).get("nodes", []):
+        suite_page = commit.get("checkSuites") or {}
+        max_suites_on_a_commit = max(max_suites_on_a_commit, suite_page.get("totalCount", 0))
+        for suite in suite_page.get("nodes", []):
             suite_queued = suite["queued"]["totalCount"]
             suite_running = suite["running"]["totalCount"]
             queued += suite_queued
@@ -311,6 +380,9 @@ def summarize_repo(repo_node: dict) -> dict:
         "running_jobs": running,
         "suites_queued": suites_queued,
         "suites_in_progress": suites_running,
+        "open_prs": (repo_node.get("pullRequests") or {}).get("totalCount", 0),
+        "max_suites_on_a_commit": max_suites_on_a_commit,
+        "source": "graphql",
         "workflows": workflows,
     }
 
@@ -336,6 +408,46 @@ def run_batch(client: GraphQLClient, org: str, names: list[str], prs: int, suite
     ]
 
 
+def recount_over_rest(client: GraphQLClient, org: str, row: dict) -> dict:
+    """Re-count one repo exactly over REST, for repos the PR window cannot cover.
+
+    GraphQL caps `pullRequests(first:)` at 100 and the sweep samples far fewer, so a repo
+    with more open PRs than the sample size is necessarily under-counted. REST has no
+    org-wide equivalent, but per repo it is exact: list the runs that are still active and
+    count their jobs.
+    """
+    name = row["repo"].split("/", 1)[1]
+    runs = client.rest(f"repos/{org}/{name}/actions/runs?per_page=100")
+    if not runs:
+        return row  # Keep the GraphQL sample rather than reporting a repo as idle.
+    active = [run for run in runs.get("workflow_runs", []) if run.get("status") in ACTIVE_RUN_STATES]
+    queued = running = awaiting_approval = 0
+    workflows: dict[str, int] = {}
+    for run in active:
+        if run["status"] in APPROVAL_RUN_STATES:
+            awaiting_approval += 1
+        jobs = client.rest(f"repos/{org}/{name}/actions/runs/{run['id']}/jobs?per_page=100&filter=latest")
+        if not jobs:
+            continue
+        for job in jobs.get("jobs", []):
+            if job["status"] not in {"queued", "in_progress"}:
+                continue
+            if job["status"] == "in_progress":
+                running += 1
+            else:
+                queued += 1
+            name_of_run = run.get("name") or "?"
+            workflows[name_of_run] = workflows.get(name_of_run, 0) + 1
+    return {
+        **row,
+        "queued_jobs": queued,
+        "running_jobs": running,
+        "runs_awaiting_approval": awaiting_approval,
+        "source": "rest",
+        "workflows": workflows,
+    }
+
+
 def csv_path(base: str, ordering: str) -> str:
     """Derive the per-ordering CSV filename from the --csv argument."""
     stem, dot, extension = base.rpartition(".")
@@ -349,8 +461,9 @@ def csv_row(row: dict) -> list:
         row["repo"],
         row["queued_jobs"],
         row["running_jobs"],
-        row["suites_queued"],
-        row["suites_in_progress"],
+        row.get("open_prs", 0),
+        row.get("runs_awaiting_approval", ""),
+        row.get("source", "graphql"),
         workflows,
     ]
 
@@ -363,7 +476,15 @@ def write_csv(path: str, rows: list[dict], totals: dict) -> None:
         for row in rows:
             writer.writerow(csv_row(row))
         writer.writerow(
-            ["TOTAL", totals["queued_jobs"], totals["running_jobs"], "", "", f"repos={totals['repos_active']}"]
+            [
+                "TOTAL",
+                totals["queued_jobs"],
+                totals["running_jobs"],
+                "",
+                "",
+                "",
+                f"repos={totals['repos_active']}",
+            ]
         )
     console.print(f"[green]Wrote {path}[/]")
 
@@ -374,6 +495,7 @@ def render_table(title: str, rows: list[dict], top: int) -> None:
     table.add_column("Repository")
     table.add_column("Queued", justify="right")
     table.add_column("Running", justify="right")
+    table.add_column("Source")
     table.add_column("Workflows")
     for row in rows[:top]:
         workflows = ", ".join(sorted(row["workflows"])) or "-"
@@ -381,7 +503,8 @@ def render_table(title: str, rows: list[dict], top: int) -> None:
             row["repo"],
             str(row["queued_jobs"]),
             str(row["running_jobs"]),
-            workflows[:60],
+            row.get("source", "graphql"),
+            workflows[:50],
         )
     console.print(table)
 
@@ -390,14 +513,21 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Report repos with GitHub Actions jobs queued or running right now.",
         epilog=(
-            "Caveats: --prs samples the most recently updated open PRs rather than every "
-            "one, so a very busy repo is under-counted; and GraphQL exposes no runner "
-            "identity, so a job held by a concurrency group looks like one waiting for "
-            "capacity. Use the REST runner endpoints (admin:org) for true runner state."
+            "Repos the GraphQL sample cannot cover — more open PRs than --prs, or more "
+            "check suites on a commit than --suites — are re-counted exactly over REST, so "
+            "the totals are not a sample. Remaining caveat: neither API attributes a job to a "
+            "runner, so a job held by a concurrency group cannot be told apart from one "
+            "waiting for capacity — runs blocked on approval are reported separately in "
+            "runs_awaiting_approval. Use the REST runner endpoints (admin:org) for true "
+            "runner state."
         ),
     )
     parser.add_argument("--org", default="apache", help="organisation to sweep (default: apache)")
     parser.add_argument("--batch-size", type=int, default=20, help="repos per GraphQL query")
+    # GraphQL's node cost climbs sharply with this: measured over the ~1250 apache repos
+    # with workflows, a sweep costs ~250 points at 3, ~2700 at 5 and ~21000 at 10, against
+    # a 5000/hour budget. Raising it only buys coverage of quiet repos, and those cost one
+    # cheap REST call each — so the low value is both cheaper and no less accurate.
     parser.add_argument("--prs", type=int, default=3, help="open PRs sampled per repo")
     parser.add_argument("--suites", type=int, default=5, help="check suites read per commit")
     # Three is about the most this survives: GitHub enforces a per-minute points cap as
@@ -411,6 +541,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--json", action="store_true", help="print JSON instead of tables")
     parser.add_argument("--github-token", help="GitHub token (default: GH_TOKEN / GITHUB_TOKEN)")
     parser.add_argument("--no-gh", action="store_true", help="use requests instead of the gh CLI")
+    parser.add_argument(
+        "--no-rest-fallback",
+        action="store_true",
+        help="skip the exact REST re-count for repos the GraphQL sample could not cover",
+    )
     return parser.parse_args()
 
 
@@ -449,6 +584,28 @@ def main() -> int:
                 break
             if done % 10 == 0:
                 console.print(f"[dim]  {done}/{len(batches)} batches (points left {client.remaining})[/]")
+
+    # The GraphQL pass covered a repo exhaustively only if *both* of its sampling limits
+    # held: no more open PRs than --prs, and no commit carrying more check suites than
+    # --suites. Checking only the first is not enough — a repo with a single open PR can
+    # still have a dozen suites on its head commit, and reading five of them under-counts
+    # it badly. Everything else is re-counted over REST, which is exact per repo.
+    incomplete = [
+        row
+        for row in results
+        if row.get("open_prs", 0) > args.prs or row.get("max_suites_on_a_commit", 0) > args.suites
+    ]
+    if incomplete and not args.no_rest_fallback:
+        console.print(
+            f"[cyan]Re-counting {len(incomplete)} repos over REST (more than {args.prs} open PRs "
+            f"or more than {args.suites} check suites on a commit, so the GraphQL sample is "
+            f"partial)[/]"
+        )
+        exact_by_repo = {}
+        with ThreadPoolExecutor(max_workers=args.workers) as pool:
+            for row in pool.map(lambda item: recount_over_rest(client, args.org, item), incomplete):
+                exact_by_repo[row["repo"]] = row
+        results = [exact_by_repo.get(row["repo"], row) for row in results]
 
     active = [row for row in results if row["queued_jobs"] or row["running_jobs"]]
     by_running = sorted(active, key=lambda row: (-row["running_jobs"], -row["queued_jobs"], row["repo"]))

--- a/utils/actions-queue-status.py
+++ b/utils/actions-queue-status.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "requests>=2.31",
+#     "rich>=13.0",
+# ]
+# ///
+
+"""
+Report which ASF repositories currently have GitHub Actions jobs queued or running.
+
+Answers "who is using the runners right now, and who is waiting" without org-admin
+rights: the self-hosted runner endpoints need `admin:org`, but check-run state is
+readable by anyone who can read the repo.
+
+Two phases, both GraphQL:
+
+1. Discovery — page through the org's repositories and read the `.github/workflows`
+   tree directly, so a repo counts as using Actions only when it really has workflow
+   files on its default branch.
+2. Status — batch the surviving repos into aliased queries (one request covers many
+   repos) and count check runs, which map one-to-one onto workflow jobs.
+
+Usage:
+    uv run utils/actions-queue-status.py
+    uv run utils/actions-queue-status.py --csv /tmp/asf-ci.csv
+    uv run utils/actions-queue-status.py --save-repos /tmp/repos.txt
+    uv run utils/actions-queue-status.py --repos-file /tmp/repos.txt --top 40
+"""
+
+import argparse
+import csv
+import json
+import os
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+from rich.console import Console
+from rich.table import Table
+
+console = Console(stderr=True)
+
+GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+
+# GitHub answers a query it considers too expensive with a bare 502 rather than a typed
+# error, and enforces the points budget per minute as well as per hour — so a burst
+# trips it even when the hourly balance looks healthy. Both are worth waiting out.
+RETRYABLE = ("502", "503", "504", "rate limit", "RATE_LIMIT", "secondary rate", "timeout")
+
+# Points held back so a sweep never leaves the caller's hourly budget at zero.
+BUDGET_FLOOR = 200
+
+REPO_PAGE_QUERY = """
+query($org: String!, $after: String) {
+  organization(login: $org) {
+    repositories(first: 100, after: $after, orderBy: {field: PUSHED_AT, direction: DESC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        name
+        isArchived
+        isDisabled
+        defaultBranchRef { name }
+        workflows: object(expression: "HEAD:.github/workflows") {
+          ... on Tree { entries { name } }
+        }
+      }
+    }
+  }
+  rateLimit { cost remaining resetAt }
+}
+"""
+
+STATUS_FRAGMENTS = """
+fragment CI on Repository {
+  nameWithOwner
+  defaultBranchRef { target { ... on Commit { ...Suites } } }
+  pullRequests(states: OPEN, first: %(prs)d, orderBy: {field: UPDATED_AT, direction: DESC}) {
+    nodes { commits(last: 1) { nodes { commit { ...Suites } } } }
+  }
+}
+fragment Suites on Commit {
+  checkSuites(first: %(suites)d) {
+    nodes {
+      status
+      workflowRun { workflow { name } }
+      queued:  checkRuns(first: 1, filterBy: {status: QUEUED})      { totalCount }
+      running: checkRuns(first: 1, filterBy: {status: IN_PROGRESS}) { totalCount }
+    }
+  }
+}
+"""
+
+CSV_HEADER = ["repo", "queued_jobs", "running_jobs", "suites_queued", "suites_in_progress", "workflows"]
+
+
+class BudgetExhausted(RuntimeError):
+    """Raised when the GraphQL points budget runs too low to keep querying safely."""
+
+
+class GraphQLClient:
+    """Minimal GraphQL client over the `gh` CLI, or `requests` when `--no-gh` is given.
+
+    Tracks the points balance reported by each query. The in-query `rateLimit` block is
+    the only trustworthy source: the REST `/rate_limit` endpoint keeps reporting a full
+    GraphQL budget while the API is actively rejecting queries as rate limited.
+    """
+
+    def __init__(self, token: str | None = None, use_requests: bool = False):
+        self.token = token
+        self.use_requests = use_requests
+        self._lock = threading.Lock()
+        self._remaining: int | None = None
+        if use_requests and not token:
+            raise SystemExit("--no-gh requires --github-token, GH_TOKEN or GITHUB_TOKEN")
+        if not use_requests and not shutil.which("gh"):
+            raise SystemExit("gh CLI not found — install it, or use --no-gh with a token")
+
+    @property
+    def remaining(self) -> int | None:
+        """Return the points balance reported by the most recent successful query."""
+        with self._lock:
+            return self._remaining
+
+    def _note_budget(self, payload: dict) -> None:
+        limit = (payload.get("data") or {}).get("rateLimit")
+        if limit:
+            with self._lock:
+                self._remaining = limit["remaining"]
+
+    def _call_gh(self, query: str, variables: dict) -> tuple[dict | None, str]:
+        cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+        for key, value in variables.items():
+            cmd.extend(["-f", f"{key}={value}"])
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            return None, (result.stderr or result.stdout).strip()[:200]
+        try:
+            return json.loads(result.stdout), ""
+        except json.JSONDecodeError:
+            return None, result.stdout.strip()[:200]
+
+    def _call_requests(self, query: str, variables: dict) -> tuple[dict | None, str]:
+        response = requests.post(
+            GITHUB_GRAPHQL_URL,
+            headers={"Authorization": f"bearer {self.token}", "Accept": "application/json"},
+            json={"query": query, "variables": variables},
+            timeout=60,
+        )
+        if response.status_code != 200:
+            return None, f"HTTP {response.status_code}: {response.text[:150]}"
+        return response.json(), ""
+
+    def query(self, query: str, variables: dict | None = None, attempts: int = 4) -> dict:
+        """Run a query, retrying transient failures, and return the payload.
+
+        On give-up the returned dict carries `__error__` instead of raising: callers
+        decide whether a failed repo is fatal or merely skipped.
+        """
+        variables = variables or {}
+        error = "no attempt made"
+        for attempt in range(attempts):
+            payload, error = (
+                self._call_requests(query, variables)
+                if self.use_requests
+                else self._call_gh(query, variables)
+            )
+            if payload is not None and not payload.get("errors"):
+                self._note_budget(payload)
+                return payload
+            if payload is not None and payload.get("errors"):
+                error = json.dumps(payload["errors"])[:200]
+            if not any(marker in error for marker in RETRYABLE):
+                break
+            # 4s, 16s, 64s. The per-minute points cap needs real time to drain; a tight
+            # retry only burns more of the budget it is waiting on.
+            time.sleep(4 ** (attempt + 1))
+        return {"__error__": error}
+
+    def check_budget(self) -> None:
+        """Stop the sweep before it drains the caller's hourly GraphQL allowance."""
+        remaining = self.remaining
+        if remaining is not None and remaining < BUDGET_FLOOR:
+            raise BudgetExhausted(f"stopping with {remaining} GraphQL points left")
+
+
+def resolve_token(args: argparse.Namespace) -> str | None:
+    """Resolve the token: --github-token, then GH_TOKEN, then GITHUB_TOKEN."""
+    if args.github_token:
+        return args.github_token
+    for name in ("GH_TOKEN", "GITHUB_TOKEN"):
+        value = os.environ.get(name)
+        if value:
+            return value
+    return None
+
+
+def has_workflows(node: dict) -> bool:
+    """Report whether the repo's default branch carries at least one workflow file."""
+    tree = node.get("workflows")
+    if not tree:
+        return False
+    return any(entry["name"].endswith((".yml", ".yaml")) for entry in tree.get("entries", []))
+
+
+def discover_repos(client: GraphQLClient, org: str, include_archived: bool) -> list[str]:
+    """Return every non-archived repo in the org that defines workflow files."""
+    repos: list[str] = []
+    scanned = 0
+    cursor = None
+    while True:
+        variables = {"org": org}
+        if cursor:
+            variables["after"] = cursor
+        payload = client.query(REPO_PAGE_QUERY, variables)
+        if "__error__" in payload:
+            # Partial discovery silently under-reports the org, which is worse than no
+            # answer at all — fail loudly and say how far the paging got.
+            raise SystemExit(
+                f"discovery failed after {scanned} repos (cursor {cursor}): {payload['__error__']}"
+            )
+        page = payload["data"]["organization"]["repositories"]
+        for node in page["nodes"]:
+            scanned += 1
+            if node["isDisabled"] or (node["isArchived"] and not include_archived):
+                continue
+            if not node.get("defaultBranchRef"):
+                continue
+            if has_workflows(node):
+                repos.append(node["name"])
+        console.print(
+            f"[dim]  scanned {scanned} repos, {len(repos)} with workflows "
+            f"(points left {client.remaining})[/]"
+        )
+        if not page["pageInfo"]["hasNextPage"]:
+            break
+        cursor = page["pageInfo"]["endCursor"]
+    console.print(f"[cyan]Discovery: {scanned} repos scanned, {len(repos)} use GitHub Actions[/]")
+    return repos
+
+
+def build_status_query(org: str, names: list[str], prs: int, suites: int) -> str:
+    """Build one aliased query covering every repo in the batch."""
+    aliases = "\n".join(
+        f'  r{index}: repository(owner: "{org}", name: "{name}") {{ ...CI }}'
+        for index, name in enumerate(names)
+    )
+    budget = "  rateLimit { cost remaining resetAt }"
+    fragments = STATUS_FRAGMENTS % {"prs": prs, "suites": suites}
+    return f"query {{\n{aliases}\n{budget}\n}}\n{fragments}"
+
+
+def collect_commits(repo_node: dict) -> list[dict]:
+    """Flatten a repo's default-branch head and open-PR heads into a commit list."""
+    commits = []
+    head = (repo_node.get("defaultBranchRef") or {}).get("target")
+    if head:
+        commits.append(head)
+    for pull_request in (repo_node.get("pullRequests") or {}).get("nodes", []):
+        for entry in (pull_request.get("commits") or {}).get("nodes", []):
+            if entry.get("commit"):
+                commits.append(entry["commit"])
+    return commits
+
+
+def summarize_repo(repo_node: dict) -> dict:
+    """Reduce one repo's check suites to queued/running job counts."""
+    queued = running = suites_queued = suites_running = 0
+    workflows: dict[str, int] = {}
+    for commit in collect_commits(repo_node):
+        for suite in (commit.get("checkSuites") or {}).get("nodes", []):
+            suite_queued = suite["queued"]["totalCount"]
+            suite_running = suite["running"]["totalCount"]
+            queued += suite_queued
+            running += suite_running
+            if suite["status"] == "QUEUED":
+                suites_queued += 1
+            elif suite["status"] == "IN_PROGRESS":
+                suites_running += 1
+            run = suite.get("workflowRun")
+            if run and (suite_queued + suite_running):
+                name = run["workflow"]["name"]
+                workflows[name] = workflows.get(name, 0) + suite_queued + suite_running
+    return {
+        "repo": repo_node["nameWithOwner"],
+        "queued_jobs": queued,
+        "running_jobs": running,
+        "suites_queued": suites_queued,
+        "suites_in_progress": suites_running,
+        "workflows": workflows,
+    }
+
+
+def run_batch(client: GraphQLClient, org: str, names: list[str], prs: int, suites: int) -> list[dict]:
+    """Query one batch, halving it on failure so one heavy repo cannot sink the rest.
+
+    Halving is why the budget has to be checked here and not only by the caller: a batch
+    that splits all the way down issues far more queries than the plan accounted for.
+    """
+    client.check_budget()
+    payload = client.query(build_status_query(org, names, prs, suites))
+    if "__error__" in payload or not payload.get("data"):
+        if len(names) == 1:
+            console.print(f"[yellow]  skipped {names[0]}: {payload.get('__error__')}[/]")
+            return []
+        middle = len(names) // 2
+        return run_batch(client, org, names[:middle], prs, suites) + run_batch(
+            client, org, names[middle:], prs, suites
+        )
+    return [
+        summarize_repo(node) for key, node in payload["data"].items() if node and key != "rateLimit"
+    ]
+
+
+def csv_path(base: str, ordering: str) -> str:
+    """Derive the per-ordering CSV filename from the --csv argument."""
+    stem, dot, extension = base.rpartition(".")
+    return f"{stem}-{ordering}{dot}{extension}" if dot else f"{base}-{ordering}"
+
+
+def csv_row(row: dict) -> list:
+    """Flatten one repo summary into CSV cells."""
+    workflows = "; ".join(f"{name}={count}" for name, count in sorted(row["workflows"].items()))
+    return [
+        row["repo"],
+        row["queued_jobs"],
+        row["running_jobs"],
+        row["suites_queued"],
+        row["suites_in_progress"],
+        workflows,
+    ]
+
+
+def write_csv(path: str, rows: list[dict], totals: dict) -> None:
+    """Write one ordering of the snapshot as CSV."""
+    with open(path, "w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(CSV_HEADER)
+        for row in rows:
+            writer.writerow(csv_row(row))
+        writer.writerow(
+            ["TOTAL", totals["queued_jobs"], totals["running_jobs"], "", "", f"repos={totals['repos_active']}"]
+        )
+    console.print(f"[green]Wrote {path}[/]")
+
+
+def render_table(title: str, rows: list[dict], top: int) -> None:
+    """Print one ordering of the snapshot as a rich table."""
+    table = Table(title=title, title_justify="left")
+    table.add_column("Repository")
+    table.add_column("Queued", justify="right")
+    table.add_column("Running", justify="right")
+    table.add_column("Workflows")
+    for row in rows[:top]:
+        workflows = ", ".join(sorted(row["workflows"])) or "-"
+        table.add_row(
+            row["repo"],
+            str(row["queued_jobs"]),
+            str(row["running_jobs"]),
+            workflows[:60],
+        )
+    console.print(table)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Report repos with GitHub Actions jobs queued or running right now.",
+        epilog=(
+            "Caveats: --prs samples the most recently updated open PRs rather than every "
+            "one, so a very busy repo is under-counted; and GraphQL exposes no runner "
+            "identity, so a job held by a concurrency group looks like one waiting for "
+            "capacity. Use the REST runner endpoints (admin:org) for true runner state."
+        ),
+    )
+    parser.add_argument("--org", default="apache", help="organisation to sweep (default: apache)")
+    parser.add_argument("--batch-size", type=int, default=20, help="repos per GraphQL query")
+    parser.add_argument("--prs", type=int, default=3, help="open PRs sampled per repo")
+    parser.add_argument("--suites", type=int, default=5, help="check suites read per commit")
+    # Three is about the most this survives: GitHub enforces a per-minute points cap as
+    # well as the hourly one, and six workers tripped it partway through an org sweep.
+    parser.add_argument("--workers", type=int, default=3, help="batched queries in flight")
+    parser.add_argument("--top", type=int, default=25, help="rows shown per table")
+    parser.add_argument("--include-archived", action="store_true", help="include archived repos")
+    parser.add_argument("--repos-file", help="skip discovery; newline-separated repo names")
+    parser.add_argument("--save-repos", help="write the discovered repo list here")
+    parser.add_argument("--csv", metavar="PATH", help="write both orderings as CSV next to PATH")
+    parser.add_argument("--json", action="store_true", help="print JSON instead of tables")
+    parser.add_argument("--github-token", help="GitHub token (default: GH_TOKEN / GITHUB_TOKEN)")
+    parser.add_argument("--no-gh", action="store_true", help="use requests instead of the gh CLI")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    client = GraphQLClient(token=resolve_token(args), use_requests=args.no_gh)
+
+    if args.repos_file:
+        with open(args.repos_file) as handle:
+            repos = [line.strip() for line in handle if line.strip()]
+        console.print(f"[cyan]Loaded {len(repos)} repos from {args.repos_file}[/]")
+    else:
+        repos = discover_repos(client, args.org, args.include_archived)
+        if args.save_repos:
+            with open(args.save_repos, "w") as handle:
+                handle.write("\n".join(repos) + "\n")
+            console.print(f"[green]Wrote {args.save_repos}[/]")
+
+    batches = [repos[index : index + args.batch_size] for index in range(0, len(repos), args.batch_size)]
+    console.print(f"[cyan]Status: {len(batches)} queries of up to {args.batch_size} repos[/]")
+
+    results: list[dict] = []
+    truncated = False
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = [
+            pool.submit(run_batch, client, args.org, batch, args.prs, args.suites) for batch in batches
+        ]
+        for done, future in enumerate(futures, start=1):
+            try:
+                results.extend(future.result())
+            except BudgetExhausted as exhausted:
+                truncated = True
+                for pending in futures:
+                    pending.cancel()
+                console.print(f"[yellow]{exhausted} — reporting {done - 1} completed batches[/]")
+                break
+            if done % 10 == 0:
+                console.print(f"[dim]  {done}/{len(batches)} batches (points left {client.remaining})[/]")
+
+    active = [row for row in results if row["queued_jobs"] or row["running_jobs"]]
+    by_running = sorted(active, key=lambda row: (-row["running_jobs"], -row["queued_jobs"], row["repo"]))
+    by_queued = sorted(active, key=lambda row: (-row["queued_jobs"], -row["running_jobs"], row["repo"]))
+    totals = {
+        "org": args.org,
+        "repos_with_actions": len(results),
+        "repos_active": len(active),
+        "queued_jobs": sum(row["queued_jobs"] for row in results),
+        "running_jobs": sum(row["running_jobs"] for row in results),
+        "truncated": truncated,
+    }
+
+    if args.json:
+        print(json.dumps({"totals": totals, "by_running": by_running, "by_queued": by_queued}, indent=2))
+        return 0
+
+    console.print(
+        f"\n[bold]{args.org}[/]: {totals['running_jobs']} jobs running, "
+        f"{totals['queued_jobs']} queued across {totals['repos_active']} of "
+        f"{totals['repos_with_actions']} repos with Actions"
+    )
+    if truncated:
+        console.print("[yellow]Counts are partial: the run stopped on the points budget.[/]")
+    render_table("Sorted by RUNNING jobs", by_running, args.top)
+    render_table("Sorted by QUEUED jobs", by_queued, args.top)
+
+    if args.csv:
+        write_csv(csv_path(args.csv, "by-running"), by_running, totals)
+        write_csv(csv_path(args.csv, "by-queued"), by_queued, totals)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# Code change

## Summary

Adds `utils/actions-queue-status.py`, which reports every repository in the org that has GitHub Actions jobs queued or running right now.

Debugging a slow ASF runner queue currently means guessing. `GET /orgs/apache/actions/runners` reports each runner's `status` and `busy` flag but needs `admin:org`, and there is no org-wide REST endpoint for queued jobs at all. Check-run state is readable by anyone who can read the repository and maps one-to-one onto workflow jobs, so this works without Infra privileges.

- **Discovery** reads the workflows directory straight out of the git tree (`object(expression: "HEAD:.github/workflows")`), so a repo counts as using Actions only when it really has workflow files — no `pushedAt` heuristics, no per-repo REST probe. 3,186 repos scanned, 1,256 use Actions.
- **Status** batches repos into aliased GraphQL queries (~20 repos per request) and counts check runs. Output is two tables — sorted by running jobs and by queued jobs — plus `--csv` (writes `-by-running.csv` and `-by-queued.csv`) and `--json`.
- **Each API where it is strongest.** A sampled count is only trustworthy if the sample provably covered the repo, so every query returns two `totalCount`s: open PRs, and check suites per commit. A repo is trusted to GraphQL only when *both* limits held; everything else is re-counted over REST, which is exact per repo. In practice ~8 of the ~160 active repos are thin enough for GraphQL alone — the cheap pass is a filter, and anything with real activity earns an exact count.
- **Rate-limit safety:** every query requests `rateLimit { cost remaining resetAt }` and the sweep stops at 200 points remaining, reporting partial counts rather than dying; 502s and rate-limit rejections retry with 4s/16s/64s backoff; `--workers` defaults to 3 because 6 trips GitHub's per-minute points cap.

Two things worth recording for anyone else writing against this API:

- The REST `/rate_limit` endpoint is not a usable pre-flight check. It reported `graphql: 5000/5000, used=0` while the API was actively rejecting queries with `RATE_LIMIT`. Only the `rateLimit` block returned inside each query is trustworthy, so that is what the script tracks.
- GraphQL's node cost climbs sharply with `--prs`: measured across the 1,256 repos, a sweep costs ~250 points at `--prs 3`, ~2,700 at 5 and ~21,000 at 10, against 5,000 per hour. Since raising it only covers *quiet* repos, and each uncovered repo costs about one cheap REST call, the low default is both cheaper and no less accurate. Discovery prints the open-PR distribution each run so the trade-off can be re-checked.

Documented in `README.md` under "Snapshotting Queued and Running Actions Jobs".

## Type of change

- [x] New utility or action
- [ ] Bug fix
- [ ] Enhancement to existing code
- [ ] Workflow or CI change
- [x] Documentation update
- [ ] Other

## Testing

Validated against the live `apache` org, with a full REST sweep as ground truth.

- `prek run --all-files` passes.
- Full-org sweep completes end to end: 3,186 repos scanned, 1,256 with workflows, 63 batched status queries.
- **Paired against ground truth.** A hybrid sweep and a blanket REST sweep of all 1,256 repos, run back to back: 160 vs 156 active repos, disagreeing on 8 repos in one direction and 12 in the other — all low-count, and within the churn of the twenty minutes separating the passes.
- **The coverage gate was caught by that comparison and fixed.** With only the open-PR test, `apache/skywalking-java` (one open PR, thirteen active runs on its head commit) was reported as 32 queued jobs against a true 203. Adding the check-suite `totalCount` routes it to REST; the repos re-counted over REST rose from 674 to 892, and the repos GraphQL is trusted for fell from 22 to 8.
- **Failure paths were exercised for real, not simulated:** an HTTP 502 mid-discovery (now retried, and fatal rather than silently partial), and points exhaustion mid-status (now guarded).

---
Drafted-by: Claude Code (Opus 5); reviewed by @potiuk before posting
