### PR TITLE
allowlist-check: install ruyaml into a hermetic Python

### DIFF
--- a/allowlist-check/action.yml
+++ b/allowlist-check/action.yml
@@ -40,6 +40,15 @@ inputs:
 runs:
   using: composite
   steps:
+    # Provide a clean, hermetic Python interpreter outside the runner's
+    # system-managed Python, so `pip install` below works without
+    # PIP_BREAK_SYSTEM_PACKAGES. Runner images whose default `python3` is the
+    # distro one -- `ubuntu-slim`, for instance -- are PEP 668 externally
+    # managed and reject installs into it.
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+      with:
+        python-version: '3.12'
     - name: Install ruyaml
       shell: bash
       run: pip install ruyaml


### PR DESCRIPTION
## Summary

`allowlist-check` pip-installs `ruyaml` into whatever `python3` the runner
provides. On images whose default interpreter is the distro one, that is PEP 668
externally managed and the install is refused — so the action cannot run there at
all. `ubuntu-slim` is the case that surfaced it: `apache/airflow` is moving its
short CI jobs onto that image and `asf-allowlist-check` was the one job that
could not follow.

- Set up a pinned Python (`actions/setup-python` v7.0.0, 3.12) before the install
- Mirrors what `pelican/action.yml` already does in this repo, for the same reason
  and with the same pinned SHA
- `actions/*` is implicitly trusted by `check_asf_allowlist.py`, so no
  `actions.yml` / `approved_patterns.yml` change is needed

## Type of change

- [X] Bug fix

## Testing

`uvx --with ruyaml pytest allowlist-check/` — 48 passed. (The 16 collection errors
in `utils/tests/verify_action_build/` are pre-existing on a clean tree and
unrelated.)

Callers pin this action by tag, so picking the fix up needs a new
`allowlist-check` tag.

---
Drafted-by: Claude Code (Opus 5); reviewed by @potiuk before posting
